### PR TITLE
Enable gradle configuration cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [REFACTOR] Migrate to faster build configuration
 - [REFACTOR] Add test for subghz provisioning
 - [Feature] Add support for NFC Shadow Files
+- [REFACTOR] Enable gradle configuration cache
 
 # 1.2.0
 

--- a/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+../../../gradle/wrapper/gradle-wrapper.properties

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 pluginManagement {
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,6 @@ android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.parallel=true
-# https://youtrack.jetbrains.com/issue/KT-47612/Task-buildKotlinToolingMetadata-is-incompatible-with-Gradle-configuration-cache
-# Fixed in Kotlin 1.7.10
-# Blocked upgrade by Anvil
-org.gradle.unsafe.configuration-cache=false
+org.gradle.unsafe.configuration-cache=true
+org.gradle.unsafe.configuration-cache-problems=fail
 org.gradle.caching=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 pluginManagement {
     includeBuild("build-logic")
 


### PR DESCRIPTION
**Background**
Speed up builds. Prepare for gradle 8.0.
Details about `STABLE_CONFIGURATION_CACHE` flag [here](https://docs.gradle.org/7.5.1/release-notes.html#:~:text=New%20STABLE_CONFIGURATION_CACHE%20feature%20flag).

**Changes**
Enable gradle configuration cache. Set the build to fail if the configuration cache has a warning.

**Test plan**
Green pipelines. Local build successful. The configuration cache is stored and reused.
