### PR TITLE
Not change state updater card after retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [BUGFIX] Changelog support `[text]`
 - [BUGFIX] Change background color card in notification
 - [BUGFIX] Fix padding on placeholder firmware version
+- [BUGFIX] In progress state when retry updater card
 - [CI] Update deps
 - [REFACTOR] Preview (Updater card/screen, Device info)
 - [Feature] Button Emulate/Send with auto close

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -92,6 +92,9 @@ class UpdateCardViewModel :
     fun retry() {
         serviceProvider.provideServiceApi(this) {
             launchWithLock(mutex, viewModelScope, "retry") {
+                // in this case we get heavy information from fw server and flipper
+                // that's why we set state in progress
+                updateCardState.emit(UpdateCardState.InProgress)
                 cardStateJob?.cancelAndJoin()
                 it.flipperRpcInformationApi.invalidate(it.requestApi)
                 invalidateUnsafe(it)


### PR DESCRIPTION
**Background**

Now, if we have error on updater screen, we see error state after click retry

**Changes**

Setup state in progress after retry, because get information from flipper/fw server - its heavy

**Test plan**

..and how we can test it
