### PR TITLE
Update RTC on Flipper by Android App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Feature] Try auto connect on each app open
 - [Feature] Add ability to upload file from file manager
 - [Feature] Add ability to download file from file manager
+- [Feature] Update RTC on Flipper by Android App
 - [BUGFIX] Exit from emulate screen
 - [BUGFIX] Lock portrait orientation
 - [BUGFIX] Update card not shown when flipper not connected

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
@@ -20,6 +20,7 @@ import com.flipperdevices.bridge.impl.manager.service.FlipperInformationApiImpl
 import com.flipperdevices.bridge.impl.manager.service.FlipperVersionApiImpl
 import com.flipperdevices.bridge.impl.manager.service.request.FlipperRequestApiImpl
 import com.flipperdevices.bridge.impl.manager.service.requestservice.FlipperRpcInformationApiImpl
+import com.flipperdevices.bridge.impl.manager.service.requestservice.FlipperRtcUpdateService
 import com.flipperdevices.bridge.impl.utils.initializeSafe
 import com.flipperdevices.bridge.impl.utils.onServiceReceivedSafe
 import com.flipperdevices.core.ktx.jre.launchWithLock
@@ -71,6 +72,7 @@ class FlipperBleManagerImpl(
         metricApi,
         dataStore
     )
+    private val flipperRtcUpdateService = FlipperRtcUpdateService()
 
     // Manager delegates
     override val connectionInformationApi = FlipperConnectionInformationApiImpl(this)
@@ -152,6 +154,11 @@ class FlipperBleManagerImpl(
                 flipperRpcInformationApi.initialize(flipperRequestApi)
             }.onFailure {
                 error(it) { "Error while initialize rpc information api" }
+            }
+            runCatching {
+                flipperRtcUpdateService.initialize(flipperRequestApi)
+            }.onFailure {
+                error(it) { "Error while initialize RTC" }
             }
 
             return@launchWithLock

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/requestservice/FlipperRtcUpdateService.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/requestservice/FlipperRtcUpdateService.kt
@@ -1,0 +1,47 @@
+package com.flipperdevices.bridge.impl.manager.service.requestservice
+
+import com.flipperdevices.bridge.api.manager.FlipperRequestApi
+import com.flipperdevices.bridge.api.model.FlipperRequestPriority
+import com.flipperdevices.bridge.api.model.wrapToRequest
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.protobuf.main
+import com.flipperdevices.protobuf.system.System
+import com.flipperdevices.protobuf.system.dateTime
+import com.flipperdevices.protobuf.system.setDateTimeRequest
+import java.util.Calendar
+
+class FlipperRtcUpdateService : LogTagProvider {
+    override val TAG = "FlipperRtcUpdateService"
+
+    suspend fun initialize(requestApi: FlipperRequestApi) {
+        requestApi.requestWithoutAnswer(
+            main {
+                systemSetDatetimeRequest = setDateTimeRequest {
+                    datetime = getCurrentDateTime()
+                }
+            }.wrapToRequest(FlipperRequestPriority.RIGHT_NOW)
+        )
+    }
+
+    @Suppress("MagicNumber")
+    private fun getCurrentDateTime(): System.DateTime {
+        val rightNow = Calendar.getInstance()
+        return dateTime {
+            hour = rightNow.get(Calendar.HOUR_OF_DAY)
+            minute = rightNow.get(Calendar.MINUTE)
+            second = rightNow.get(Calendar.SECOND)
+            day = rightNow.get(Calendar.DAY_OF_MONTH)
+            month = rightNow.get(Calendar.MONTH) + 1
+            weekday = when (rightNow.get(Calendar.DAY_OF_WEEK)) {
+                Calendar.MONDAY -> 1
+                Calendar.TUESDAY -> 2
+                Calendar.WEDNESDAY -> 3
+                Calendar.THURSDAY -> 4
+                Calendar.FRIDAY -> 5
+                Calendar.SATURDAY -> 6
+                Calendar.SUNDAY -> 7
+                else -> 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Background**

Now if user using only Android, flipper never has correct time

**Changes**

- Update time on each connection to Flipper

**Test plan**

Try launch flipper and then check time on Flipper