### PR TITLE
Replace dynamic link on static template deeplink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Feature] Compose Theme(new module `core:ui:theme`)
 - [BUGFIX] Lock portrait orientation
 - [BUGFIX] Update card not shown when flipper not connected
+- [BUGFIX] Static URL on dynamic link docs
 
 
 # 1.1.4

--- a/components/firstpair/impl/src/main/res/values/strings.xml
+++ b/components/firstpair/impl/src/main/res/values/strings.xml
@@ -31,17 +31,17 @@
 
     <string name="firstpair_help_title">Can’t Find your Flipper?</string>
     <string name="firstpair_help_1_title">Check the correct name of your Flipper.</string>
-    <string name="firstpair_help_1_description">[How to know the name of Flipper](https://docs.flipperzero.one/basics/control/dolphin#yj-flipper-name)</string>
+    <string name="firstpair_help_1_description">[How to know the name of Flipper](https://flipp.dev/passport)</string>
     <string name="firstpair_help_2_title">Make sure Bluetooth on your Flipper is turned On.</string>
-    <string name="firstpair_help_2_description">[How to turn On Bluetooth on Flipper](https://docs.flipperzero.one/basics/control/bluetooth#n3-turn-on-bluetooth)</string>
+    <string name="firstpair_help_2_description">[How to turn On Bluetooth on Flipper](https://flipp.dev/bluetooth-on)</string>
     <string name="firstpair_help_3_title">Check Bluetooth connection on your phone.</string>
     <string name="firstpair_help_3_description">Go to Bluetooth settings</string>
     <string name="firstpair_help_4_title">Disconnect your Flipper from other apps and devices.</string>
     <string name="firstpair_help_5_title">Install the latest firmware version on Flipper. It’s important to update regularly.</string>
-    <string name="firstpair_help_5_description">[How to install](https://docs.flipperzero.one/basics/firmware-update)</string>
+    <string name="firstpair_help_5_description">[How to install](https://flipp.dev/firmware-update)</string>
     <string name="firstpair_help_6_title">Check that you have the latest version of the Flipper App installed.</string>
     <string name="firstpair_help_6_description">Go to Play Market</string>
     <string name="firstpair_help_7_title">Try to reboot your Flipper.</string>
-    <string name="firstpair_help_7_description">[How to reboot Flipper](https://docs.flipperzero.one/basics/reboot)</string>
+    <string name="firstpair_help_7_description">[How to reboot Flipper](https://flipp.dev/reboot)</string>
 
 </resources>


### PR DESCRIPTION
**Background**

* Dynamic links in the documentation can change, so we want to replace them with a deep link template

**Changes**

*  Replace in string resource link

**Test plan**

* Going to First Pair screen and click to links