### PR TITLE
Fix crash when delete from trash key with favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [FIX] Uploading share errors
 - [FIX] Display by white color meta data on NFC card
 - [FIX] Scrim status bar and design changes on bottom sheet
+- [FIX] Fix crash when delete from trash key with favorites
 - [CI] Git submodule `Flipper Protobuf`
 
 # 1.3.0


### PR DESCRIPTION
**Background**

Right now when we delete key from trash and this key exist in favorites, app throw crash

**Changes**

Delete key before permanently delete from trash

**Test plan**

- Add key to favorite
- Move it to trash
- Delete it from trash
