### PR TITLE
Fix crash when file content is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 1.1.2 - In progress
 
 - [BUGFIX] Fix crash with custom firmware version
+- [BUGFIX] Fix crash when key file not exist
 - [Feature] Redesign Settings
 
 # 1.1.1

--- a/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperKeyContent.kt
+++ b/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperKeyContent.kt
@@ -22,7 +22,12 @@ sealed class FlipperKeyContent : Parcelable {
 
     @Parcelize
     data class InternalFile(val file: File) : FlipperKeyContent() {
-        override fun openStream() = FileInputStream(file)
+        override fun openStream(): InputStream {
+            return if (file.exists()) {
+                FileInputStream(file)
+            } else ByteArray(0).inputStream()
+        }
+
         override fun length() = file.length()
     }
 


### PR DESCRIPTION
**Background**

Now we crash application if file for `InternalFile` is not exist
**Changes**

- Just return empty stream for not-exist file