### PR TITLE
Add screenshot and unlock button in screenstreaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Feature] Not found if key not found in mfkey32
 - [Feature] Fix format for user keys
 - [Feature] Updater card display update from url
+- [Feature] Add screenshot and unlock to screenstreaming
 - [CI] Auto git submodule update via gradle task
 - [FIX] Options button in device screen
 - [FIX] WearOS connection

--- a/components/core/share/src/main/kotlin/com/flipperdevices/core/share/SharableFile.kt
+++ b/components/core/share/src/main/kotlin/com/flipperdevices/core/share/SharableFile.kt
@@ -5,7 +5,7 @@ import java.io.File
 
 private const val SHARE_DIR = "sharedkeys/"
 
-data class SharableFile(
-    private val context: Context,
-    private val nameFile: String
+class SharableFile(
+    context: Context,
+    nameFile: String
 ) : File(context.cacheDir, "$SHARE_DIR$nameFile")

--- a/components/core/ui/res/src/main/res/drawable/ic_double_back.xml
+++ b/components/core/ui/res/src/main/res/drawable/ic_double_back.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:height="24dp"
+        android:tint="#000000"
+        android:viewportHeight="24"
+        android:viewportWidth="24"
+        android:width="24dp">
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.59,18l1.41,-1.41l-4.58,-4.59l4.58,-4.59l-1.41,-1.41l-6,6z" />
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M11,18l1.41,-1.41l-4.58,-4.59l4.58,-4.59l-1.41,-1.41l-6,6z" />
+</vector>

--- a/components/core/ui/res/src/main/res/drawable/ic_screenshot.xml
+++ b/components/core/ui/res/src/main/res/drawable/ic_screenshot.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:height="24dp"
+        android:tint="#000000"
+        android:viewportHeight="24"
+        android:viewportWidth="24"
+        android:width="24dp">
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0" />
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z" />
+</vector>

--- a/components/screenstreaming/impl/build.gradle.kts
+++ b/components/screenstreaming/impl/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation(projects.components.core.di)
     implementation(projects.components.core.log)
     implementation(projects.components.core.ktx)
+    implementation(projects.components.core.share)
+    implementation(projects.components.core.preference)
     implementation(projects.components.core.ui.lifecycle)
     implementation(projects.components.core.ui.theme)
     implementation(projects.components.core.ui.navigation)
@@ -40,4 +42,7 @@ dependencies {
     // Dagger deps
     implementation(libs.dagger)
     kapt(libs.dagger.kapt)
+    implementation(libs.tangle.viewmodel.compose)
+    implementation(libs.tangle.viewmodel.api)
+    anvil(libs.tangle.viewmodel.compiler)
 }

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ButtonEnum.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ButtonEnum.kt
@@ -1,8 +1,8 @@
 package com.flipperdevices.screenstreaming.impl.composable
 
-import com.flipperdevices.core.ui.res.R as DesignSystem
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import com.flipperdevices.core.ui.res.R as DesignSystem
 import com.flipperdevices.protobuf.screen.Gui
 import com.flipperdevices.screenstreaming.impl.R
 

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ButtonEnum.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ButtonEnum.kt
@@ -1,20 +1,22 @@
 package com.flipperdevices.screenstreaming.impl.composable
 
+import com.flipperdevices.core.ui.res.R as DesignSystem
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.flipperdevices.core.ui.res.R as DesignSystem
 import com.flipperdevices.protobuf.screen.Gui
 import com.flipperdevices.screenstreaming.impl.R
 
 enum class ButtonEnum(
     @DrawableRes val icon: Int,
     @StringRes val description: Int,
-    val key: Gui.InputKey
+    val key: Gui.InputKey?
 ) {
     LEFT(DesignSystem.drawable.ic_arrow_left, R.string.control_left, Gui.InputKey.LEFT),
     RIGHT(DesignSystem.drawable.ic_arrow_right, R.string.control_right, Gui.InputKey.RIGHT),
     UP(DesignSystem.drawable.ic_arrow_up, R.string.control_up, Gui.InputKey.UP),
     DOWN(DesignSystem.drawable.ic_arrow_down, R.string.control_down, Gui.InputKey.DOWN),
     OK(DesignSystem.drawable.ic_circle, R.string.control_ok, Gui.InputKey.OK),
-    BACK(DesignSystem.drawable.ic_back_arrow, R.string.control_back, Gui.InputKey.BACK)
+    BACK(DesignSystem.drawable.ic_back_arrow, R.string.control_back, Gui.InputKey.BACK),
+    UNLOCK(DesignSystem.drawable.ic_double_back, R.string.control_unlock, Gui.InputKey.BACK),
+    SCREENSHOT(DesignSystem.drawable.ic_screenshot, R.string.control_screenshot, null)
 }

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableControlButtons.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableControlButtons.kt
@@ -31,13 +31,13 @@ fun ComposableControlButtons(
     onLongPressButton: (ButtonEnum) -> Unit = {}
 ) {
     /**
-     * |----|  up  |-------|
-     * |left|  ok  | right |
-     * |----| down | back |
+     * | photo |  up  | unlock |
+     * | left |  ok  | right |
+     * |------| down  | back |
      */
     Column(modifier) {
         ControlRow(
-            start = null, center = ButtonEnum.UP, end = null,
+            start = ButtonEnum.SCREENSHOT, center = ButtonEnum.UP, end = ButtonEnum.UNLOCK,
             onPressButton, onLongPressButton
         )
         ControlRow(

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableScreen.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -23,31 +22,22 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.flipperdevices.screenstreaming.impl.R
-import com.flipperdevices.screenstreaming.impl.model.StreamingState
 import com.flipperdevices.screenstreaming.impl.viewmodel.FLIPPER_SCREEN_RATIO
 import com.flipperdevices.screenstreaming.impl.viewmodel.ScreenStreamingViewModel
 import kotlin.math.roundToInt
 
 @ExperimentalFoundationApi
 @ExperimentalComposeUiApi
-@Preview(
-    showBackground = true,
-    showSystemUi = true
-)
 @Composable
 fun ComposableScreen(
-    viewModel: ScreenStreamingViewModel = viewModel(),
+    viewModel: ScreenStreamingViewModel,
     onPressButton: (ButtonEnum) -> Unit = {},
-    onLongPressButton: (ButtonEnum) -> Unit = {},
-    onScreenStreamingSwitch: (StreamingState) -> Unit = {}
+    onLongPressButton: (ButtonEnum) -> Unit = {}
 ) {
     val flipperScreen by viewModel.getFlipperScreen().collectAsState()
-    val streamingState by viewModel.getStreamingState().collectAsState()
     val speedState by viewModel.getSpeed().collectAsState()
 
     Column {
@@ -60,26 +50,6 @@ fun ComposableScreen(
         ) {
             ComposableFlipperScreen(flipperScreen)
             ComposableControlButtons(Modifier.weight(1f), onPressButton, onLongPressButton)
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    onScreenStreamingSwitch(
-                        when (streamingState) {
-                            StreamingState.DISABLED -> StreamingState.ENABLED
-                            StreamingState.ENABLED -> StreamingState.DISABLED
-                        }
-                    )
-                }
-            ) {
-                Text(
-                    text = stringResource(
-                        id = when (streamingState) {
-                            StreamingState.DISABLED -> R.string.screen_streaming_enable
-                            StreamingState.ENABLED -> R.string.screen_streaming_disable
-                        }
-                    )
-                )
-            }
         }
         Column {
             val rx = Formatter.formatFileSize(LocalContext.current, speedState.receiveBytesInSec)

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableStreamingScreen.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableStreamingScreen.kt
@@ -4,17 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.flipperdevices.core.ktx.android.observeAsState
-import com.flipperdevices.screenstreaming.impl.model.StreamingState
 import com.flipperdevices.screenstreaming.impl.viewmodel.ScreenStreamingViewModel
+import tangle.viewmodel.compose.tangleViewModel
 
 @Composable
-fun ComposableStreamingScreen(
-    screenStreamingViewModel: ScreenStreamingViewModel = viewModel()
-) {
+fun ComposableStreamingScreen() {
+    val screenStreamingViewModel: ScreenStreamingViewModel = tangleViewModel()
     val lifecycleState by LocalLifecycleOwner.current.lifecycle.observeAsState()
     when (lifecycleState) {
+        Lifecycle.Event.ON_RESUME -> screenStreamingViewModel.enableStreaming()
         Lifecycle.Event.ON_PAUSE -> screenStreamingViewModel.disableStreaming()
         else -> {}
     }
@@ -26,12 +25,6 @@ fun ComposableStreamingScreen(
         },
         onLongPressButton = { button ->
             screenStreamingViewModel.onLongPressButton(button)
-        },
-        onScreenStreamingSwitch = { state ->
-            when (state) {
-                StreamingState.ENABLED -> screenStreamingViewModel.enableStreaming()
-                StreamingState.DISABLED -> screenStreamingViewModel.disableStreaming()
-            }
         }
     )
 }

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/FlipperRequestApiButtonKtx.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/FlipperRequestApiButtonKtx.kt
@@ -6,29 +6,32 @@ import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.screen.Gui
 import com.flipperdevices.protobuf.screen.sendInputEventRequest
-import com.flipperdevices.screenstreaming.impl.composable.ButtonEnum
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+@Suppress("SpreadOperator")
 internal fun FlipperRequestApi.pressOnButton(
     viewModelScope: CoroutineScope,
-    buttonEnum: ButtonEnum,
-    type: Gui.InputType
+    key: Gui.InputKey,
+    type: Gui.InputType,
+    times: Int = 1
 ) = viewModelScope.launch {
-    requestWithoutAnswer(
-        getRequestFor(buttonEnum, Gui.InputType.PRESS),
-        getRequestFor(buttonEnum, type),
-        getRequestFor(buttonEnum, Gui.InputType.RELEASE)
-    )
+    val requests = mutableListOf<FlipperRequest>()
+    repeat(times) {
+        requests.add(getRequestFor(key, Gui.InputType.PRESS))
+        requests.add(getRequestFor(key, type))
+        requests.add(getRequestFor(key, Gui.InputType.RELEASE))
+    }
+    requestWithoutAnswer(*requests.toTypedArray())
 }
 
 private fun getRequestFor(
-    buttonEnum: ButtonEnum,
+    inputKey: Gui.InputKey,
     buttonType: Gui.InputType
 ): FlipperRequest {
     return main {
         guiSendInputEventRequest = sendInputEventRequest {
-            key = buttonEnum.key
+            key = inputKey
             type = buttonType
         }
     }.wrapToRequest()

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
@@ -73,20 +73,21 @@ class ScreenStreamingViewModel @VMInject constructor(
     fun getFlipperScreen(): StateFlow<Bitmap> = flipperScreen
     fun getSpeed(): StateFlow<FlipperSerialSpeed> = speedState
 
-    fun onPressButton(buttonEnum: ButtonEnum) {
-        if (buttonEnum == ButtonEnum.UNLOCK) {
-            serviceApi?.requestApi?.pressOnButton(
-                viewModelScope, Gui.InputKey.BACK, Gui.InputType.SHORT, times = 3
-            )
-            return
+    fun onPressButton(buttonEnum: ButtonEnum) = when (buttonEnum) {
+        ButtonEnum.UNLOCK -> serviceApi?.requestApi?.pressOnButton(
+            viewModelScope, Gui.InputKey.BACK, Gui.InputType.SHORT, times = 3
+        )
+        ButtonEnum.SCREENSHOT -> shareScreenshot()
+        ButtonEnum.LEFT,
+        ButtonEnum.RIGHT,
+        ButtonEnum.UP,
+        ButtonEnum.DOWN,
+        ButtonEnum.OK,
+        ButtonEnum.BACK -> buttonEnum.key?.let { key ->
+            serviceApi?.requestApi?.pressOnButton(viewModelScope, key, Gui.InputType.SHORT)
         }
-        if (buttonEnum == ButtonEnum.SCREENSHOT) {
-            shareScreenshot()
-            return
-        }
-        val key = buttonEnum.key ?: return
-        serviceApi?.requestApi?.pressOnButton(viewModelScope, key, Gui.InputType.SHORT)
     }
+
 
     fun onLongPressButton(buttonEnum: ButtonEnum) {
         val key = buttonEnum.key ?: return

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
@@ -88,7 +88,6 @@ class ScreenStreamingViewModel @VMInject constructor(
         }
     }
 
-
     fun onLongPressButton(buttonEnum: ButtonEnum) {
         val key = buttonEnum.key ?: return
         serviceApi?.requestApi?.pressOnButton(viewModelScope, key, Gui.InputType.LONG)

--- a/components/screenstreaming/impl/src/main/res/values/strings.xml
+++ b/components/screenstreaming/impl/src/main/res/values/strings.xml
@@ -6,9 +6,10 @@
     <string name="control_right">Right</string>
     <string name="control_ok">OK</string>
     <string name="control_back">Back</string>
+    <string name="control_unlock">Unlock</string>
+    <string name="control_screenshot">Screenshot</string>
+    <string name="screenshot_export_title">Share screenshot of flipper…</string>
     <string name="flipper_display">Flipper display</string>
-    <string name="screen_streaming_enable">Start streaming</string>
-    <string name="screen_streaming_disable">Stop streaming</string>
     <string name="screen_streaming_speed_receive">Receive speed: %1$s per sec</string>
     <string name="screen_streaming_speed_send">Send speed: %1$s per sec</string>
 </resources>


### PR DESCRIPTION
**Background**

Right now we can't do screenshot and unlock flipper by one button

**Changes**

Add unlock button
Add screenshot button

**Test plan**

Try lock flipper and unlock via unlock button
Try screenshot flipper
![telegram-cloud-photo-size-2-5409350171185234689-y](https://user-images.githubusercontent.com/5871715/199538198-4ba7ab81-3306-40a3-b36f-60ff5aab713b.jpg)
