### PR TITLE
Execute connectIfNotForceDisconnect in FlipperAutoDisconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Feature] Update RTC on Flipper by Android App
 - [Feature] Add ability to edit file from file manager
 - [Feature] Add ability to create file from file manager
+- [BUGFIX] Execute connectIfNotForceDisconnect in FlipperAutoDisconnect
 - [BUGFIX] Exit from emulate screen
 - [BUGFIX] Lock portrait orientation
 - [BUGFIX] Update card not shown when flipper not connected

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperAutoDisconnect.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperAutoDisconnect.kt
@@ -47,6 +47,7 @@ class FlipperAutoDisconnect(
     }
 
     override fun onActivityResumed(activity: Activity) {
+        serviceApi.connectIfNotForceDisconnect()
         activityVisible.set(true)
     }
 

--- a/components/singleactivity/impl/build.gradle.kts
+++ b/components/singleactivity/impl/build.gradle.kts
@@ -15,8 +15,6 @@ dependencies {
     implementation(projects.components.singleactivity.api)
     implementation(projects.components.firstpair.api)
     implementation(projects.components.updater.api)
-    implementation(projects.components.bridge.api)
-    implementation(projects.components.bridge.service.api)
 
     implementation(libs.annotations)
     implementation(libs.appcompat)

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
@@ -4,11 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import com.flipperdevices.bottombar.api.BottomNavigationApi
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
-import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
-import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -35,8 +31,7 @@ const val LAUNCH_PARAMS_INTENT = "launch_params_intent"
 class SingleActivity :
     AppCompatActivity(),
     RouterProvider,
-    LogTagProvider,
-    FlipperBleServiceConsumer {
+    LogTagProvider {
     override val TAG = "SingleActivity"
 
     @Inject
@@ -56,9 +51,6 @@ class SingleActivity :
 
     @Inject
     lateinit var updaterUIApi: UpdaterUIApi
-
-    @Inject
-    lateinit var serviceApi: FlipperServiceProvider
 
     lateinit var binding: SingleActivityBinding
 
@@ -132,8 +124,6 @@ class SingleActivity :
         super.onResume()
         SingleActivityHolder.setUpSingleActivity(this)
         cicerone.getNavigationHolder().setNavigator(navigator)
-        // Try connect each time to flipper when activity visible
-        serviceApi.provideServiceApi(this, this, Lifecycle.Event.ON_PAUSE)
     }
 
     override fun onPause() {
@@ -153,9 +143,5 @@ class SingleActivity :
         } else {
             cicerone.getRouter().exit()
         }
-    }
-
-    override fun onServiceApiReady(serviceApi: FlipperServiceApi) {
-        serviceApi.connectIfNotForceDisconnect()
     }
 }


### PR DESCRIPTION
**Background**

Sometimes we don't need execute connect, but in resume in SingleActivity we always execute it

**Changes**

- Now execute connectIfNotForceDisconnect only in FlipperAutoDisconnect

**Test plan**

Check that connectIfNotForceDisconnect not execute in first pair screens