### PR TITLE
Fix possibility cancel editing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 1.1 - In progress
 
+- [BUGFIX] Now we can cancel editing key
 - [BUGFIX] Fix reconnect issues
 - [BUGFIX] Fix synchronization start after first login
 - [Feature] Added an option to cancel existing Flipper RPC requests

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/SaveDelegate.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/SaveDelegate.kt
@@ -27,7 +27,7 @@ class SaveDelegate {
     }
 
     suspend fun onEditSaveInternal(oldKey: FlipperKey, newKey: FlipperKey) {
-        if(oldKey == newKey) return
+        if (oldKey == newKey) return
 
         val newNote = newKey.notes
         if (oldKey.path == newKey.path && !newNote.isNullOrBlank()) {

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/SaveDelegate.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/SaveDelegate.kt
@@ -27,6 +27,8 @@ class SaveDelegate {
     }
 
     suspend fun onEditSaveInternal(oldKey: FlipperKey, newKey: FlipperKey) {
+        if(oldKey == newKey) return
+
         val newNote = newKey.notes
         if (oldKey.path == newKey.path && !newNote.isNullOrBlank()) {
             utilsKeyApi.updateNote(oldKey.path, newNote)


### PR DESCRIPTION
**Background**

Now we can cancel editing key

**Changes**

* Add condition equals old/new key after cancel editing key

**Test plan**

* Choose key
* Select Edit
* Do something changes
* Click 'Cancel'
* Look for key information didn't change
