### PR TITLE
Fix crash in internal release

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,4 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 @Suppress("UnstableApiUsage")

--- a/components/core/markdown/build.gradle.kts
+++ b/components/core/markdown/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
 
-    implementation(libs.flexmark.all)
+    implementation(libs.flexmark.core)
 
     // Testing
     testImplementation(projects.components.core.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,8 @@ lottie = "4.2.1"
 material = "1.5.0"
 annotations = "1.3.0"
 appcompat = "1.4.1"
-flexmark = "0.64.0"
+# https://github.com/vsch/flexmark-java/issues/442
+flexmark = "0.42.14"
 
 # Testing
 junit = "4.12"
@@ -75,7 +76,7 @@ compose-swipetorefresh = { module = "com.google.accompanist:accompanist-swiperef
 compose-constraint = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose_constraint" }
 
 # Flexmark Markdown
-flexmark-all = { module = "com.vladsch.flexmark:flexmark-all", version.ref = "flexmark" }
+flexmark-core = { module = "com.vladsch.flexmark:flexmark", version.ref = "flexmark" }
 
 # Storage
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 rootProject.name = "FlipperApp"
 
-enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 dependencyResolutionManagement {


### PR DESCRIPTION
**Background**

Now application crash in internal and production release
```
Caused by: java.lang.IllegalArgumentException: No enum constant gd.d.a.P
   at java.lang.Enum.valueOf(Enum.java:257)
   at ed.b.c(BitFieldSet.java:9)
   at ed.b.f(BitFieldSet.java:1)
   at gd.d.<clinit>(ISegmentBuilder.java:3)
   at gd.l.<init>(SequenceBuilder.java:6) 
   at fd.d.W(BasedSequenceImpl.java:1) 
   at fd.m.t(SegmentedSequence.java:1) 
   at xc.c.h0(Block.java:1) 
   at tc.k.h(ParagraphParser.java:2) 
```

**Changes**

- Downgrade flexmark, because https://github.com/vsch/flexmark-java/issues/442 not fixed
- Remove feature preview toggle for `VERSION_CATALOGS`

**Test plan**

Build internal release
Run it