### PR TITLE
use dependencyResolutionManagement block

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,14 +6,6 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version GradlePlugins.KTLINT
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven("https://jitpack.io")
-    }
-}
-
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,13 @@
 rootProject.name = "Flipper App"
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven("https://jitpack.io")
+    }
+}
+
 include(":components:bridge:api")
 include(":components:bridge:dao")
 include(":components:bridge:impl")


### PR DESCRIPTION
**Background**

allprojects/subprojects blocks should be avoided, because it adds additional complexity for build configuration, that could be avoided by using convention plugins and special contructs as `dependencyResolutionManagement`, also it blocks configureOnDemand and incoming ['project-isolation'](https://gradle.github.io/configuration-cache/#constraints_for_build_scripts_and_plugins) feature

**Changes**

Use new centralized block for dependency resolution

**Test plan**

dependency resolution trigger for all configuration will show a problem with repository configuration
simple current PR build will be enough