### PR TITLE
Remove image share preview and fix encoding for url

### DIFF
--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/parsers/url/FFFUrlEncoder.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/parsers/url/FFFUrlEncoder.kt
@@ -15,6 +15,7 @@ class FFFUrlEncoder : LogTagProvider {
             .joinToString(QUERY_DELIMITED_CHAR) {
                 val field = URLEncoder.encode(it.first.trim(), "UTF-8")
                 val value = URLEncoder.encode(it.second.trim(), "UTF-8")
+                    .replace("%2F", "/") // We want safe / for readability
                 "$field$QUERY_VALUE_DELIMITED_CHAR$value"
             }
         return URL(

--- a/components/keyscreen/impl/build.gradle.kts
+++ b/components/keyscreen/impl/build.gradle.kts
@@ -14,8 +14,6 @@ dependencies {
     implementation(projects.components.core.preference)
     implementation(projects.components.bridge.dao.api)
 
-    implementation(projects.components.filemanager.api)
-
     // Compose
     implementation(libs.compose.ui)
     implementation(libs.compose.tooling)

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/KeyScreenViewModel.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/KeyScreenViewModel.kt
@@ -10,7 +10,6 @@ import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.warn
-import com.flipperdevices.filemanager.api.share.ShareApi
 import com.flipperdevices.keyscreen.impl.R
 import com.flipperdevices.keyscreen.impl.di.KeyScreenComponent
 import com.flipperdevices.keyscreen.impl.model.DeleteState
@@ -38,15 +37,12 @@ class KeyScreenViewModel(
     @Inject
     lateinit var keyParser: KeyParser
 
-    @Inject
-    lateinit var shareApi: ShareApi
-
     init {
         ComponentHolder.component<KeyScreenComponent>().inject(this)
     }
 
     private val keyScreenState = MutableStateFlow<KeyScreenState>(KeyScreenState.InProgress)
-    private val shareDelegate = ShareDelegate(application, shareApi, keyParser)
+    private val shareDelegate = ShareDelegate(application, keyParser)
 
     init {
         viewModelScope.launch {

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/ShareDelegate.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/ShareDelegate.kt
@@ -2,111 +2,37 @@ package com.flipperdevices.keyscreen.impl.viewmodel
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.VectorDrawable
-import android.net.Uri
-import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
 import com.flipperdevices.bridge.dao.api.delegates.KeyParser
-import com.flipperdevices.bridge.dao.api.model.FlipperFileType
 import com.flipperdevices.bridge.dao.api.model.FlipperKey
 import com.flipperdevices.core.log.LogTagProvider
-import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
-import com.flipperdevices.core.preference.FlipperStorageProvider
-import com.flipperdevices.filemanager.api.share.ShareApi
-import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private const val BITMAP_QUALITY = 100
-
 class ShareDelegate(
     private val context: Context,
-    private val shareApi: ShareApi,
     private val keyParser: KeyParser
 ) : LogTagProvider {
     override val TAG = "ShareDelegate"
 
     suspend fun share(flipperKey: FlipperKey) {
         val link = keyParser.keyToUrl(flipperKey)
-        val icon: Uri? = try {
-            flipperKey.path.fileType?.let {
-                shareIcon(it)
-            }
-        } catch (
-            @Suppress("TooGenericExceptionCaught")
-            exception: Exception
-        ) {
-            error(exception) { "I can't share icon for $flipperKey" }
-            null
-        }
-        info { "Share ${flipperKey.path.name} with icon uri $icon and link $link" }
-        shareLink(flipperKey, link, icon)
-    }
-
-    private suspend fun shareIcon(
-        fileType: FlipperFileType
-    ): Uri = withContext(Dispatchers.IO) {
-        val bitmap = getBitmap(fileType.icon)!!
-        return@withContext FlipperStorageProvider.useTemporaryFolder(context) {
-            val iconFile = File(it, "${fileType.extension}.png")
-
-            iconFile.outputStream().use { outputStream ->
-                bitmap.compress(
-                    Bitmap.CompressFormat.PNG,
-                    BITMAP_QUALITY,
-                    outputStream
-                )
-            }
-
-            return@useTemporaryFolder shareApi.getExternalUriForFile(
-                context, iconFile
-            )
-        }
+        info { "Share ${flipperKey.path.name} with link $link" }
+        shareLink(flipperKey, link)
     }
 
     private suspend fun shareLink(
         flipperKey: FlipperKey,
-        link: String,
-        shareIconUri: Uri?
+        link: String
     ) = withContext(Dispatchers.Main) {
         val intent = Intent(Intent.ACTION_SEND)
 
+        intent.type = "text/plain"
         intent.putExtra(Intent.EXTRA_TEXT, link)
         intent.putExtra(Intent.EXTRA_TITLE, flipperKey.path.name)
-        if (shareIconUri != null) {
-            // TODO preview icon doesn't show
-            intent.data = shareIconUri
-            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
 
         val chooserIntent = Intent.createChooser(intent, null)
         chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(chooserIntent)
-    }
-
-    private suspend fun getBitmap(
-        @DrawableRes resourceId: Int
-    ) = withContext(Dispatchers.Default) {
-        val drawable: Drawable? = ContextCompat.getDrawable(context, resourceId)
-        if (drawable is BitmapDrawable) {
-            return@withContext drawable.bitmap
-        }
-        if (drawable !is VectorDrawable) {
-            return@withContext null
-        }
-        val bitmap = Bitmap.createBitmap(
-            drawable.getIntrinsicWidth(),
-            drawable.getIntrinsicHeight(),
-            Bitmap.Config.ARGB_8888
-        )
-        val canvas = Canvas(bitmap)
-        drawable.setBounds(0, 0, canvas.width, canvas.height)
-        drawable.draw(canvas)
-        return@withContext bitmap
     }
 }


### PR DESCRIPTION
**Background**

Now if we want share to Slack, we share image, not link
Also we encode `/`

**Changes**

- Not encode `/` for improve readability of link
- Remove code for image preview

**Test plan**

..and how we can test it
