### PR TITLE
Fix incorrect rescale for nfc editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [BUGFIX] Fix padding and typography on information screen
 - [BUGFIX] Fix icon color dropdown menu on Deleted keys
 - [BUGFIX] Fix emulate when key edited
+- [BUGFIX] Nfceditor on little screens
 - [CI] Update deps
 - [REFACTOR] Preview (Updater card/screen, Device info)
 - [REFACTOR] Button Emulate/Send with auto close

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcCell.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcCell.kt
@@ -1,7 +1,9 @@
 package com.flipperdevices.nfceditor.impl.composable
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
@@ -47,6 +49,7 @@ fun ComposableNfcCell(
 
     var textFieldModifier = Modifier
         .padding(start = paddingDp)
+        .width(IntrinsicSize.Min)
 
     val textColor = when (cell.cellType) {
         NfcCellType.SIMPLE -> LocalPallet.current.text100

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcCell.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcCell.kt
@@ -2,7 +2,6 @@ package com.flipperdevices.nfceditor.impl.composable
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
@@ -45,13 +44,9 @@ fun ComposableNfcCell(
     val paddingDp = remember(scaleFactor) {
         (scaleFactor * PADDING_CELL_DP).dp
     }
-    val widthDp = remember(scaleFactor) {
-        (scaleFactor * 2 * WIDTH_LINE_INDEX_DP).dp
-    }
 
     var textFieldModifier = Modifier
         .padding(start = paddingDp)
-        .width(widthDp)
 
     val textColor = when (cell.cellType) {
         NfcCellType.SIMPLE -> LocalPallet.current.text100

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
@@ -41,7 +41,11 @@ fun ComposableNfcEditor(nfcEditorViewModel: NfcEditorViewModel, nfcEditorState: 
                     ?.length() ?: 0
             }
 
-            val scaleFactor = key(maxIndexSymbolCount) {
+            val scaleFactor = key(
+                constraints.maxWidth,
+                constraints.minWidth,
+                maxIndexSymbolCount
+            ) {
                 calculateScaleFactor(maxIndexSymbolCount)
             }
 

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
@@ -2,6 +2,7 @@ package com.flipperdevices.nfceditor.impl.composable
 
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.LocalTextStyle
@@ -12,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ktx.jre.length
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.core.ui.theme.LocalTypography
@@ -21,7 +23,12 @@ import com.flipperdevices.nfceditor.impl.viewmodel.NfcEditorViewModel
 
 @Composable
 fun ComposableNfcEditor(nfcEditorViewModel: NfcEditorViewModel, nfcEditorState: NfcEditorState) {
-    BoxWithConstraints(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+    BoxWithConstraints(
+        Modifier
+            .fillMaxWidth()
+            .padding(end = 14.dp),
+        contentAlignment = Alignment.Center
+    ) {
         CompositionLocalProvider(
             LocalTextStyle provides LocalTypography.current.monoSpaceM14.merge(
                 TextStyle(
@@ -60,7 +67,7 @@ private fun ComposableNfcEditor(
     LazyColumn {
         if (nfcEditorState.nfcEditorCardInfo != null) {
             item(nfcEditorState.nfcEditorCardInfo.hashCode()) {
-                ComposableNfcCard(nfcEditorState.nfcEditorCardInfo)
+                ComposableNfcCard(nfcEditorState.nfcEditorCardInfo, scaleFactor)
             }
         }
         items(nfcEditorState.sectors.size, key = { it.hashCode() }) { index ->

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableScaleFactorCalculate.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableScaleFactorCalculate.kt
@@ -16,6 +16,8 @@ import kotlin.math.roundToInt
 const val WIDTH_LINE_INDEX_DP = 9
 
 private const val NFC_LINE_BYTE_COUNT = 16
+
+// The accuracy with which we select the scaleFactor
 private const val SCALE_FACTOR_MULTIPLIER = 0.98f
 
 /**

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableScaleFactorCalculate.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableScaleFactorCalculate.kt
@@ -16,7 +16,7 @@ import kotlin.math.roundToInt
 const val WIDTH_LINE_INDEX_DP = 9
 
 private const val NFC_LINE_BYTE_COUNT = 16
-private const val SCALE_FACTOR_MULTIPLIER = 0.9f
+private const val SCALE_FACTOR_MULTIPLIER = 0.98f
 
 /**
  * @param maxIndexCount How many numbers can be in the number of lines (line index)

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableNfcCard.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableNfcCard.kt
@@ -30,9 +30,12 @@ import com.flipperdevices.nfceditor.impl.model.NfcEditorCardInfo
 import com.flipperdevices.nfceditor.impl.model.NfcEditorCardType
 
 @Composable
-fun ComposableNfcCard(nfcEditorCardInfo: NfcEditorCardInfo) {
+fun ComposableNfcCard(
+    nfcEditorCardInfo: NfcEditorCardInfo,
+    scaleFactor: Float
+) {
     Card(
-        modifier = Modifier.padding(14.dp),
+        modifier = Modifier.padding(top = 14.dp, bottom = 14.dp, start = 14.dp),
         shape = RoundedCornerShape(12.dp)
     ) {
         Box {
@@ -50,6 +53,7 @@ fun ComposableNfcCard(nfcEditorCardInfo: NfcEditorCardInfo) {
                 modifier = if (isOpened) {
                     Modifier.matchParentSize()
                 } else Modifier,
+                scaleFactor = scaleFactor,
                 nfcEditorCardInfo = nfcEditorCardInfo,
                 isOpened = isOpened,
                 onClick = onClick
@@ -59,11 +63,13 @@ fun ComposableNfcCard(nfcEditorCardInfo: NfcEditorCardInfo) {
 }
 
 @Composable
+@Suppress("MagicNumber")
 private fun ComposableNfcCardInternal(
     modifier: Modifier,
     nfcEditorCardInfo: NfcEditorCardInfo,
     isOpened: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    scaleFactor: Float
 ) {
     Column(
         modifier = modifier,
@@ -71,12 +77,12 @@ private fun ComposableNfcCardInternal(
     ) {
         CompositionLocalProvider(
             LocalTextStyle provides LocalTypography.current.monoSpaceM14
-                .copy(fontSize = 10.sp, color = LocalPallet.current.onNfcCard),
+                .copy(fontSize = (scaleFactor * 10).sp, color = LocalPallet.current.onNfcCard),
             LocalContentColor provides LocalPallet.current.onNfcCard
         ) {
             ComposableHeaderCard(nfcEditorCardInfo.cardType, isOpened, onClick)
             if (isOpened) {
-                ComposableSchemeCard()
+                ComposableSchemeCard(scaleFactor)
                 ComposableAdditionalInfoCard(nfcEditorCardInfo)
             }
         }
@@ -96,7 +102,8 @@ private fun ComposableNfcCardPreview() {
                 uid = "B6 69 03 36 8A 98 02",
                 atqa = "02 02",
                 sak = "98"
-            )
+            ),
+            scaleFactor = 1.0f
         )
     }
 }

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableSchemeCard.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableSchemeCard.kt
@@ -24,41 +24,44 @@ import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.nfceditor.impl.R
 
 @Composable
-fun ComposableSchemeCard() {
+@Suppress("MagicNumber")
+fun ComposableSchemeCard(scaleFactor: Float) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(10.dp),
+            .padding((scaleFactor * 10).dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = stringResource(id = R.string.nfc_card_sector).uppercase(),
-            fontSize = 6.sp,
+            fontSize = (scaleFactor * 6).sp,
             modifier = Modifier.rotate(degrees = -90f)
         )
         Icon(
             painter = painterResource(id = DesignSystem.drawable.ic_bracket),
             contentDescription = ""
         )
-        ComposableSectorsCard()
+        ComposableSectorsCard(scaleFactor)
     }
 }
 
 @Composable
-private fun ComposableSectorsCard() {
+private fun ComposableSectorsCard(scaleFactor: Float) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        ComposableFirstSector()
-        ComposableWhiteSector()
-        ComposableWhiteSector()
-        ComposableSecondSector()
+        ComposableFirstSector(scaleFactor)
+        ComposableWhiteSector(scaleFactor)
+        ComposableWhiteSector(scaleFactor)
+        ComposableSecondSector(scaleFactor)
     }
 }
 
 @Composable
+@Suppress("MagicNumber")
 private fun ComposableSector(
+    scaleFactor: Float,
     content: @Composable (RowScope.() -> Unit)
 ) {
     Row(
@@ -66,21 +69,24 @@ private fun ComposableSector(
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Text(
-            text = stringResource(id = R.string.nfc_card_block).uppercase(),
-            fontSize = 6.sp
+            text = stringResource(R.string.nfc_card_block).uppercase(),
+            fontSize = (scaleFactor * 6).sp
         )
-        Row(modifier = Modifier.weight(16f)) {
+        Row(
+            modifier = Modifier.weight(weight = 16f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             content()
         }
     }
 }
 
 @Composable
-private fun ComposableFirstSector() {
+private fun ComposableFirstSector(scaleFactor: Float) {
     val text = "${stringResource(id = R.string.nfc_card_uid)} " +
         "+ ${stringResource(id = R.string.nfc_card_manufacture_data).uppercase()}"
 
-    ComposableSector {
+    ComposableSector(scaleFactor) {
         repeat(times = 3) {
             Text(
                 modifier = Modifier.weight(weight = 1f),
@@ -113,8 +119,8 @@ private fun ComposableFirstSector() {
 }
 
 @Composable
-private fun ComposableWhiteSector() {
-    ComposableSector {
+private fun ComposableWhiteSector(scaleFactor: Float) {
+    ComposableSector(scaleFactor) {
         repeat(times = 16) {
             Text(
                 modifier = Modifier.weight(weight = 1f),
@@ -127,8 +133,8 @@ private fun ComposableWhiteSector() {
 
 @Composable
 @Suppress("LongMethod")
-private fun ComposableSecondSector() {
-    ComposableSector {
+private fun ComposableSecondSector(scaleFactor: Float) {
+    ComposableSector(scaleFactor) {
         repeat(2) {
             Text(
                 modifier = Modifier.weight(weight = 1f),


### PR DESCRIPTION
**Background**

Now we overlaps when screen is too small

**Changes**

- Use fontSize instead of width of each text field

**Test plan**

Try open screen on small phone