### PR TITLE
Change CI for RC and release

### DIFF
--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -202,8 +202,8 @@ jobs:
           cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-gms.apk artifacts/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
           cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-wear-gms.aab artifacts/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.aab
           cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-wear-gms.apk artifacts/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
-          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-nogms.aab artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.aab
-          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-nogms.apk artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
+          cp ${{steps.download-nogms.outputs.download-path}}/flipper-zero-nogms.aab artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.aab
+          cp ${{steps.download-nogms.outputs.download-path}}/flipper-zero-nogms.apk artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
           echo "::set-output name=path::artifacts/"
       - name: Create internal Release
         id: create_internal_release
@@ -232,10 +232,6 @@ jobs:
         id: download
         with:
           name: artifacts-gms
-      - name: Debug Print
-        id: print_debug
-        run: |
-          ls ${{steps.download.outputs.download-path}}
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1.0.15
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,5 +247,5 @@ jobs:
           tag_name: ${{ steps.vars.outputs.major_version }}
           name: Flipper App ${{ steps.vars.outputs.major_version }}
           body_path: .github/changelog/whatsnew-en-US
-          draft: true
+          draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,28 @@ on:
   push:
     branches:
       - 'master'
+      - 'ci/rc_and_release'
 
 jobs:
-  build:
+  build_number:
+    name: Generate build number
     runs-on: ubuntu-latest
+    outputs:
+      number: ${{ steps.vars.outputs.number }}
+    steps:
+      - name: Generate build number
+        id: buildnumber
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Set variables'
+        id: vars
+        run: |
+          echo "::set-output name=number::${{ steps.buildnumber.outputs.build_number }}"
+  build_release_nogms:
+    name: Build AAB and APK (Without GMS)
+    runs-on: ubuntu-latest
+    needs: build_number
     steps:
       - uses: actions/checkout@v2
         with:
@@ -17,28 +35,25 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Generate build number
-        id: buildnumber
-        uses: einaregilsson/build-number@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set variables'
         id: vars
         run: |
           export $(cat .github/workflows/version.env | xargs)
           echo "::set-output name=major_version::${MAJOR_VERSION}"
-      - name: Build production release
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
+      - name: Build internal release
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal :dumpApkVersion \
-            -Dversion_code=${{ steps.buildnumber.outputs.build_number }} \
+          ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal \
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
             -Dversion_name="${{ steps.vars.outputs.major_version }}" \
             -Dcountly_url="${{ secrets.COUNTLY_URL_PROD }}" \
             -Dcountly_app_key="${{ secrets.COUNTLY_APP_KEY_PROD }}" \
-            -Dis_sentry_publish=true
-      - name: Sign release AAB
-        id: sign_aab_release
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=false
+      - name: Sign AAB
+        id: sign_aab
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/bundle/internal
@@ -46,8 +61,8 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
-      - name: Sign release APK
-        id: sign_apk_release
+      - name: Sign APK
+        id: sign_apk
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/apk/internal
@@ -59,63 +74,177 @@ jobs:
         id: artifacts_copy
         run: |
           mkdir artifacts
