### PR TITLE
Support unknown firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 1.1.6 - In progress
 
+- [Feature] Support Unknown firmware
 - [Feature] Compose Navigation on "Info" Screen
 - [Feature] Dark Theme(with support switch, splash screen for all android versions)
 - [Feature] Add black flipper support (update and info screen)

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/info/ComposableFirmwareVersion.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/info/ComposableFirmwareVersion.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.info.impl.R
 import com.flipperdevices.info.shared.ComposableDeviceInfoRow
-import com.flipperdevices.info.shared.ComposableDeviceInfoRowText
 import com.flipperdevices.info.shared.ComposableDeviceInfoRowWithText
+import com.flipperdevices.info.shared.ComposableLongDeviceInfoRowText
 import com.flipperdevices.info.shared.getColorByChannel
 import com.flipperdevices.info.shared.getTextByVersion
 import com.flipperdevices.updater.model.FirmwareChannel
@@ -34,7 +34,7 @@ fun ComposableFirmwareVersion(
         R.string.info_device_info_version,
         firmwareVersionInProgress
     ) {
-        ComposableDeviceInfoRowText(
+        ComposableLongDeviceInfoRowText(
             modifier = it,
             text = getTextByVersion(firmwareVersion),
             color = getColorByChannel(firmwareVersion.channel)

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/model/DeviceInfo.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/model/DeviceInfo.kt
@@ -29,7 +29,7 @@ fun StorageStats.toString(context: Context): String {
             )
             val totalHumanReadable = Formatter.formatFileSize(context, total)
 
-            "$usedHumanReadable/$totalHumanReadable"
+            "$usedHumanReadable / $totalHumanReadable"
         }
     }
 }

--- a/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableDeviceInfoRow.kt
+++ b/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableDeviceInfoRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.ktx.placeholderConnecting
 import com.flipperdevices.core.ui.theme.LocalPallet
@@ -89,6 +90,22 @@ fun ComposableDeviceInfoRowText(
         modifier = modifier,
         text = text,
         color = color,
+        style = LocalTypography.current.bodyR14
+    )
+}
+
+@Composable
+fun ComposableLongDeviceInfoRowText(
+    modifier: Modifier = Modifier,
+    text: String,
+    color: Color = LocalPallet.current.text100
+) {
+    Text(
+        modifier = modifier.padding(start = 24.dp),
+        text = text,
+        color = color,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
         style = LocalTypography.current.bodyR14
     )
 }

--- a/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableFirmwareVersion.kt
+++ b/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableFirmwareVersion.kt
@@ -14,7 +14,7 @@ fun getNameByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc
-        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_empty
     }
 }
 
@@ -24,7 +24,7 @@ fun getFullNameByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev_full
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release_full
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc_full
-        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_full
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_empty
     }
 }
 
@@ -34,16 +34,13 @@ fun getDescriptionByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev_desc
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release_desc
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc_desc
-        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_desc
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_empty
     }
 }
 
 @Composable
 fun getTextByVersion(version: FirmwareVersion): String {
-    return when (version.channel) {
-        FirmwareChannel.UNKNOWN -> version.version
-        else -> "${stringResource(getNameByChannel(version.channel))} ${version.version}"
-    }
+    return "${stringResource(getNameByChannel(version.channel))} ${version.version}".trim()
 }
 
 @Composable

--- a/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableFirmwareVersion.kt
+++ b/components/info/shared/src/main/java/com/flipperdevices/info/shared/ComposableFirmwareVersion.kt
@@ -14,6 +14,7 @@ fun getNameByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown
     }
 }
 
@@ -23,6 +24,7 @@ fun getFullNameByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev_full
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release_full
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc_full
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_full
     }
 }
 
@@ -32,12 +34,16 @@ fun getDescriptionByChannel(channel: FirmwareChannel): Int {
         FirmwareChannel.DEV -> R.string.info_device_firmware_version_dev_desc
         FirmwareChannel.RELEASE -> R.string.info_device_firmware_version_release_desc
         FirmwareChannel.RELEASE_CANDIDATE -> R.string.info_device_firmware_version_rc_desc
+        FirmwareChannel.UNKNOWN -> R.string.info_device_firmware_version_unknown_desc
     }
 }
 
 @Composable
 fun getTextByVersion(version: FirmwareVersion): String {
-    return "${stringResource(getNameByChannel(version.channel))} ${version.version}"
+    return when (version.channel) {
+        FirmwareChannel.UNKNOWN -> version.version
+        else -> "${stringResource(getNameByChannel(version.channel))} ${version.version}"
+    }
 }
 
 @Composable
