### PR TITLE
Add charging state and fix corner radius for battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - [Feature] New error placeholder in FW Update
 - [Feature] Redesign Menu for choose firmware channel
 - [Feature] Add Low Battery dialog
+- [Feature] Show when flipper charging
+- [BUGFIX] Fix incorrect corner radius for battery icon
 
-# 1.1.2B
+# 1.1.2
 
 - [BUGFIX] Fix crash with custom firmware version
 - [BUGFIX] Fix crash when key file not exist

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/bar/ComposableDeviceBar.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/bar/ComposableDeviceBar.kt
@@ -48,7 +48,8 @@ fun ComposableDeviceBar(deviceStatusViewModel: DeviceStatusViewModel = viewModel
             is DeviceStatus.NoDeviceInformation -> NotConnectedText(localDeviceStatus.deviceName)
             is DeviceStatus.Connected -> ConnectedText(
                 localDeviceStatus.deviceName,
-                localDeviceStatus.batteryLevel
+                localDeviceStatus.batteryLevel,
+                localDeviceStatus.isCharging
             )
         }
     }
@@ -94,7 +95,7 @@ private fun NotConnectedText(title: String) {
 }
 
 @Composable
-private fun ConnectedText(title: String, batteryValue: Float) {
+private fun ConnectedText(title: String, batteryValue: Float, isCharging: Boolean) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -106,7 +107,8 @@ private fun ConnectedText(title: String, batteryValue: Float) {
             ) {
                 ComposableFlipperBattery(
                     Modifier.size(width = 30.dp, height = 14.dp),
-                    percent = batteryValue
+                    percent = batteryValue,
+                    isCharging = isCharging
                 )
                 Text(
                     modifier = Modifier.padding(start = 5.dp),

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/bar/ComposableFlipperBattery.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/bar/ComposableFlipperBattery.kt
@@ -29,10 +29,20 @@ private const val FULL_BATTERY = 1.0f
 @Composable
 fun ComposableFlipperBattery(
     modifier: Modifier = Modifier,
-    @FloatRange(from = 0.0, to = 1.0) percent: Float
+    @FloatRange(from = 0.0, to = 1.0) percent: Float,
+    isCharging: Boolean
 ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        BatteryContent(modifier, percent)
+        Box(contentAlignment = Alignment.Center) {
+            BatteryContent(modifier, percent)
+            if (isCharging) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_charging),
+                    contentDescription = null,
+                    tint = colorResource(DesignSystem.color.black_80)
+                )
+            }
+        }
         Icon(
             modifier = Modifier.padding(start = 1.dp),
             painter = painterResource(R.drawable.ic_battery_pin),
@@ -59,7 +69,7 @@ private fun BatteryContent(
             .clip(RoundedCornerShape(3.dp))
             .background(colorResource(R.color.battery_backgroud))
             .padding(1.dp)
-            .clip(RoundedCornerShape(3.dp))
+            .clip(RoundedCornerShape(2.dp))
             .background(Color.White)
             .padding(1.66.dp)
             .clip(RoundedCornerShape(1.dp))
@@ -87,7 +97,8 @@ private fun ComposableFlipperBatteryPreview() {
     Box {
         ComposableFlipperBattery(
             Modifier.size(width = 30.dp, height = 14.dp),
-            percent = 1.0f
+            percent = 1.0f,
+            isCharging = true
         )
     }
 }

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/model/DeviceStatus.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/model/DeviceStatus.kt
@@ -9,6 +9,7 @@ sealed class DeviceStatus {
 
     data class Connected(
         val deviceName: String,
-        val batteryLevel: Float
+        val batteryLevel: Float,
+        val isCharging: Boolean
     ) : DeviceStatus()
 }

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/DeviceStatusViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/DeviceStatusViewModel.kt
@@ -72,7 +72,8 @@ class DeviceStatusViewModel : LifecycleViewModel(), FlipperBleServiceConsumer {
                         updaterApi.onDeviceConnected()
                         DeviceStatus.Connected(
                             deviceName,
-                            batteryLevel
+                            batteryLevel,
+                            flipperInformation.isCharging
                         )
                     }
                 }

--- a/components/info/impl/src/main/res/drawable/ic_charging.xml
+++ b/components/info/impl/src/main/res/drawable/ic_charging.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:height="16dp"
+        android:viewportHeight="16"
+        android:viewportWidth="8"
+        android:width="8dp">
+    <path
+            android:fillColor="#303030"
+            android:pathData="M7.112,5.771L4.03,5.766L3.579,1.135C3.47,0.091 2.518,0.159 2.344,0.951L0.493,9.252C0.407,9.846 0.615,10.266 1.096,10.332L4.185,10.342L4.639,15.026C4.753,15.963 5.649,15.965 5.87,15.161L7.724,6.858C7.81,6.284 7.557,5.818 7.112,5.771Z" />
+</vector>


### PR DESCRIPTION
**Background**

Now we don't show if flipper charge now

**Changes**

- Show when flipper charging
- Fix incorrect corner radius for battery icon

**Test plan**

Connect flipper to charger and check that flipper app shown them
