### PR TITLE
Fixes update navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - [BUGFIX] Update card not shown when flipper not connected
 - [BUGFIX] Static URL on dynamic link docs
 - [BUGFIX] Fix unsupported version comparison
+- [BUGFIX] Fix crash on cancel updating
+- [BUGFIX] Fix navigation after updating when phone locked or app not visible
+- [BUGFIX] Fix updating image hide after update failed/canceled
 
 # 1.1.5 - HotFix
 

--- a/components/singleactivity/api/build.gradle.kts
+++ b/components/singleactivity/api/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(projects.components.deeplink.api)
+    implementation(libs.cicerone)
 }

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
@@ -89,7 +89,7 @@ class SingleActivity : AppCompatActivity(), RouterProvider, LogTagProvider {
         invalidate()
     }
 
-    private fun invalidate() {
+    fun invalidate() {
         info { "Open clear screen, pending deeplinks size is ${deeplinkStack.size}" }
 
         if (firstPairApi.shouldWeOpenPairScreen()) {
@@ -114,12 +114,18 @@ class SingleActivity : AppCompatActivity(), RouterProvider, LogTagProvider {
 
     override fun onResume() {
         super.onResume()
+        SingleActivityHolder.setUpSingleActivity(this)
         cicerone.getNavigationHolder().setNavigator(navigator)
     }
 
     override fun onPause() {
         cicerone.getNavigationHolder().removeNavigator()
         super.onPause()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        SingleActivityHolder.removeSingleActivity()
     }
 
     override fun onBackPressed() {

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivityHolder.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivityHolder.kt
@@ -1,0 +1,17 @@
+package com.flipperdevices.singleactivity.impl
+
+import java.lang.ref.WeakReference
+
+internal object SingleActivityHolder {
+    private var singleActivity = WeakReference<SingleActivity?>(null)
+
+    fun setUpSingleActivity(activity: SingleActivity) {
+        singleActivity = WeakReference(activity)
+    }
+
+    fun removeSingleActivity() {
+        singleActivity = WeakReference(null)
+    }
+
+    fun getSingleActivity(): SingleActivity? = singleActivity.get()
+}

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/api/SingleActivityApiImpl.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/api/SingleActivityApiImpl.kt
@@ -7,6 +7,7 @@ import com.flipperdevices.deeplink.model.Deeplink
 import com.flipperdevices.singleactivity.api.SingleActivityApi
 import com.flipperdevices.singleactivity.impl.LAUNCH_PARAMS_INTENT
 import com.flipperdevices.singleactivity.impl.SingleActivity
+import com.flipperdevices.singleactivity.impl.SingleActivityHolder
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -15,6 +16,11 @@ class SingleActivityApiImpl @Inject constructor(
     private val context: Context
 ) : SingleActivityApi {
     override fun open(deeplink: Deeplink?) {
+        val currentActivity = SingleActivityHolder.getSingleActivity()
+        if (currentActivity != null) {
+            currentActivity.invalidate()
+            return
+        }
         context.startActivity(
             Intent(context, SingleActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
@@ -56,15 +56,17 @@ class UpdaterTask(
         serviceApi: FlipperServiceApi,
         input: UpdateRequest,
         stateListener: suspend (UpdatingState) -> Unit
-    ) {
+    ) = try {
         startInternalUnwrapped(scope, serviceApi, input) {
             if (it.isFinalState) {
                 isStoppedManually = true
-                withContext(NonCancellable) {
-                    flipperUpdateImageHelper.stopImageOnFlipperSafe(serviceApi.requestApi)
-                }
             }
+
             stateListener(it)
+        }
+    } finally {
+        withContext(NonCancellable) {
+            flipperUpdateImageHelper.stopImageOnFlipperSafe(serviceApi.requestApi)
         }
     }
 

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
@@ -28,8 +28,10 @@ import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class UpdaterTask(
     serviceProvider: FlipperServiceProvider,
@@ -58,7 +60,9 @@ class UpdaterTask(
         startInternalUnwrapped(scope, serviceApi, input) {
             if (it.isFinalState) {
                 isStoppedManually = true
-                flipperUpdateImageHelper.stopImageOnFlipperSafe(serviceApi.requestApi)
+                withContext(NonCancellable) {
+                    flipperUpdateImageHelper.stopImageOnFlipperSafe(serviceApi.requestApi)
+                }
             }
             stateListener(it)
         }

--- a/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/fragments/UpdaterFragment.kt
+++ b/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/fragments/UpdaterFragment.kt
@@ -44,9 +44,9 @@ class UpdaterFragment : ComposeFragment(), StatusBarColorProvider {
     override fun RenderView() {
         val updaterScreenState by updaterViewModel.getState().collectAsState()
         if (updaterScreenState is UpdaterScreenState.Finish) {
-            onFinish()
             return
         }
+
         ComposableUpdaterScreen(updaterScreenState, updaterViewModel::cancel) {
             val updateRequest = arguments?.getParcelable<UpdateRequest>(EXTRA_UPDATE_REQUEST)
             updaterViewModel.retry(updateRequest)
@@ -56,10 +56,6 @@ class UpdaterFragment : ComposeFragment(), StatusBarColorProvider {
     override fun onStop() {
         super.onStop()
         activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-    }
-
-    private fun onFinish() {
-        singleActivity.open()
     }
 
     override fun getStatusBarColor() = DesignSystem.color.background


### PR DESCRIPTION
**Background**

Now we have bugs with update navigation. When we cancel update and e.t.c

**Changes**

- Not open single activity if it already open
- Hide update image when update finished

**Test plan**

Try cancel update, try lock phone when update in progress