@@ -46,5 +52,6 @@ fun getColorByChannel(channel: FirmwareChannel): Color {
         FirmwareChannel.DEV -> LocalPallet.current.channelFirmwareDev
         FirmwareChannel.RELEASE_CANDIDATE -> LocalPallet.current.channelFirmwareReleaseCandidate
         FirmwareChannel.RELEASE -> LocalPallet.current.channelFirmwareRelease
+        FirmwareChannel.UNKNOWN -> LocalPallet.current.channelFirmwareUnknown
     }
 }

--- a/components/info/shared/src/main/res/values/strings.xml
+++ b/components/info/shared/src/main/res/values/strings.xml
@@ -10,5 +10,9 @@
     <string name="info_device_firmware_version_release_full">Release</string>
     <string name="info_device_firmware_version_release_desc">Stable release (recommended)</string>
 
+    <string name="info_device_firmware_version_unknown">Unknown</string>
+    <string name="info_device_firmware_version_unknown_full">Unknown</string>
+    <string name="info_device_firmware_version_unknown_desc">Unknown</string>
+
     <string name="info_device_unknown">—</string>
 </resources>

--- a/components/info/shared/src/main/res/values/strings.xml
+++ b/components/info/shared/src/main/res/values/strings.xml
@@ -10,9 +10,7 @@
     <string name="info_device_firmware_version_release_full">Release</string>
     <string name="info_device_firmware_version_release_desc">Stable release (recommended)</string>
 
