### PR TITLE
Add synchronization percent in archive screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Feature] Add metrics (fully anonymously)
 - [Feature] Add dialog about sucs/not update
 - [Feature] Add failed upload and network dialog
+- [Feature] Add synchronization percent in archive screen
 - [BUGFIX] Fix incorrect corner radius for battery icon
 - [BUGFIX] Fix searching pic
 - [CI] Pass countly prod creds in application when building

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/composable/ComposableArchive.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/composable/ComposableArchive.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.flipperdevices.archive.impl.R
 import com.flipperdevices.archive.impl.composable.category.ComposableCategoryCard
+import com.flipperdevices.archive.impl.composable.page.ArchiveProgressScreen
 import com.flipperdevices.archive.impl.composable.page.ComposableAllKeysTitle
 import com.flipperdevices.archive.impl.composable.page.ComposableFavoriteKeysTitle
 import com.flipperdevices.archive.impl.composable.page.ComposableKeysGrid
@@ -50,8 +51,30 @@ fun ComposableArchive(
     val keys by tabViewModel.getKeys().collectAsState()
     val favoriteKeys by tabViewModel.getFavoriteKeys().collectAsState()
     val synchronizationState by tabViewModel.getSynchronizationState().collectAsState()
+    val localSynchronizationState = synchronizationState
     val isKeysPresented = !favoriteKeys.isNullOrEmpty() || !keys.isNullOrEmpty()
 
+    if (localSynchronizationState is SynchronizationState.InProgress) {
+        ArchiveProgressScreen(localSynchronizationState)
+    } else ComposableArchiveReady(
+        synchronizationUiApi,
+        keys,
+        favoriteKeys,
+        tabViewModel,
+        synchronizationState,
+        isKeysPresented
+    )
+}
+
+@Composable
+private fun ComposableArchiveReady(
+    synchronizationUiApi: SynchronizationUiApi,
+    keys: List<FlipperKey>?,
+    favoriteKeys: List<FlipperKey>,
+    tabViewModel: GeneralTabViewModel,
+    synchronizationState: SynchronizationState,
+    isKeysPresented: Boolean
+) {
     Column(verticalArrangement = Arrangement.Top) {
         ComposableAppBar(
             title = stringResource(R.string.archive_title),

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/composable/page/ArchiveProgressScreen.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/composable/page/ArchiveProgressScreen.kt
@@ -1,0 +1,48 @@
+package com.flipperdevices.archive.impl.composable.page
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.flipperdevices.archive.impl.R
+import com.flipperdevices.bridge.synchronization.api.SynchronizationState
+import com.flipperdevices.core.ktx.jre.roundPercentToString
+import com.flipperdevices.core.ui.res.R as DesignSystem
+
+@Composable
+fun ArchiveProgressScreen(inProgressState: SynchronizationState.InProgress) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(24.dp),
+            color = colorResource(DesignSystem.color.accent_secondary),
+            strokeWidth = 2.dp
+        )
+        Text(
+            modifier = Modifier.padding(top = 14.dp),
+            text = LocalContext.current.getString(
+                R.string.archive_sync_percent,
+                inProgressState.progress.roundPercentToString()
+            ),
+            fontWeight = FontWeight.W500,
+            fontSize = 14.sp,
+            color = colorResource(DesignSystem.color.black_60),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/components/archive/impl/src/main/res/values/strings.xml
+++ b/components/archive/impl/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="archive_tab_deleted">Deleted</string>
     <string name="archive_title">Archive</string>
     <string name="archive_sync_progress">Syncing with Flipper…</string>
+    <string name="archive_sync_percent">Syncing %1$s</string>
 </resources>

--- a/components/connection/impl/src/main/java/com/flipperdevices/connection/impl/viewmodel/ConnectionTabStateMapper.kt
+++ b/components/connection/impl/src/main/java/com/flipperdevices/connection/impl/viewmodel/ConnectionTabStateMapper.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import com.flipperdevices.bottombar.model.TabState
 import com.flipperdevices.connection.impl.R
 import com.flipperdevices.connection.impl.model.ConnectionStatusState
+import com.flipperdevices.core.ktx.jre.roundPercentToString
 import com.flipperdevices.core.ui.res.R as DesignSystem
-import kotlin.math.roundToInt
-
-const val PERCENT_MAX = 100
 
 object ConnectionTabStateMapper {
     @Suppress("LongMethod")
@@ -56,7 +54,7 @@ object ConnectionTabStateMapper {
                 notSelectedIcon = R.raw.ic_syncing,
                 text = context.getString(
                     R.string.connection_status_syncing,
-                    roundPercent(connectionState.progress)
+                    connectionState.progress.roundPercentToString()
                 ),
                 selectedColor = DesignSystem.color.accent_secondary,
                 unselectedColor = DesignSystem.color.black_30
@@ -70,10 +68,5 @@ object ConnectionTabStateMapper {
                 unselectedColorIcon = DesignSystem.color.accent_secondary
             )
         }
-    }
-
-    private fun roundPercent(percent: Float): String {
-        val processedPercent = if (percent > 1.0f) 1.0f else if (percent < 0.0f) 0.0f else percent
-        return "${(processedPercent * PERCENT_MAX).roundToInt()}%"
     }
 }

--- a/components/core/ktx/src/main/java/com/flipperdevices/core/ktx/jre/NumberKtx.kt
+++ b/components/core/ktx/src/main/java/com/flipperdevices/core/ktx/jre/NumberKtx.kt
@@ -1,5 +1,9 @@
 package com.flipperdevices.core.ktx.jre
 
+import kotlin.math.roundToInt
+
+private const val PERCENT_MAX = 100
+
 /**
  * @return int if long fit in Int.MIN_VALUE..Int.MAX_VALUE.
  * If not, return Int.MIN_VALUE or Int.MAX_VALUE
@@ -14,4 +18,9 @@ fun Long.toIntSafe(): Int {
     }
 
     return this.toInt()
+}
+
+fun Float.roundPercentToString(): String {
+    val processedPercent = if (this > 1.0f) 1.0f else if (this < 0.0f) 0.0f else this
+    return "${(processedPercent * PERCENT_MAX).roundToInt()}%"
 }


### PR DESCRIPTION
**Background**

Now users sometimes don't understand that archive screen not filled by all keys instantly

**Changes**

- Add big progress bar in archive screen

**Test plan**

Just see archive tab