### PR TITLE
Fix synchronization status with shadow files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [FIX] Now search for devices by Mac address and by flipper name
 - [FIX] Subghz provisioning while geoip is null
 - [FIX] Separate screen for edit key
+- [FIX] Synchronization with shadow files
 
 # 1.2.0
 

--- a/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/delegates/key/SimpleKeyApi.kt
+++ b/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/delegates/key/SimpleKeyApi.kt
@@ -7,7 +7,7 @@ import com.flipperdevices.bridge.dao.api.model.FlipperKeyType
 import kotlinx.coroutines.flow.Flow
 
 interface SimpleKeyApi {
-    suspend fun getAllKeys(): List<FlipperKey>
+    suspend fun getAllKeys(includeDeleted: Boolean = false): List<FlipperKey>
 
     fun getKeyAsFlow(keyPath: FlipperKeyPath): Flow<FlipperKey?>
 

--- a/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperFileType.kt
+++ b/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperFileType.kt
@@ -1,6 +1,6 @@
 package com.flipperdevices.bridge.dao.api.model
 
-private const val SHADOW_FILE_EXTENSION = "shd"
+const val SHADOW_FILE_EXTENSION = "shd"
 
 /**
  * Order is important

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/SimpleKeyApiImpl.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/SimpleKeyApiImpl.kt
@@ -31,8 +31,14 @@ class SimpleKeyApiImpl @Inject constructor(
     private val simpleKeyDao by keysDaoProvider
     private val additionalFileDao by additionalFileDaoProvider
 
-    override suspend fun getAllKeys(): List<FlipperKey> = withContext(Dispatchers.IO) {
-        return@withContext simpleKeyDao.getAll().map { it.toFlipperKey(additionalFileDao) }
+    override suspend fun getAllKeys(
+        includeDeleted: Boolean
+    ): List<FlipperKey> = withContext(Dispatchers.IO) {
+        return@withContext if (includeDeleted) {
+            simpleKeyDao.getAllIncludeDeleted()
+        } else {
+            simpleKeyDao.getAll()
+        }.map { it.toFlipperKey(additionalFileDao) }
     }
 
     override fun getKeyAsFlow(keyPath: FlipperKeyPath): Flow<FlipperKey?> {

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/repository/key/SimpleKeyDao.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/repository/key/SimpleKeyDao.kt
@@ -12,6 +12,9 @@ interface SimpleKeyDao {
     @Query("SELECT * FROM keys WHERE deleted = 0")
     suspend fun getAll(): List<Key>
 
+    @Query("SELECT * FROM keys")
+    suspend fun getAllIncludeDeleted(): List<Key>
+
     @Update
     fun update(key: Key)
 

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/api/SynchronizationApiImpl.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/api/SynchronizationApiImpl.kt
@@ -41,7 +41,7 @@ class SynchronizationApiImpl @Inject constructor(
     private val syncWearableApi: SyncWearableApi,
     private val updateKeyApi: UpdateKeyApi
 ) : SynchronizationApi, LogTagProvider {
-    override val TAG = "SynchronizationApi"
+    override val TAG = "SynchronizationApi-${hashCode()}"
 
     private val isLaunched = AtomicBoolean(false)
     private val synchronizationState = MutableStateFlow<SynchronizationState>(

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/KeysSynchronization.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/KeysSynchronization.kt
@@ -55,7 +55,7 @@ class KeysSynchronization(
     suspend fun syncKeys(
         onStateUpdate: suspend (SynchronizationState) -> Unit
     ): List<KeyWithHash> {
-        val allKeysFromAndroid = simpleKeyApi.getAllKeys(incudeDeleted = true)
+        val allKeysFromAndroid = simpleKeyApi.getAllKeys(includeDeleted = true)
         val keysFromAndroid = allKeysFromAndroid.filterNot { it.deleted }
         val hashesFromAndroid = androidHashRepository.calculateHash(keysFromAndroid)
         val hashesFromFlipper = getManifestOnFlipper(onStateUpdate)

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/android/SynchronizationStateRepository.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/android/SynchronizationStateRepository.kt
@@ -1,9 +1,7 @@
 package com.flipperdevices.bridge.synchronization.impl.repository.android
 
 import com.flipperdevices.bridge.dao.api.delegates.key.UtilsKeyApi
-import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
-import com.flipperdevices.bridge.synchronization.impl.model.KeyAction
-import com.flipperdevices.bridge.synchronization.impl.model.KeyDiff
+import com.flipperdevices.bridge.dao.api.model.FlipperKey
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 
@@ -12,19 +10,12 @@ class SynchronizationStateRepository(
 ) : LogTagProvider {
     override val TAG = "SynchronizationStateRepository"
 
-    suspend fun markAsSynchronized(diff: List<KeyDiff>) {
-        val uniqueDiffs = diff
-            .distinctBy { it.newHash.keyPath }
-        for (diffToMark in uniqueDiffs) {
+    suspend fun markAsSynchronized(usedKeys: List<FlipperKey>) {
+        usedKeys.forEach {
             try {
-                utilsKeyApi.markAsSynchronized(
-                    FlipperKeyPath(
-                        diffToMark.newHash.keyPath,
-                        deleted = diffToMark.action == KeyAction.DELETED
-                    )
-                )
-            } catch (exception: Exception) {
-                error(exception) { "While mark synchronized $diffToMark" }
+                utilsKeyApi.markAsSynchronized(it.getKeyPath())
+            } catch (throwable: Exception) {
+                error(throwable) { "Error while marked as synchronized" }
             }
         }
     }

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorStateProducerHelper.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorStateProducerHelper.kt
@@ -2,8 +2,10 @@ package com.flipperdevices.nfceditor.impl.viewmodel
 
 import com.flipperdevices.bridge.dao.api.model.FlipperFile
 import com.flipperdevices.bridge.dao.api.model.FlipperFileFormat
+import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
 import com.flipperdevices.bridge.dao.api.model.FlipperFileType
 import com.flipperdevices.bridge.dao.api.model.FlipperKey
+import com.flipperdevices.bridge.dao.api.model.SHADOW_FILE_EXTENSION
 import com.flipperdevices.bridge.dao.api.model.parsed.FlipperKeyParsed
 import com.flipperdevices.nfceditor.impl.model.NfcCellType
 import com.flipperdevices.nfceditor.impl.model.NfcEditorCardInfo
@@ -173,21 +175,19 @@ object NfcEditorStateProducerHelper {
 
         val shadowFile = oldKey.additionalFiles
             .find { it.path.fileType == FlipperFileType.SHADOW_NFC }
-        if (shadowFile != null) {
-            val newAdditionalFiles = oldKey.additionalFiles.minus(shadowFile)
-                .plus(
-                    FlipperFile(
-                        path = shadowFile.path,
-                        content = FlipperFileFormat(orderedMap.toList())
-                    )
+        val newAdditionalFiles = oldKey.additionalFiles.minus(shadowFile)
+            .plus(
+                FlipperFile(
+                    path = FlipperFilePath(
+                        oldKey.mainFile.path.folder,
+                        "${oldKey.mainFile.path.nameWithoutExtension}.$SHADOW_FILE_EXTENSION"
+                    ),
+                    content = FlipperFileFormat(orderedMap.toList())
                 )
-            return oldKey.copy(
-                additionalFiles = newAdditionalFiles
-            )
-        }
+            ).filterNotNull()
 
         return oldKey.copy(
-            mainFile = oldKey.mainFile.copy(content = FlipperFileFormat(orderedMap.toList()))
+            additionalFiles = newAdditionalFiles
         )
     }
 }


### PR DESCRIPTION
**Background**

Right now we have bugs with synchronization and shadow files

**Changes**

- Create a shadow file when editing a card even if there is no shadow file
- Mark all keys that are present at the moment as synchronized

**Test plan**
Try renaming the file back and forth. For example, "Office.nfc"->"Office_1.nfc" -> "Office.nfc".
Behavior with old firmware: never sync
Behavior with new firmware: synchronizes
