### PR TITLE
Search for devices by Mac address and by flipper name (Fix #335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [REFACTOR] Migrate to faster build configuration
 - [REFACTOR] Add test for subghz provisioning
 - [Feature] Add support for NFC Shadow Files
+- [FIX] Now search for devices by Mac address and by flipper name
 
 # 1.2.0
 

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/scanner/DiscoveredBluetoothDevice.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/scanner/DiscoveredBluetoothDevice.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.bridge.api.scanner
 
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
@@ -24,7 +25,8 @@ data class DiscoveredBluetoothDevice(
     constructor(scanResult: ScanResult) : this(
         device = scanResult.device,
         lastScanResult = scanResult,
-        nameInternal = scanResult.scanRecord?.deviceName,
+        nameInternal = scanResult.scanRecord?.deviceName
+            ?: scanResult.device.getNameSafe(),
         rssiInternal = scanResult.rssi,
         previousRssi = scanResult.rssi,
         highestRssiInternal = scanResult.rssi
@@ -48,4 +50,13 @@ data class DiscoveredBluetoothDevice(
     }
 
     override fun hashCode() = device.hashCode()
+}
+
+@SuppressLint("MissingPermission")
+private fun BluetoothDevice.getNameSafe(): String? {
+    return try {
+        name
+    } catch (ignored: Exception) {
+        null
+    }
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 
 object Constants {
     const val DEVICENAME_PREFIX = "Flipper"
+    const val MAC_PREFIX = "80:E1:26:"
     const val KEYS_DEFAULT_STORAGE = "/any/"
     const val RPC_START_REQUEST_ARG = "RPC"
     val API_MAX_SUPPORTED_VERSION = FlipperVersionInformation(majorVersion = 1, minorVersion = 0)

--- a/components/bridge/impl/build.gradle.kts
+++ b/components/bridge/impl/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     // Testing
     testImplementation(projects.components.core.test)
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.ktx.testing)
     testImplementation(libs.roboelectric)

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImpl.kt
@@ -101,10 +101,11 @@ class FlipperScannerImpl @Inject constructor(
      * So we take the connected devices and search among them.
      */
     private fun getAlreadyConnectedDevices(): List<DiscoveredBluetoothDevice> {
-        if (ActivityCompat.checkSelfPermission(
-                context,
-                Manifest.permission.BLUETOOTH_CONNECT
-            ) != PackageManager.PERMISSION_GRANTED
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S &&
+            ActivityCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.BLUETOOTH_CONNECT
+                ) != PackageManager.PERMISSION_GRANTED
         ) {
             return emptyList()
         }
@@ -144,9 +145,6 @@ class FlipperScannerImpl @Inject constructor(
                 previousRssi = 0
             )
         }.firstOrNull()
-    }
-
-    private fun filterByMac(macAddress: String) {
     }
 
     private fun provideSettings(): ScanSettings {

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImpl.kt
@@ -56,26 +56,28 @@ class FlipperScannerImpl @Inject constructor(
             scanner.scanFlow(provideSettings(), provideFilterForDefaultScan()).map {
                 DiscoveredBluetoothDevice(it)
             }
-        ).filter { it.device.name?.startsWith(Constants.DEVICENAME_PREFIX) == true }
-            .map { discoveredBluetoothDevice ->
-                var mutableDevicesList: List<DiscoveredBluetoothDevice> = emptyList()
-                withLock(mutex, "scan_map") {
-                    val alreadyExistDBD = devices.getOrNull(
-                        devices.indexOf(discoveredBluetoothDevice)
-                    )
-                    if (alreadyExistDBD != null) {
-                        val scanResult = discoveredBluetoothDevice.scanResult
-                        if (scanResult != null) {
-                            alreadyExistDBD.update(scanResult)
-                        }
-                    } else {
-                        info { "Find new device $discoveredBluetoothDevice" }
-                        devices.add(discoveredBluetoothDevice)
+        ).filter {
+            it.address.startsWith(Constants.MAC_PREFIX) ||
+                it.name?.startsWith(Constants.DEVICENAME_PREFIX) == true
+        }.map { discoveredBluetoothDevice ->
+            var mutableDevicesList: List<DiscoveredBluetoothDevice> = emptyList()
+            withLock(mutex, "scan_map") {
+                val alreadyExistDBD = devices.getOrNull(
+                    devices.indexOf(discoveredBluetoothDevice)
+                )
+                if (alreadyExistDBD != null) {
+                    val scanResult = discoveredBluetoothDevice.scanResult
+                    if (scanResult != null) {
+                        alreadyExistDBD.update(scanResult)
                     }
-                    mutableDevicesList = devices.toList()
+                } else {
+                    info { "Find new device $discoveredBluetoothDevice" }
+                    devices.add(discoveredBluetoothDevice)
                 }
-                return@map mutableDevicesList
+                mutableDevicesList = devices.toList()
             }
+            return@map mutableDevicesList
+        }
     }
 
     override fun findFlipperById(deviceId: String): Flow<DiscoveredBluetoothDevice> {
@@ -111,7 +113,8 @@ class FlipperScannerImpl @Inject constructor(
         }
 
         return bluetoothManager.getConnectedDevices(BluetoothProfile.GATT).filter {
-            it.name?.startsWith(Constants.DEVICENAME_PREFIX) == true
+            it.address?.startsWith(Constants.MAC_PREFIX) == true ||
+                it.name?.startsWith(Constants.DEVICENAME_PREFIX) == true
         }.map {
             DiscoveredBluetoothDevice(
                 device = it,
@@ -141,6 +144,9 @@ class FlipperScannerImpl @Inject constructor(
                 previousRssi = 0
             )
         }.firstOrNull()
+    }
+
+    private fun filterByMac(macAddress: String) {
     }
 
     private fun provideSettings(): ScanSettings {

--- a/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImplTest.kt
+++ b/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImplTest.kt
@@ -1,0 +1,338 @@
+package com.flipperdevices.bridge.impl.scanner
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flipperdevices.bridge.api.scanner.DiscoveredBluetoothDevice
+import com.flipperdevices.bridge.api.scanner.FlipperScanner
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat
+import no.nordicsemi.android.support.v18.scanner.ScanResult
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(AndroidJUnit4::class)
+class FlipperScannerImplTest {
+    private lateinit var scanner: BluetoothLeScannerCompat
+    private lateinit var bluetoothManager: BluetoothManager
+    private lateinit var bluetoothAdapter: BluetoothAdapter
+    private lateinit var context: Context
+    private lateinit var flipperScanner: FlipperScanner
+
+    @Before
+    fun setUp() {
+        ReflectionHelpers.setStaticField(
+            Build.VERSION::class.java,
+            "SDK_INT",
+            Build.VERSION_CODES.S_V2
+        )
+        scanner = mockk()
+        mockkStatic("com.flipperdevices.bridge.impl.scanner.FlowScanCallbackKt")
+        bluetoothManager = mockk()
+        bluetoothAdapter = mockk()
+        context = mockk()
+        every {
+            context.checkPermission(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                any(),
+                any()
+            )
+        } returns PackageManager.PERMISSION_GRANTED
+        flipperScanner = FlipperScannerImpl(
+            scanner,
+            bluetoothManager,
+            bluetoothAdapter,
+            context
+        )
+    }
+
+    @Test(expected = SecurityException::class)
+    fun `request bluetooth permission`() {
+        every {
+            context.checkPermission(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                any(),
+                any()
+            )
+        } returns PackageManager.PERMISSION_DENIED
+
+        flipperScanner.findFlipperDevices()
+    }
+
+    @Test
+    fun `not request bluetooth permission on old device`() {
+        ReflectionHelpers.setStaticField(
+            Build.VERSION::class.java,
+            "SDK_INT",
+            Build.VERSION_CODES.R
+        )
+        every {
+            context.checkPermission(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                any(),
+                any()
+            )
+        } returns PackageManager.PERMISSION_DENIED
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        flipperScanner.findFlipperDevices()
+    }
+
+    @Test
+    fun `find correct single device`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns "Flipper Test"
+            every { address } returns ""
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = flipperScanner.findFlipperDevices().first()
+
+        val foundDevice = flipperDevices.firstOrNull()
+        Assert.assertNotNull(foundDevice)
+        Assert.assertEquals(bluetoothDevice, foundDevice!!.device)
+    }
+
+    @Test
+    fun `find correct two device`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns "Flipper Test"
+            every { address } returns ""
+        }
+        val secondBluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns null
+            every { address } returns "80:E1:26:AF:AF:26"
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+        val sr2 = ScanResult(secondBluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr, sr2)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+        val resultList = flipperDevices.last().toList()
+        val foundDevice = resultList.getOrNull(0)
+        val foundDevice2 = resultList.getOrNull(1)
+        Assert.assertNotNull(foundDevice)
+        Assert.assertNotNull(foundDevice2)
+        Assert.assertEquals(bluetoothDevice, foundDevice!!.device)
+        Assert.assertEquals(secondBluetoothDevice, foundDevice2!!.device)
+        collectJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `filter device by mac`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns null
+            every { address } returns "80:E1:26:A1:4C:2D"
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = flipperScanner.findFlipperDevices().first()
+
+        val foundDevice = flipperDevices.firstOrNull()
+        Assert.assertNotNull(foundDevice)
+        Assert.assertEquals(bluetoothDevice, foundDevice!!.device)
+    }
+
+    @Test
+    fun `filter device by name`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns "Flipper Dumper"
+            every { address } returns ""
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = flipperScanner.findFlipperDevices().first()
+
+        val foundDevice = flipperDevices.firstOrNull()
+        Assert.assertNotNull(foundDevice)
+        Assert.assertEquals(bluetoothDevice, foundDevice!!.device)
+    }
+
+    @Test
+    fun `block device with incorrect name`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns "Dupper"
+            every { address } returns ""
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+
+        Assert.assertTrue(flipperDevices.toList().isEmpty())
+
+        collectJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `block device with empty name`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns ""
+            every { address } returns ""
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+
+        Assert.assertTrue(flipperDevices.toList().isEmpty())
+
+        collectJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `block device with incorrect mac`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice>() {
+            every { name } returns null
+            every { address } returns "81:E1:26:A1:4C:2D"
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+
+        Assert.assertTrue(flipperDevices.toList().isEmpty())
+
+        collectJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `block device with empty mac`() = runTest {
+        val bluetoothDevice = mockk<BluetoothDevice> {
+            every { name } returns null
+            every { address } returns ""
+        }
+
+        val sr = ScanResult(bluetoothDevice, 0, 0, 0, 0, 0, 0, 0, null, 0L)
+
+        every { scanner.scanFlow(any(), any()) } returns flowOf(sr)
+        every { bluetoothManager.getConnectedDevices(any()) } returns emptyList()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+
+        Assert.assertTrue(flipperDevices.toList().isEmpty())
+
+        collectJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `answer bounded device with correct mac`() = runTest {
+        val alreadyConnectedBluetoothDevice = mockk<BluetoothDevice> {
+            every { name } returns null
+            every { address } returns "80:E1:26:A1:4C:2D"
+        }
+
+        every { bluetoothManager.getConnectedDevices(BluetoothProfile.GATT) } returns listOf(
+            alreadyConnectedBluetoothDevice
+        )
+
+        every { scanner.scanFlow(any(), any()) } returns emptyFlow()
+
+        val flipperDevices = flipperScanner.findFlipperDevices().first()
+
+        val foundDevice = flipperDevices.firstOrNull()
+        Assert.assertNotNull(foundDevice)
+        Assert.assertEquals(alreadyConnectedBluetoothDevice, foundDevice!!.device)
+    }
+
+    @Test
+    fun `answer bounded device with correct name`() = runTest {
+        val alreadyConnectedBluetoothDevice = mockk<BluetoothDevice> {
+            every { name } returns "Flipper Test"
+            every { address } returns ""
+        }
+
+        every { bluetoothManager.getConnectedDevices(BluetoothProfile.GATT) } returns listOf(
+            alreadyConnectedBluetoothDevice
+        )
+
+        every { scanner.scanFlow(any(), any()) } returns emptyFlow()
+
+        val flipperDevices = flipperScanner.findFlipperDevices().first()
+
+        val foundDevice = flipperDevices.firstOrNull()
+        Assert.assertNotNull(foundDevice)
+        Assert.assertEquals(alreadyConnectedBluetoothDevice, foundDevice!!.device)
+    }
+
+    @Test
+    fun `not answer bounded device without correct name or mac`() = runTest {
+        val alreadyConnectedBluetoothDevice = mockk<BluetoothDevice> {
+            every { name } returns null
+            every { address } returns ""
+        }
+
+        every { bluetoothManager.getConnectedDevices(BluetoothProfile.GATT) } returns listOf(
+            alreadyConnectedBluetoothDevice
+        )
+
+        every { scanner.scanFlow(any(), any()) } returns emptyFlow()
+
+        val flipperDevices = mutableListOf<Iterable<DiscoveredBluetoothDevice>>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            flipperScanner.findFlipperDevices().toList(flipperDevices)
+        }
+
+        Assert.assertTrue(flipperDevices.toList().isEmpty())
+
+        collectJob.cancelAndJoin()
+    }
+}

--- a/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImplTest.kt
+++ b/components/bridge/impl/src/test/java/com/flipperdevices/bridge/impl/scanner/FlipperScannerImplTest.kt
@@ -99,7 +99,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `find correct single device`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns "Flipper Test"
             every { address } returns ""
         }
@@ -118,11 +118,11 @@ class FlipperScannerImplTest {
 
     @Test
     fun `find correct two device`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns "Flipper Test"
             every { address } returns ""
         }
-        val secondBluetoothDevice = mockk<BluetoothDevice>() {
+        val secondBluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns null
             every { address } returns "80:E1:26:AF:AF:26"
         }
@@ -149,7 +149,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `filter device by mac`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns null
             every { address } returns "80:E1:26:A1:4C:2D"
         }
@@ -168,7 +168,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `filter device by name`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns "Flipper Dumper"
             every { address } returns ""
         }
