### PR TITLE
Fix request order

### DIFF
--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/model/FlipperRequest.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/model/FlipperRequest.kt
@@ -4,6 +4,7 @@ import com.flipperdevices.protobuf.Flipper
 
 data class FlipperRequest(
     val data: Flipper.Main,
+    val createTimestamp: Long = System.currentTimeMillis(),
     val priority: FlipperRequestPriority = FlipperRequestPriority.DEFAULT
 )
 

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestComparator.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestComparator.kt
@@ -2,8 +2,32 @@ package com.flipperdevices.bridge.impl.manager.overflow
 
 import com.flipperdevices.bridge.api.model.FlipperRequest
 
+private const val GREATER = 1
+private const val EQUALS = 0
+private const val LESS = -1
+
 class FlipperRequestComparator : Comparator<FlipperRequest> {
     override fun compare(first: FlipperRequest, second: FlipperRequest): Int {
-        return first.priority.ordinal - second.priority.ordinal
+        var solution = EQUALS
+
+        // Request with high priority have large timestamp
+        if (first.priority.ordinal > second.priority.ordinal) {
+            solution = GREATER
+        } else if (first.priority.ordinal < second.priority.ordinal) {
+            solution = LESS
+        }
+
+        if (solution != EQUALS) {
+            return solution
+        }
+
+        // Request with lower timestamp have larger priority
+        if (first.createTimestamp > second.createTimestamp) {
+            solution = GREATER
+        } else if (first.createTimestamp < second.createTimestamp) {
+            solution = LESS
+        }
+
+        return solution
     }
 }

--- a/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestComparatorTest.kt
+++ b/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestComparatorTest.kt
@@ -1,0 +1,33 @@
+package com.flipperdevices.bridge.impl.manager.overflow
+
+import com.flipperdevices.bridge.api.model.FlipperRequest
+import com.flipperdevices.bridge.api.model.FlipperRequestPriority
+import com.flipperdevices.protobuf.main
+import org.junit.Assert
+import org.junit.Test
+
+class FlipperRequestComparatorTest {
+    private val subject = FlipperRequestComparator()
+
+    @Test
+    fun `Highest priority larger`() {
+        val backgroundRequest =
+            FlipperRequest(main { }, priority = FlipperRequestPriority.BACKGROUND)
+        val foregroundRequest =
+            FlipperRequest(main { }, priority = FlipperRequestPriority.FOREGROUND)
+
+        val result = subject.compare(backgroundRequest, foregroundRequest)
+
+        Assert.assertEquals(1, result)
+    }
+
+    @Test
+    fun `Oldest priority larger`() {
+        val firstRequest = FlipperRequest(main { }, 100L)
+        val secondRequest = FlipperRequest(main { }, 200L)
+
+        val result = subject.compare(secondRequest, firstRequest)
+
+        Assert.assertEquals(1, result)
+    }
+}

--- a/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestStorageTest.kt
+++ b/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperRequestStorageTest.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.bridge.impl.manager.overflow
 
+import com.flipperdevices.bridge.api.model.FlipperRequest
 import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.protobuf.main
@@ -22,6 +23,19 @@ class FlipperRequestStorageTest {
         val lowPriority = main { }.wrapToRequest(FlipperRequestPriority.BACKGROUND)
         val mediumPriority = main { }.wrapToRequest()
         val highestPriority = main { }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
+
+        subject.sendRequest(mediumPriority, lowPriority, highestPriority)
+
+        assertEquals(highestPriority, subject.getNextRequest(timeout = 100))
+        assertEquals(mediumPriority, subject.getNextRequest(timeout = 100))
+        assertEquals(lowPriority, subject.getNextRequest(timeout = 100))
+    }
+
+    @Test
+    fun `Check that oldest object returns first`() = runBlocking {
+        val lowPriority = FlipperRequest(main { }, 300L)
+        val mediumPriority = FlipperRequest(main { }, 200L)
+        val highestPriority = FlipperRequest(main { }, 100L)
 
         subject.sendRequest(mediumPriority, lowPriority, highestPriority)
 


### PR DESCRIPTION
**Background**

Now we can shuffle our requests to flipper. It can cause bugs, when you send request, where order is important.

**Changes**

- Improve comparator
- Request with highest timestamp have largest priority (when priority is equals)

**Test plan**

- Try upload large file