-          cp ${{ steps.sign_aab_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.aab
-          cp ${{ steps.sign_apk_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.apk
-          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-release.txt
-          cp build/version/apk-version.properties artifacts/apk-version-release.properties
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts
+          name: artifacts-nogms
           path: ${{ steps.artifacts_copy.outputs.path }}
-  upload_to_playstore:
-    name: Upload to Play Store
+  build_release_gms:
+    name: Build AAB and APK (GMS)
     runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        id: download
-        with:
-          name: artifacts
-      - name: Upload to Play Store
-        uses: r0adkll/upload-google-play@v1.0.17
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_PUBLISHER_JSON }}
-          packageName: com.flipperdevices.app
-          releaseFiles: ${{steps.download.outputs.download-path}}/flipper-zero-release.aab
-          track: production
-          status: draft
-          whatsNewDirectory: .github/changelog
-          mappingFile: ${{steps.download.outputs.download-path}}/mapping-release.txt
-  upload_to_github:
-    name: Upload to Github Releases
-    runs-on: ubuntu-latest
-    needs: build
+    needs: build_number
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: 'Set variables'
         id: vars
         run: |
           export $(cat .github/workflows/version.env | xargs)
           echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
+      - name: Build internal release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal :instances:wearable:assembleInternal :instances:wearable:bundleInternal \
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
+            -Dversion_name="${{ steps.vars.outputs.major_version }}" \
+            -Dcountly_url="${{ secrets.COUNTLY_URL_PROD }}" \
+            -Dcountly_app_key="${{ secrets.COUNTLY_APP_KEY_PROD }}" \
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=true
+      - name: Sign AAB
+        id: sign_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/bundle/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign APK
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/apk/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear AAB
+        id: sign_wear_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/bundle/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear APK
+        id: sign_wear_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/apk/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Copy artifacts
+        id: artifacts_copy
+        run: |
+          mkdir artifacts
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-gms.txt
+          cp ${{ steps.sign_wear_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.aab
+          cp ${{ steps.sign_wear_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.apk
+          cp instances/wearable/build/outputs/mapping/internal/mapping.txt artifacts/mapping-wear-gms.txt
+          echo "::set-output name=path::artifacts/"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-gms
+          path: ${{ steps.artifacts_copy.outputs.path }}
+  upload_to_playstore:
+    name: Upload to Play Store
+    runs-on: ubuntu-latest
+    needs: build_release_gms
+    steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         id: download
         with:
-          name: artifacts
-      - name: Create Production Release
+          name: artifacts-gms
+      - name: Upload to Play Store
+        uses: r0adkll/upload-google-play@v1.0.17
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_PUBLISHER_JSON }}
+          packageName: com.flipperdevices.app
+          releaseFiles: |
+            ${{steps.download.outputs.download-path}}/flipper-zero-gms.aab,
+            ${{steps.download.outputs.download-path}}/flipper-zero-wear-gms.aab
+          track: production
+          status: draft
+          whatsNewDirectory: .github/changelog
+          mappingFile: ${{steps.download.outputs.download-path}}/mapping-gms.txt
+  upload_to_github:
+    name: Upload to Github Releases
+    runs-on: ubuntu-latest
+    needs: [ build_release_nogms, build_release_gms ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - uses: actions/download-artifact@v2
+        id: download-gms
+        with:
+          name: artifacts-gms
+      - uses: actions/download-artifact@v2
+        id: download-nogms
+        with:
+          name: artifacts-nogms
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+      - name: Install zip
+        uses: montudor/action-zip@v1
+      - name: Prepare mapping
+        id: mappings
+        run: |
+          mkdir mappings
+          cp ${{steps.download-nogms.outputs.download-path}}/mapping-nogms.txt mappings/mapping-nogms.txt
+          cp ${{steps.download-gms.outputs.download-path}}/mapping-gms.txt mappings/mapping-gms.txt
+          cp ${{steps.download-gms.outputs.download-path}}/mapping-wear-gms.txt mappings/mapping-wear-gms.txt
+          zip -qq -r mappings.zip mappings
+          echo "::set-output name=archive::mappings.zip"
+      - name: Copy artifacts
+        id: artifacts_copy
+        run: |
+          mkdir artifacts
+          cp ${{ steps.mappings.outputs.archive }} artifacts/mappings-${{ steps.vars.outputs.major_version }}.zip
+          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-gms.aab artifacts/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.aab
+          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-gms.apk artifacts/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.apk
+          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-wear-gms.aab artifacts/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.aab
+          cp ${{steps.download-gms.outputs.download-path}}/flipper-zero-wear-gms.apk artifacts/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.apk
+          cp ${{steps.download-nogms.outputs.download-path}}/flipper-zero-nogms.aab artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.aab
+          cp ${{steps.download-nogms.outputs.download-path}}/flipper-zero-nogms.apk artifacts/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.apk
+          echo "::set-output name=path::artifacts/"
+      - name: Create internal Release
+        id: create_internal_release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            ${{steps.download.outputs.download-path}}/flipper-zero-release.aab
-            ${{steps.download.outputs.download-path}}/flipper-zero-release.apk
-            ${{steps.download.outputs.download-path}}/mapping-release.txt
-            ${{steps.download.outputs.download-path}}/apk-version-release.properties
+            ${{ steps.artifacts_copy.outputs.path }}/mappings-${{ steps.vars.outputs.major_version }}.zip
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-wear-gms-${{ steps.vars.outputs.major_version }}.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.apk
           tag_name: ${{ steps.vars.outputs.major_version }}
           name: Flipper App ${{ steps.vars.outputs.major_version }}
           body_path: .github/changelog/whatsnew-en-US

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'ci/rc_and_release'
 
 jobs:
   build_number:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,5 +248,5 @@ jobs:
           tag_name: ${{ steps.vars.outputs.major_version }}
           name: Flipper App ${{ steps.vars.outputs.major_version }}
           body_path: .github/changelog/whatsnew-en-US
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'rc'
-      - 'ci/rc_and_release'
 
 jobs:
   build_number:
@@ -381,7 +380,7 @@ jobs:
             ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-wear-gms-${{ steps.vars.outputs.major_version }}-rc.apk
             ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.aab
             ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.apk
-          tag_name: Release Candidate ${{ steps.vars.outputs.major_version }}
+          tag_name: ${{ steps.vars.outputs.major_version }}-rc
           name: Flipper App ${{ steps.vars.outputs.major_version }}-rc
           draft: false
           prerelease: true

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -74,6 +74,8 @@ jobs:
           mkdir artifacts
           cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
           cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
+          ls instances/app/build/outputs/
+          ls instances/app/build/outputs/mapping/internal/
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -74,8 +74,6 @@ jobs:
           mkdir artifacts
           cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
           cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
-          ls instances/app/build/outputs/
-          ls instances/app/build/outputs/mapping/internal/
           cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
@@ -215,7 +213,7 @@ jobs:
           mkdir artifacts
           cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
           cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
-          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
+          cp instances/app/build/outputs/mapping/release/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -292,10 +290,10 @@ jobs:
           mkdir artifacts
           cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.aab
           cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.apk
-          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-gms.txt
+          cp instances/app/build/outputs/mapping/release/mapping.txt artifacts/mapping-gms.txt
           cp ${{ steps.sign_wear_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.aab
           cp ${{ steps.sign_wear_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.apk
-          cp instances/wearable/build/outputs/mapping/internal/mapping.txt artifacts/mapping-wear-gms.txt
+          cp instances/wearable/build/outputs/mapping/release/mapping.txt artifacts/mapping-wear-gms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,17 +4,15 @@ on:
   push:
     branches:
       - 'rc'
+      - 'ci/rc_and_release'
 
 jobs:
-  generate_version:
+  build_number:
+    name: Generate build number
     runs-on: ubuntu-latest
     outputs:
-      major_version: ${{ steps.vars.outputs.major_version }}
-      minor_version: ${{ steps.vars.outputs.minor_version }}
+      number: ${{ steps.vars.outputs.number }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
       - name: Generate build number
         id: buildnumber
         uses: einaregilsson/build-number@v3
@@ -23,13 +21,11 @@ jobs:
       - name: 'Set variables'
         id: vars
         run: |
-          export $(cat .github/workflows/version.env | xargs)
-          echo "::set-output name=major_version::${MAJOR_VERSION}"
-          echo "::set-output name=minor_version::${{ steps.buildnumber.outputs.build_number }}"
-  build_internal:
-    name: "Build internal version (with logs and s2r)"
+          echo "::set-output name=number::${{ steps.buildnumber.outputs.build_number }}"
+  build_internal_nogms:
+    name: Build Internal AAB and APK (Without GMS)
     runs-on: ubuntu-latest
-    needs: generate_version
+    needs: build_number
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,16 +35,23 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
       - name: Build internal release
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal \
-            -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
-            -Dversion_name="${{ needs.generate_version.outputs.major_version }}.${{ needs.generate_version.outputs.minor_version }}-internal-rc" \
-            -Dis_sentry_publish=true
-      - name: Sign internal AAB
-        id: sign_aab_internal
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
+            -Dversion_name="${{ steps.vars.outputs.major_version }}-rc" \
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=false
+      - name: Sign AAB
+        id: sign_aab
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/bundle/internal
@@ -56,8 +59,8 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
-      - name: Sign internal APK
-        id: sign_apk_internal
+      - name: Sign APK
+        id: sign_apk
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/apk/internal
@@ -65,23 +68,23 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
-      - name: Copy internal artifacts
+      - name: Copy artifacts
         id: artifacts_copy
         run: |
           mkdir artifacts
-          cp ${{ steps.sign_aab_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.aab
-          cp ${{ steps.sign_apk_internal.outputs.signedReleaseFile }} artifacts/flipper-zero-internal.apk
-          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-internal.txt
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts-internal
+          name: artifacts-internal-nogms
           path: ${{ steps.artifacts_copy.outputs.path }}
-  build_release:
-    name: "Build release version"
+  build_internal_gms:
+    name: Build Internal AAB and APK (GMS)
     runs-on: ubuntu-latest
-    needs: generate_version
+    needs: build_number
     steps:
       - uses: actions/checkout@v2
         with:
@@ -91,17 +94,103 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Build production release
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
+      - name: Build internal release
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          rm -rf **/build
+          ./gradlew :instances:app:assembleInternal :instances:app:bundleInternal :instances:wearable:assembleInternal :instances:wearable:bundleInternal \
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
+            -Dversion_name="${{ steps.vars.outputs.major_version }}-rc" \
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=true
+      - name: Sign AAB
+        id: sign_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/bundle/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign APK
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/apk/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear AAB
+        id: sign_wear_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/bundle/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear APK
+        id: sign_wear_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/apk/internal
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Copy artifacts
+        id: artifacts_copy
+        run: |
+          mkdir artifacts
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-gms.txt
+          cp ${{ steps.sign_wear_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.aab
+          cp ${{ steps.sign_wear_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.apk
+          cp instances/wearable/build/outputs/mapping/internal/mapping.txt artifacts/mapping-wear-gms.txt
+          echo "::set-output name=path::artifacts/"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-internal-gms
+          path: ${{ steps.artifacts_copy.outputs.path }}
+  build_release_nogms:
+    name: Build Release AAB and APK (Without GMS)
+    runs-on: ubuntu-latest
+    needs: build_number
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
+      - name: Build release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
           ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease \
-          -Dversion_code=${{ needs.generate_version.outputs.minor_version }} \
-          -Dversion_name="${{ needs.generate_version.outputs.major_version }}.${{ needs.generate_version.outputs.minor_version }}-rc" \
-          -Dis_sentry_publish=true
-      - name: Sign release AAB
-        id: sign_aab_release
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
+            -Dversion_name="${{ steps.vars.outputs.major_version }}-rc" \
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=false
+      - name: Sign AAB
+        id: sign_aab
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/bundle/release
@@ -109,8 +198,8 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
-      - name: Sign release APK
-        id: sign_apk_release
+      - name: Sign APK
+        id: sign_apk
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: instances/app/build/outputs/apk/release
@@ -118,16 +207,181 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
-      - name: Copy release artifacts
+      - name: Copy artifacts
         id: artifacts_copy
         run: |
           mkdir artifacts
-          cp ${{ steps.sign_aab_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.aab
-          cp ${{ steps.sign_apk_release.outputs.signedReleaseFile }} artifacts/flipper-zero-release.apk
-          cp instances/app/build/outputs/mapping/release/mapping.txt artifacts/mapping-release.txt
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-nogms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-nogms.txt
           echo "::set-output name=path::artifacts/"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts-release
+          name: artifacts-release-nogms
           path: ${{ steps.artifacts_copy.outputs.path }}
+  build_release_gms:
+    name: Build Release AAB and APK (GMS)
+    runs-on: ubuntu-latest
+    needs: build_number
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+          echo "::set-output name=minor_version::${{ needs.build_number.outputs.number }}"
+      - name: Build release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          ./gradlew :instances:app:assembleRelease :instances:app:bundleRelease :instances:wearable:assembleRelease :instances:wearable:bundleRelease \
+            -Dversion_code=${{ steps.vars.outputs.minor_version }} \
+            -Dversion_name="${{ steps.vars.outputs.major_version }}-rc" \
+            -Dis_sentry_publish=true \
+            -Dis_google_feature=true
+      - name: Sign AAB
+        id: sign_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign APK
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear AAB
+        id: sign_wear_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Sign Wear APK
+        id: sign_wear_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: instances/wearable/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_ALIAS_PASSWORD }}
+      - name: Copy artifacts
+        id: artifacts_copy
+        run: |
+          mkdir artifacts
+          cp ${{ steps.sign_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.aab
+          cp ${{ steps.sign_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-gms.apk
+          cp instances/app/build/outputs/mapping/internal/mapping.txt artifacts/mapping-gms.txt
+          cp ${{ steps.sign_wear_aab.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.aab
+          cp ${{ steps.sign_wear_apk.outputs.signedReleaseFile }} artifacts/flipper-zero-wear-gms.apk
+          cp instances/wearable/build/outputs/mapping/internal/mapping.txt artifacts/mapping-wear-gms.txt
+          echo "::set-output name=path::artifacts/"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-release-gms
+          path: ${{ steps.artifacts_copy.outputs.path }}
+  upload_to_github:
+    name: Upload to Github Releases
+    runs-on: ubuntu-latest
+    needs: [ build_internal_nogms, build_internal_gms, build_release_nogms, build_release_gms ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - uses: actions/download-artifact@v2
+        id: download-internal-gms
+        with:
+          name: artifacts-internal-nogms
+      - uses: actions/download-artifact@v2
+        id: download-internal-nogms
+        with:
+          name: artifacts-internal-nogms
+      - uses: actions/download-artifact@v2
+        id: download-release-gms
+        with:
+          name: artifacts-release-gms
+      - uses: actions/download-artifact@v2
+        id: download-release-nogms
+        with:
+          name: artifacts-release-nogms
+      - name: 'Set variables'
+        id: vars
+        run: |
+          export $(cat .github/workflows/version.env | xargs)
+          echo "::set-output name=major_version::${MAJOR_VERSION}"
+      - name: Install zip
+        uses: montudor/action-zip@v1
+      - name: Prepare mapping
+        id: mappings
+        run: |
+          mkdir mappings
+          cp ${{steps.download-internal-nogms.outputs.download-path}}/mapping-nogms.txt mappings/mapping-internal-nogms.txt
+          cp ${{steps.download-internal-gms.outputs.download-path}}/mapping-gms.txt mappings/mapping-internal-gms.txt
+          cp ${{steps.download-internal-gms.outputs.download-path}}/mapping-wear-gms.txt mappings/mapping-internal-wear-gms.txt
+          cp ${{steps.download-release-nogms.outputs.download-path}}/mapping-nogms.txt mappings/mapping-release-nogms.txt
+          cp ${{steps.download-release-gms.outputs.download-path}}/mapping-gms.txt mappings/mapping-release-gms.txt
+          cp ${{steps.download-release-gms.outputs.download-path}}/mapping-wear-gms.txt mappings/mapping-release-wear-gms.txt
+          zip -qq -r mappings.zip mappings
+          echo "::set-output name=archive::mappings.zip"
+      - name: Copy artifacts
+        id: artifacts_copy
+        run: |
+          mkdir artifacts
+          cp ${{ steps.mappings.outputs.archive }} artifacts/mappings-${{ steps.vars.outputs.major_version }}-rc.zip
+          cp ${{steps.download-internal-gms.outputs.download-path}}/flipper-zero-gms.aab artifacts/flipper-zero-internal-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-internal-gms.outputs.download-path}}/flipper-zero-gms.apk artifacts/flipper-zero-internal-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+          cp ${{steps.download-internal-gms.outputs.download-path}}/flipper-zero-wear-gms.aab artifacts/flipper-zero-internal-wear-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-internal-gms.outputs.download-path}}/flipper-zero-wear-gms.apk artifacts/flipper-zero-internal-wear-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+          cp ${{steps.download-internal-nogms.outputs.download-path}}/flipper-zero-nogms.aab artifacts/flipper-zero-internal-nogms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-internal-nogms.outputs.download-path}}/flipper-zero-nogms.apk artifacts/flipper-zero-internal-nogms-${{ steps.vars.outputs.major_version }}-rc.apk
+          cp ${{steps.download-release-gms.outputs.download-path}}/flipper-zero-gms.aab artifacts/flipper-zero-release-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-release-gms.outputs.download-path}}/flipper-zero-gms.apk artifacts/flipper-zero-release-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+          cp ${{steps.download-release-gms.outputs.download-path}}/flipper-zero-wear-gms.aab artifacts/flipper-zero-release-wear-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-release-gms.outputs.download-path}}/flipper-zero-wear-gms.apk artifacts/flipper-zero-release-wear-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+          cp ${{steps.download-release-nogms.outputs.download-path}}/flipper-zero-nogms.aab artifacts/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.aab
+          cp ${{steps.download-release-nogms.outputs.download-path}}/flipper-zero-nogms.apk artifacts/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.apk
+          echo "::set-output name=path::artifacts/"
+      - name: Create Release Candidate
+        id: create_internal_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            ${{ steps.artifacts_copy.outputs.path }}/mappings-${{ steps.vars.outputs.major_version }}-rc.zip
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-wear-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-wear-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-nogms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-internal-nogms-${{ steps.vars.outputs.major_version }}-rc.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-wear-gms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-wear-gms-${{ steps.vars.outputs.major_version }}-rc.apk
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.aab
+            ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-release-nogms-${{ steps.vars.outputs.major_version }}-rc.apk
+          tag_name: Release Candidate ${{ steps.vars.outputs.major_version }}
+          name: Flipper App ${{ steps.vars.outputs.major_version }}-rc
+          draft: false
+          prerelease: true


### PR DESCRIPTION
**Background**

Right now we have deprecated CI for RC and release

**Changes**

- Upload gms and nogms in release and release candidate

**Test plan**

Run it on dev