@@ -187,7 +187,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `block device with incorrect name`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns "Dupper"
             every { address } returns ""
         }
@@ -209,7 +209,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `block device with empty name`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns ""
             every { address } returns ""
         }
@@ -231,7 +231,7 @@ class FlipperScannerImplTest {
 
     @Test
     fun `block device with incorrect mac`() = runTest {
-        val bluetoothDevice = mockk<BluetoothDevice>() {
+        val bluetoothDevice = mockk<BluetoothDevice> {
             every { name } returns null
             every { address } returns "81:E1:26:A1:4C:2D"
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ install-referrer = "2.2"
 junit = "4.12"
 mockito = "4.0.0"
 roboelectric = "4.8.1"
+mockk = "1.12.7"
 
 [libraries]
 # Gradle - Core
@@ -184,6 +185,7 @@ protobuf-metric = { module = "com.github.flipperdevices.flipperzero-protobuf-jvm
 junit = { module = "junit:junit", version.ref = "junit" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
 roboelectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # Google Play Api
 install-referrer = { module = "com.android.installreferrer:installreferrer", version.ref = "install-referrer" }


### PR DESCRIPTION
**Background**

Now we are not looking for objects that do not match by name - some flippers may give an invalid name or mac address.

**Changes**

- Added new condition to the device filter by mac address
- Added `FlipperScannerImplTest`

**Test plan**

Try to find a flipper with an empty name

Fix #335 