### PR TITLE
Update manifest for 3rd file manager by android 11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [BUGFIX] In progress state when retry updater card
 - [BUGFIX] Update synchronization status instantly and respect the flag
 - [BUGFIX] Rewrite animation for tab state in bottom bar
+- [BUGFIX] Upload from 3rd file manager on Android 11+
 - [CI] Update deps
 - [REFACTOR] Preview (Updater card/screen, Device info)
 - [Feature] Button Emulate/Send with auto close

--- a/components/filemanager/impl/src/main/AndroidManifest.xml
+++ b/components/filemanager/impl/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application>
         <provider
-                android:authorities="com.flipperdevices.filemanager.impl"
+                android:authorities="${shareFileAuthorities}"
                 android:exported="false"
                 android:grantUriPermissions="true"
                 android:name="androidx.core.content.FileProvider">

--- a/components/filemanager/impl/src/main/AndroidManifest.xml
+++ b/components/filemanager/impl/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application>
         <provider
-                android:authorities="${shareFileAuthorities}"
+                android:authorities="com.flipperdevices.filemanager.impl"
                 android:exported="false"
                 android:grantUriPermissions="true"
                 android:name="androidx.core.content.FileProvider">
@@ -12,4 +12,15 @@
                     android:resource="@xml/filepaths" />
         </provider>
     </application>
+
+    <!--
+        https://developer.android.com/reference/android/content/Intent#ACTION_GET_CONTENT
+        https://developer.android.com/about/versions/11/privacy/package-visibility
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.GET_CONTENT" />
+            <data android:mimeType="*/*"/>
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
**Background**

Now we can't use 3rd file manager for upload file on android 11+

**Changes**

Update manifest for GetContent

**Test plan**

Try upload file from 3rd file picker