-    <string name="info_device_firmware_version_unknown">Unknown</string>
-    <string name="info_device_firmware_version_unknown_full">Unknown</string>
-    <string name="info_device_firmware_version_unknown_desc">Unknown</string>
+    <string name="info_device_firmware_version_unknown_empty" />
 
     <string name="info_device_unknown">—</string>
 </resources>

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/model/FirmwareChannel.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/model/FirmwareChannel.kt
@@ -3,5 +3,6 @@ package com.flipperdevices.updater.model
 enum class FirmwareChannel {
     RELEASE,
     RELEASE_CANDIDATE,
-    DEV
+    DEV,
+    UNKNOWN
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/composable/ComposableFirmwareVersionValueChoice.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/composable/ComposableFirmwareVersionValueChoice.kt
@@ -163,7 +163,7 @@ fun ComposableFirmwareColumn(
     onClickMenuItem: (FirmwareChannel) -> Unit = {}
 ) {
     Column {
-        val channels = FirmwareChannel.values()
+        val channels = FirmwareChannel.values().filter { it != FirmwareChannel.UNKNOWN }
         channels.forEachIndexed { index, channel ->
             Column(
                 modifier = Modifier

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -173,7 +173,8 @@ class UpdateCardViewModel :
             return
         }
         val isUpdateAvailable = alwaysShowUpdate ||
-            latestVersionFromNetwork.version.isGreaterThan(flipperFirmwareVersion) ?: true
+            latestVersionFromNetwork.version.isGreaterThan(flipperFirmwareVersion) ?: true ||
+            updateChannel == FirmwareChannel.UNKNOWN
 
         if (isUpdateAvailable) {
             updateCardState.emit(
@@ -215,5 +216,6 @@ private fun FirmwareChannel?.toSelectedChannel(): SelectedChannel = when (this) 
     FirmwareChannel.RELEASE -> SelectedChannel.RELEASE
     FirmwareChannel.RELEASE_CANDIDATE -> SelectedChannel.RELEASE_CANDIDATE
     FirmwareChannel.DEV -> SelectedChannel.DEV
+    FirmwareChannel.UNKNOWN -> SelectedChannel.UNRECOGNIZED
     null -> SelectedChannel.UNRECOGNIZED
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -216,6 +216,6 @@ private fun FirmwareChannel?.toSelectedChannel(): SelectedChannel = when (this) 
     FirmwareChannel.RELEASE -> SelectedChannel.RELEASE
     FirmwareChannel.RELEASE_CANDIDATE -> SelectedChannel.RELEASE_CANDIDATE
     FirmwareChannel.DEV -> SelectedChannel.DEV
-    FirmwareChannel.UNKNOWN -> SelectedChannel.UNRECOGNIZED
+    FirmwareChannel.UNKNOWN -> error("Can`t convert unknown firmware channel to internal channel")
     null -> SelectedChannel.UNRECOGNIZED
 }

--- a/components/updater/impl/build.gradle.kts
+++ b/components/updater/impl/build.gradle.kts
@@ -32,4 +32,7 @@ dependencies {
     // Dagger deps
     implementation(libs.dagger)
     kapt(libs.dagger.kapt)
+
+    // Testing
+    testImplementation(libs.junit)
 }

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/utils/FirmwareVersionBuildHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/utils/FirmwareVersionBuildHelper.kt
@@ -8,6 +8,8 @@ private const val DEVICE_VERSION_COMMIT_INDEX = 0
 private const val DEVICE_VERSION_TYPE_INDEX = 1
 private const val DEVICE_VERSION_TYPE_DEV = "dev"
 private const val DEVICE_VERSION_TYPE_RC = "rc"
+private const val DEVICE_VERSION_TYPE_RC_REGEX = "^\\d+\\.\\d+\\.\\d+-rc"
+private const val DEVICE_VERSION_TYPE_RELEASE_REGEX = "^\\d+\\.\\d+\\.\\d+"
 private const val DEVICE_VERSION_DATE_INDEX = 3
 
 object FirmwareVersionBuildHelper {
@@ -26,7 +28,7 @@ object FirmwareVersionBuildHelper {
             return FirmwareVersion(FirmwareChannel.DEV, hash, date)
         }
 
-        if (typeVersion.contains(DEVICE_VERSION_TYPE_RC)) {
+        if (DEVICE_VERSION_TYPE_RC_REGEX.toRegex() matches typeVersion) {
             return FirmwareVersion(
                 FirmwareChannel.RELEASE_CANDIDATE,
                 typeVersion.replace(
@@ -37,8 +39,16 @@ object FirmwareVersionBuildHelper {
             )
         }
 
+        if (DEVICE_VERSION_TYPE_RELEASE_REGEX.toRegex() matches typeVersion) {
+            return FirmwareVersion(
+                FirmwareChannel.RELEASE,
+                typeVersion,
+                date
+            )
+        }
+
         return FirmwareVersion(
-            FirmwareChannel.RELEASE,
+            FirmwareChannel.UNKNOWN,
             typeVersion,
             date
         )

--- a/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
+++ b/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
@@ -1,0 +1,70 @@
+package com.flipperdevices.updater.impl
+
+import com.flipperdevices.updater.impl.utils.FirmwareVersionBuildHelper
+import com.flipperdevices.updater.model.FirmwareChannel
+import com.flipperdevices.updater.model.FirmwareVersion
+import org.junit.Assert
+import org.junit.Test
+
+class FirmwareVersionBuildHelperTest {
+
+    @Test
+    fun `Correct dev firmware`() {
+        val firmwareVersion = "3b81940f dev 2442 16-07-2022"
+        val parseFirmware =
+            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
+        val actualFirmware = FirmwareVersion(
+            channel = FirmwareChannel.DEV,
+            version = "3b81940f",
+            buildDate = "16-07-2022"
+        )
+        Assert.assertEquals(parseFirmware, actualFirmware)
+    }
+
+    @Test
+    fun `Correct release candidate firmware`() {
+        val firmwareVersion = "2a1d679g 0.63.1-rc 1363 15-07-2022"
+        val parseFirmware =
+            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
+        val actualFirmware = FirmwareVersion(
+            channel = FirmwareChannel.RELEASE_CANDIDATE,
+            version = "0.63.1",
+            buildDate = "15-07-2022"
+        )
+        Assert.assertEquals(parseFirmware, actualFirmware)
+    }
+
+    @Test
+    fun `Correct release firmware`() {
+        val firmwareVersion = "3e5d499b 0.62.1 1363 13-07-2022"
+        val parseFirmware =
+            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
+        val actualFirmware = FirmwareVersion(
+            channel = FirmwareChannel.RELEASE,
+            version = "0.62.1",
+            buildDate = "13-07-2022"
+        )
+        Assert.assertEquals(parseFirmware, actualFirmware)
+    }
+
+    @Test
+    fun `Correct unknown firmware`() {
+        val firmwareVersion = "3e5d499b name/2204_bt_forget_devices02d45365 1363 13-07-2022"
+        val parseFirmware =
+            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
+        val actualFirmware = FirmwareVersion(
+            channel = FirmwareChannel.UNKNOWN,
+            version = "name/2204_bt_forget_devices02d45365",
+            buildDate = "13-07-2022"
+        )
+        Assert.assertEquals(parseFirmware, actualFirmware)
+    }
+
+    @Test
+    fun `Uncorrected device version part count`() {
+        val firmwareVersion = "3e5d499b12345671363 13-07-2022"
+        val parseFirmware =
+            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
+        Assert.assertEquals(parseFirmware, null)
+    }
+}

--- a/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
+++ b/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
@@ -5,66 +5,61 @@ import com.flipperdevices.updater.model.FirmwareChannel
 import com.flipperdevices.updater.model.FirmwareVersion
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class FirmwareVersionBuildHelperTest {
+@RunWith(Parameterized::class)
+class FirmwareVersionBuildHelperTest(
+    private val version: String,
+    private val firmwareVersion: FirmwareVersion?
+) {
 
     @Test
-    fun `Correct dev firmware`() {
-        val firmwareVersion = "3b81940f dev 2442 16-07-2022"
-        val parseFirmware =
-            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
-        val actualFirmware = FirmwareVersion(
-            channel = FirmwareChannel.DEV,
-            version = "3b81940f",
-            buildDate = "16-07-2022"
-        )
-        Assert.assertEquals(parseFirmware, actualFirmware)
+    fun `Correct firmware`() {
+        val firmware = FirmwareVersionBuildHelper.buildFirmwareVersionFromString(version)
+        Assert.assertEquals(firmware, firmwareVersion)
     }
 
-    @Test
-    fun `Correct release candidate firmware`() {
-        val firmwareVersion = "2a1d679g 0.63.1-rc 1363 15-07-2022"
-        val parseFirmware =
-            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
-        val actualFirmware = FirmwareVersion(
-            channel = FirmwareChannel.RELEASE_CANDIDATE,
-            version = "0.63.1",
-            buildDate = "15-07-2022"
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data() = listOf(
+            arrayOf(
+                "fc15d5cc 0.61.1 1333 28-06-2022",
+                FirmwareVersion(
+                    channel = FirmwareChannel.RELEASE,
+                    version = "0.61.1",
+                    buildDate = "28-06-2022"
+                )
+            ),
+            arrayOf(
+                "577a4ba5 0.62.1-rc 1327 12-07-2022",
+                FirmwareVersion(
+                    channel = FirmwareChannel.RELEASE_CANDIDATE,
+                    version = "0.62.1",
+                    buildDate = "12-07-2022"
+                )
+            ),
+            arrayOf(
+                "2a8ea142 dev 2270 11-07-2022",
+                FirmwareVersion(
+                    channel = FirmwareChannel.DEV,
+                    version = "2a8ea142",
+                    buildDate = "11-07-2022"
+                )
+            ),
+            arrayOf(
+                "532082f3 dev-cfw 1784 10-07-2022",
+                FirmwareVersion(
+                    channel = FirmwareChannel.UNKNOWN,
+                    version = "dev-cfw",
+                    buildDate = "10-07-2022"
+                )
+            ),
+            arrayOf(
+                "532082f3 1784 10-07-2022",
+                null
+            )
         )
-        Assert.assertEquals(parseFirmware, actualFirmware)
-    }
-
-    @Test
-    fun `Correct release firmware`() {
-        val firmwareVersion = "3e5d499b 0.62.1 1363 13-07-2022"
-        val parseFirmware =
-            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
-        val actualFirmware = FirmwareVersion(
-            channel = FirmwareChannel.RELEASE,
-            version = "0.62.1",
-            buildDate = "13-07-2022"
-        )
-        Assert.assertEquals(parseFirmware, actualFirmware)
-    }
-
-    @Test
-    fun `Correct unknown firmware`() {
-        val firmwareVersion = "3e5d499b name/2204_bt_forget_devices02d45365 1363 13-07-2022"
-        val parseFirmware =
-            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
-        val actualFirmware = FirmwareVersion(
-            channel = FirmwareChannel.UNKNOWN,
-            version = "name/2204_bt_forget_devices02d45365",
-            buildDate = "13-07-2022"
-        )
-        Assert.assertEquals(parseFirmware, actualFirmware)
-    }
-
-    @Test
-    fun `Uncorrected device version part count`() {
-        val firmwareVersion = "3e5d499b12345671363 13-07-2022"
-        val parseFirmware =
-            FirmwareVersionBuildHelper.buildFirmwareVersionFromString(firmwareVersion)
-        Assert.assertEquals(parseFirmware, null)
     }
 }


### PR DESCRIPTION
**Background**

Support unknown firmware https://github.com/flipperdevices/Flipper-Android-App/issues/234

**Changes**

* New value for enum FirmwareChanel
* Update flag 'always update' if we connected with unknown firmware 
* Update parser version string to FirmwareVersion (like qFlipper https://github.com/flipperdevices/qFlipper/blob/7aeb2b595da4eabdfe16e270834777c2c1033aa7/backend/flipperzero/helper/deviceinfohelper.cpp#L262) + test

**Test plan**

Connect application to flipper with unknown firmware 
