### PR TITLE
Fix unsupported dialog in device info screen

### DIFF
--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/elements/ComposableFirmwareUpdate.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/elements/ComposableFirmwareUpdate.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,15 +57,17 @@ private fun ComposableFirmwareUpdateUnsupported() {
             text = stringResource(R.string.info_firmware_update_unsupported_title),
             fontSize = 14.sp,
             fontWeight = FontWeight.W500,
-            color = colorResource(DesignSystem.color.black_100)
+            color = colorResource(DesignSystem.color.black_100),
+            textAlign = TextAlign.Center
         )
 
         Text(
-            modifier = Modifier.padding(top = 8.dp),
+            modifier = Modifier.padding(top = 8.dp, start = 12.dp, end = 12.dp),
             text = stringResource(R.string.info_firmware_update_unsupported_desc),
             fontSize = 14.sp,
             fontWeight = FontWeight.W400,
-            color = colorResource(DesignSystem.color.black_40)
+            color = colorResource(DesignSystem.color.black_40),
+            textAlign = TextAlign.Center
         )
 
         ClickableUrlText(

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/elements/InfoElementCard.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/elements/InfoElementCard.kt
@@ -8,8 +8,12 @@ import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.flipperdevices.core.ui.R as DesignSystem
 
 @Composable
 fun InfoElementCard(
@@ -28,7 +32,10 @@ fun InfoElementCard(
                     top = 12.dp,
                     bottom = 6.dp
                 ),
-                text = stringResource(titleId)
+                text = stringResource(titleId),
+                fontWeight = FontWeight.W700,
+                fontSize = 16.sp,
+                color = colorResource(DesignSystem.color.black_100)
             )
             content()
         }


### PR DESCRIPTION
**Background**

Now we have error with align
![image](https://user-images.githubusercontent.com/5871715/160820614-fd9f881d-24a9-4e5d-8a1a-4dca33961719.png)

**Changes**

Fix potential bug with this
