### PR TITLE
Remove fragment as activity

### DIFF
--- a/components/bottombar/impl/src/main/AndroidManifest.xml
+++ b/components/bottombar/impl/src/main/AndroidManifest.xml
@@ -1,10 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="com.flipperdevices.bottombar.impl">
-
-    <application>
-        <activity
-                android:exported="false"
-                android:launchMode="singleTop"
-                android:name=".main.BottomNavigationFragment" />
-    </application>
-</manifest>
+<manifest package="com.flipperdevices.bottombar.impl" />


### PR DESCRIPTION
**Background**

Now sometimes we use fragment `BottomNavigationFragment` as activity
https://sentry.flipperdevices.com/organizations/flipper/issues/64/

**Changes**

- Remove `BottomNavigationFragment` declaration as Activity

**Test plan**

Merge it and see if crash happens with newest version in sentry
