### PR TITLE
Fix RC naming

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -59,7 +59,7 @@ jobs:
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
       - name: Build production release
         run: |
-          rm -rf buildSrc/build
+          rm -rf **/build
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
             -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
             -Dversion_name="${{ steps.vars.outputs.major_version }}-rc"

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'rc'
-      - 'ci/fix_rc_naming'
 
 jobs:
   generate_version:
@@ -44,7 +43,7 @@ jobs:
         run: |
           ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal \
             -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
-            -Dversion_name="${{ needs.generate_version.outputs.major_version }}-internal-rc"
+            -Dversion_name="${{ needs.generate_version.outputs.major_version }}.${{ needs.generate_version.outputs.minor_version }}-internal-rc"
       - name: Sign internal AAB
         id: sign_aab_internal
         uses: r0adkll/sign-android-release@v1
@@ -94,7 +93,7 @@ jobs:
           rm -rf **/build
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
           -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
-          -Dversion_name="${{ needs.generate_version.outputs.major_version }}-rc"
+          -Dversion_name="${{ needs.generate_version.outputs.major_version }}.${{ needs.generate_version.outputs.minor_version }}-rc"
       - name: Sign release AAB
         id: sign_aab_release
         uses: r0adkll/sign-android-release@v1

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -13,6 +13,9 @@ jobs:
       major_version: ${{ steps.vars.outputs.major_version }}
       minor_version: ${{ steps.vars.outputs.minor_version }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Generate build number
         id: buildnumber
         uses: einaregilsson/build-number@v3

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -59,7 +59,7 @@ jobs:
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
       - name: Build production release
         run: |
-          ./gradlew clean
+          rm -rf buildSrc/build
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
             -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
             -Dversion_name="${{ steps.vars.outputs.major_version }}-rc"

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'rc'
+      - 'ci/fix_rc_naming'
 
 jobs:
   build:
@@ -58,6 +59,7 @@ jobs:
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
       - name: Build production release
         run: |
+          ./gradlew clean
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
             -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
             -Dversion_name="${{ steps.vars.outputs.major_version }}-rc"
@@ -91,26 +93,3 @@ jobs:
         with:
           name: artifacts
           path: ${{ steps.artifacts_copy.outputs.path }}
-  upload_to_firebase:
-    name: Upload to Firebase App Distribution
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/download-artifact@v2
-        id: download
-        with:
-          name: artifacts
-      - name: Upload artifact to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          groups: testers
-          file: ${{steps.download.outputs.download-path}}/flipper-zero-internal.aab
-      - name: Upload artifact to release candidate group
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          groups: release-candidate
-          file: ${{steps.download.outputs.download-path}}/flipper-zero-release.aab

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -7,17 +7,12 @@ on:
       - 'ci/fix_rc_naming'
 
 jobs:
-  build:
+  generate_version:
     runs-on: ubuntu-latest
+    outputs:
+      major_version: ${{ steps.vars.outputs.major_version }}
+      minor_version: ${{ steps.vars.outputs.minor_version }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-      - name: Set up JDK 1.11
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
       - name: Generate build number
         id: buildnumber
         uses: einaregilsson/build-number@v3
@@ -28,11 +23,25 @@ jobs:
         run: |
           export $(cat .github/workflows/version.env | xargs)
           echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ steps.buildnumber.outputs.build_number }}"
+  build_internal:
+    name: "Build internal version (with logs and s2r)"
+    runs-on: ubuntu-latest
+    needs: generate_version
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Build internal release
         run: |
           ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal \
-            -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
-            -Dversion_name="${{ steps.vars.outputs.major_version }}-internal-rc"
+            -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
+            -Dversion_name="${{ needs.generate_version.outputs.major_version }}-internal-rc"
       - name: Sign internal AAB
         id: sign_aab_internal
         uses: r0adkll/sign-android-release@v1
@@ -57,12 +66,30 @@ jobs:
           cp ${{ steps.sign_aab_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.aab
           cp ${{ steps.sign_apk_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.apk
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-internal
+          path: ${{ steps.artifacts_copy.outputs.path }}
+  build_release:
+    name: "Build release version"
+    runs-on: ubuntu-latest
+    needs: generate_version
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Build production release
         run: |
           rm -rf **/build
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
-            -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
-            -Dversion_name="${{ steps.vars.outputs.major_version }}-rc"
+          -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
+          -Dversion_name="${{ needs.generate_version.outputs.major_version }}-rc"
       - name: Sign release AAB
         id: sign_aab_release
         uses: r0adkll/sign-android-release@v1
@@ -91,5 +118,5 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts
+          name: artifacts-release
           path: ${{ steps.artifacts_copy.outputs.path }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -126,3 +126,30 @@ jobs:
         with:
           name: artifacts-release
           path: ${{ steps.artifacts_copy.outputs.path }}
+  upload_to_firebase:
+    name: Upload to Firebase App Distribution
+    runs-on: ubuntu-latest
+    needs: [ build_internal, build_release ]
+    steps:
+      - uses: actions/download-artifact@v2
+        id: download-internal
+        with:
+          name: artifacts-internal
+      - uses: actions/download-artifact@v2
+        id: download-release
+        with:
+          name: artifacts-release
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          groups: release-candidate
+          file: ${{steps.download-internal.outputs.download-path}}/flipper-zero-internal.aab
+      - name: Upload artifact to release candidate group
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          groups: release-candidate
+          file: ${{steps.download-release.outputs.download-path}}/flipper-zero-release.aab

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -61,11 +61,13 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
       - name: Copy internal artifacts
+        id: artifacts_copy
         run: |
           mkdir artifacts
           cp ${{ steps.sign_aab_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.aab
           cp ${{ steps.sign_apk_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.apk
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
+          echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -111,6 +113,7 @@ jobs:
       - name: Copy release artifacts
         id: artifacts_copy
         run: |
+          mkdir artifacts
           cp ${{ steps.sign_aab_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.aab
           cp ${{ steps.sign_apk_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.apk
           cp instances/app/build/outputs/mapping/release/mapping.txt artifacts/mapping-release.txt

--- a/buildSrc/src/main/java/commonAndroid.kt
+++ b/buildSrc/src/main/java/commonAndroid.kt
@@ -40,6 +40,7 @@ private fun BaseExtension.configureDefaultConfig() {
             resources.excludes += "META-INF/LICENSE-LGPL-3.txt"
             resources.excludes += "META-INF/LICENSE-W3C-TEST"
             resources.excludes += "META-INF/DEPENDENCIES"
+            resources.excludes += "*.proto"
         }
 
         testOptions {


### PR DESCRIPTION
**Background**

Now RC version naming is "-internal-rc", but we expect "-rc" for RC release build and "-internal-rc" for internal build of RC

**Changes**

- Now release and internal is different jobs

**Test plan**

See https://github.com/flipperdevices/Flipper-Android-App/actions/runs/1854443531