### PR TITLE
Add timeout for each pending request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 1.1 - In progress
 
 - [BUGFIX] Fix synchronization start after first login
+- [Feature] Restart connection if flipper not respond 30 seconds
 - [Feature] Add disconnect button and improve reconnect
 - [Feature] Now you can delete or restore all keys from trash
 - [Feature] Add recover support to deleted keys (on keyscreen)

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
@@ -20,5 +20,4 @@ interface FlipperLagsDetector {
      */
     fun <T> wrapPendingAction(request: FlipperRequest?, flow: Flow<T>): Flow<T>
     fun notifyAboutAction()
-    fun reset()
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.bridge.api.manager
 
+import com.flipperdevices.bridge.api.model.FlipperRequest
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -9,8 +10,15 @@ import kotlinx.coroutines.flow.Flow
  * we restart the connection to the flipper.
  */
 interface FlipperLagsDetector {
-    suspend fun <T> wrapPendingAction(block: suspend () -> T): T
-    fun <T> wrapPendingAction(flow: Flow<T>): Flow<T>
+    /**
+     * @param request for debug purposes
+     */
+    suspend fun <T> wrapPendingAction(request: FlipperRequest?, block: suspend () -> T): T
+
+    /**
+     * @param request for debug purposes
+     */
+    fun <T> wrapPendingAction(request: FlipperRequest?, flow: Flow<T>): Flow<T>
     fun notifyAboutAction()
     fun reset()
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperLagsDetector.kt
@@ -1,0 +1,16 @@
+package com.flipperdevices.bridge.api.manager
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * This service is designed to detect a flipper hangup and restart the connection.
+ *
+ * If we wait for a response from the flipper but get nothing,
+ * we restart the connection to the flipper.
+ */
+interface FlipperLagsDetector {
+    suspend fun <T> wrapPendingAction(block: suspend () -> T): T
+    fun <T> wrapPendingAction(flow: Flow<T>): Flow<T>
+    fun notifyAboutAction()
+    fun reset()
+}

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
@@ -7,6 +7,7 @@ object Constants {
     const val DEVICENAME_PREFIX = "Flipper"
     const val KEYS_DEFAULT_STORAGE = "/any/"
     const val API_SUPPORTED_VERSION = 0.3f
+    const val LAGS_FLIPPER_DETECT_TIMEOUT_MS = 30 * 1000L // 30 seconds
 
     object GenericService {
         val SERVICE_UUID: UUID = UUID.fromString("00001800-0000-1000-8000-00805f9b34fb")

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
@@ -159,7 +159,7 @@ class FlipperBleManagerImpl constructor(
 
         override fun onServicesInvalidated() {
             scope.launch(bleDispatcher) {
-                // lagsDetector.reset()
+                lagsDetector.reset()
                 informationApi.reset(this@FlipperBleManagerImpl)
                 flipperVersionApi.reset(this@FlipperBleManagerImpl)
                 flipperRequestApi.reset(this@FlipperBleManagerImpl)

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
@@ -159,7 +159,6 @@ class FlipperBleManagerImpl constructor(
 
         override fun onServicesInvalidated() {
             scope.launch(bleDispatcher) {
-                lagsDetector.reset()
                 informationApi.reset(this@FlipperBleManagerImpl)
                 flipperVersionApi.reset(this@FlipperBleManagerImpl)
                 flipperRequestApi.reset(this@FlipperBleManagerImpl)

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
@@ -2,12 +2,14 @@ package com.flipperdevices.bridge.impl.manager
 
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
 import android.content.Context
 import androidx.datastore.core.DataStore
 import com.flipperdevices.bridge.BuildConfig
 import com.flipperdevices.bridge.api.error.FlipperBleServiceError
 import com.flipperdevices.bridge.api.error.FlipperServiceErrorListener
 import com.flipperdevices.bridge.api.manager.FlipperBleManager
+import com.flipperdevices.bridge.api.manager.FlipperLagsDetector
 import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
 import com.flipperdevices.bridge.api.manager.ktx.stateAsFlow
 import com.flipperdevices.bridge.api.utils.Constants
@@ -38,16 +40,18 @@ class FlipperBleManagerImpl constructor(
     context: Context,
     private val settingsStore: DataStore<Settings>,
     private val scope: CoroutineScope,
-    private val serviceErrorListener: FlipperServiceErrorListener
+    private val serviceErrorListener: FlipperServiceErrorListener,
+    private val lagsDetector: FlipperLagsDetector
 ) : UnsafeBleManager(scope, context), FlipperBleManager, LogTagProvider {
     override val TAG = "FlipperBleManager"
     private val bleDispatcher = newSingleThreadExecutor(TAG)
         .asCoroutineDispatcher()
 
     // Gatt Delegates
+
     override val informationApi = FlipperInformationApiImpl(scope)
     override val flipperVersionApi = FlipperVersionApiImpl(settingsStore)
-    override val flipperRequestApi = FlipperRequestApiImpl(scope)
+    override val flipperRequestApi = FlipperRequestApiImpl(scope, lagsDetector)
 
     // RPC services
     override val flipperRpcInformationApi = FlipperRpcInformationApiImpl(scope)
@@ -155,11 +159,22 @@ class FlipperBleManagerImpl constructor(
 
         override fun onServicesInvalidated() {
             scope.launch(bleDispatcher) {
+                // lagsDetector.reset()
                 informationApi.reset(this@FlipperBleManagerImpl)
                 flipperVersionApi.reset(this@FlipperBleManagerImpl)
                 flipperRequestApi.reset(this@FlipperBleManagerImpl)
                 flipperRpcInformationApi.reset()
             }
+        }
+
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic
+        ) {
+            // This callback is used to know that the flipper is not hanging.
+            @Suppress("DEPRECATION")
+            super.onCharacteristicRead(gatt, characteristic)
+            lagsDetector.notifyAboutAction()
         }
     }
 }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
@@ -63,6 +63,7 @@ class FlipperRequestApiImpl(
     override fun request(
         command: FlipperRequest
     ): Flow<Flipper.Main> = lagsDetector.wrapPendingAction(
+        command,
         channelFlow {
             verbose { "Pending commands count: ${requestListeners.size}. Request $command" }
             // Generate unique ID for each command
@@ -92,7 +93,7 @@ class FlipperRequestApiImpl(
 
     override suspend fun request(
         commandFlow: Flow<FlipperRequest>
-    ): Flipper.Main = lagsDetector.wrapPendingAction {
+    ): Flipper.Main = lagsDetector.wrapPendingAction(null) {
         verbose { "Pending commands count: ${requestListeners.size}. Request command flow" }
         // Generate unique ID for each command
         val uniqueId = findEmptyId()

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
@@ -11,6 +11,7 @@ import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.impl.delegate.FlipperLagsDetectorImpl
 import com.flipperdevices.bridge.service.impl.delegate.FlipperSafeConnectWrapper
 import com.flipperdevices.bridge.service.impl.di.FlipperServiceComponent
+import com.flipperdevices.bridge.service.impl.utils.WeakConnectionStateProvider
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -41,10 +42,13 @@ class FlipperServiceApiImpl(
     }
 
     private val scope = lifecycleOwner.lifecycleScope
-    private val lagsDetector = FlipperLagsDetectorImpl(scope, this)
+    private val connectionStateProvider = WeakConnectionStateProvider(scope)
+    private val lagsDetector = FlipperLagsDetectorImpl(scope, this, connectionStateProvider)
     private val bleManager: FlipperBleManager = FlipperBleManagerImpl(
         context, settingsStore, scope, serviceErrorListener, lagsDetector
-    )
+    ).apply {
+        connectionStateProvider.initialize(this.connectionInformationApi)
+    }
     private val inited = AtomicBoolean(false)
     private val flipperSafeConnectWrapper =
         FlipperSafeConnectWrapper(context, bleManager, scope, serviceErrorListener)

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.bridge.api.error.FlipperServiceErrorListener
 import com.flipperdevices.bridge.api.manager.FlipperBleManager
 import com.flipperdevices.bridge.impl.manager.FlipperBleManagerImpl
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.service.impl.delegate.FlipperLagsDetectorImpl
 import com.flipperdevices.bridge.service.impl.delegate.FlipperSafeConnectWrapper
 import com.flipperdevices.bridge.service.impl.di.FlipperServiceComponent
 import com.flipperdevices.core.di.ComponentHolder
@@ -40,8 +41,9 @@ class FlipperServiceApiImpl(
     }
 
     private val scope = lifecycleOwner.lifecycleScope
+    private val lagsDetector = FlipperLagsDetectorImpl(scope, this)
     private val bleManager: FlipperBleManager = FlipperBleManagerImpl(
-        context, settingsStore, scope, serviceErrorListener
+        context, settingsStore, scope, serviceErrorListener, lagsDetector
     )
     private val inited = AtomicBoolean(false)
     private val flipperSafeConnectWrapper =

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -55,6 +55,7 @@ class FlipperLagsDetectorImpl(
                         serviceApi.reconnect()
                     }
                 } else if (pendingResponseCounter.get() < 0) {
+                    pendingResponseCounter.set(0)
                     if (BuildConfig.INTERNAL) {
                         error("Pending response counter less than zero")
                     }
@@ -114,10 +115,5 @@ class FlipperLagsDetectorImpl(
         scope.launch(Dispatchers.Default) {
             pendingResponseFlow.emit(Unit)
         }
-    }
-
-    override fun reset() {
-        info { "Reset flipper lags detector" }
-        pendingResponseCounter.set(0)
     }
 }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -1,0 +1,93 @@
+package com.flipperdevices.bridge.service.impl.delegate
+
+import com.flipperdevices.bridge.api.manager.FlipperLagsDetector
+import com.flipperdevices.bridge.api.utils.Constants
+import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.core.log.BuildConfig
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.flipperdevices.core.log.info
+import com.flipperdevices.core.log.verbose
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+
+class FlipperLagsDetectorImpl(
+    private val scope: CoroutineScope,
+    private val serviceApi: FlipperServiceApi
+) : FlipperLagsDetector, LogTagProvider {
+    override val TAG = "FlipperLagsDetector"
+
+    private val pendingResponseCounter = AtomicInteger(0)
+    private val pendingResponseFlow = MutableSharedFlow<Unit>()
+
+    init {
+        scope.launch(Dispatchers.Default) {
+            pendingResponseFlow.collectLatest {
+                delay(Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS)
+                if (pendingResponseCounter.get() > 0) {
+                    error {
+                        "We have pending commands, but flipper not respond " +
+                            "${Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS}ms"
+                    }
+                    serviceApi.reconnect()
+                } else if (pendingResponseCounter.get() < 0) {
+                    if (BuildConfig.INTERNAL) {
+                        error("Pending response counter less than zero")
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun <T> wrapPendingAction(block: suspend () -> T): T {
+        incrementPendingCounter()
+        val result = try {
+            block()
+        } finally {
+            val pendingCount = pendingResponseCounter.decrementAndGet()
+            verbose { "Decrease pending response command, current size is $pendingCount" }
+        }
+        return result
+    }
+
+    override fun <T> wrapPendingAction(flow: Flow<T>): Flow<T> {
+        return flow.onStart {
+            incrementPendingCounter()
+        }.onEach {
+            notifyAboutAction()
+        }.onCompletion {
+            val pendingCount = pendingResponseCounter.decrementAndGet()
+            verbose { "Decrease pending response command, current size is $pendingCount" }
+        }
+    }
+
+    private suspend fun incrementPendingCounter() {
+        val pendingCount = pendingResponseCounter.getAndIncrement()
+        verbose { "Increase pending response command, current size is ${pendingCount + 1}" }
+        if (pendingCount == 0) {
+            info { "Pending response count is zero, so we launch pending flow" }
+            pendingResponseFlow.emit(Unit)
+        }
+    }
+
+    override fun notifyAboutAction() {
+        verbose { "Receive that flipper active" }
+        scope.launch(Dispatchers.Default) {
+            pendingResponseFlow.emit(Unit)
+        }
+    }
+
+    override fun reset() {
+        info { "Reset flipper lags detector" }
+        pendingResponseCounter.set(0)
+    }
+}

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/utils/WeakConnectionStateProvider.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/utils/WeakConnectionStateProvider.kt
@@ -1,0 +1,25 @@
+package com.flipperdevices.bridge.service.impl.utils
+
+import com.flipperdevices.bridge.api.manager.delegates.FlipperConnectionInformationApi
+import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+class WeakConnectionStateProvider(private val scope: CoroutineScope) {
+    private val connectionFlow = MutableSharedFlow<ConnectionState>()
+    private val inited = AtomicBoolean(false)
+
+    fun initialize(connectionInformationApi: FlipperConnectionInformationApi) {
+        if (!inited.compareAndSet(false, true)) {
+            return
+        }
+        connectionInformationApi.getConnectionStateFlow().onEach {
+            connectionFlow.emit(it)
+        }.launchIn(scope)
+    }
+
+    fun getConnectionFlow() = connectionFlow
+}


### PR DESCRIPTION
**Background**

Sometimes we have infinite synchronization. So we can restart connection if we see similar problem

**Changes**

- Add lags detector

**Test plan**

Try use flipper with buggy rpc. You can reproduce it with this patch:
```
diff --git a/firmware/targets/f7/ble_glue/serial_service.c b/firmware/targets/f7/ble_glue/serial_service.c
index a5d3b97a..9e011477 100644
--- a/firmware/targets/f7/ble_glue/serial_service.c
+++ b/firmware/targets/f7/ble_glue/serial_service.c
@@ -217,6 +217,7 @@ bool serial_svc_update_tx(uint8_t* data, uint16_t data_len) {
         return false;
     }
 
+    furi_crash("Test RPC freeze");
     for(uint16_t remained = data_len; remained > 0;) {
         uint8_t value_len = MIN(SERIAL_SVC_CHAR_VALUE_LEN_MAX, remained);
         uint16_t value_offset = data_len - remained;
```
