### PR TITLE
Bump length for server-side share link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [CI] Android lint in CI
 - [FIX] Clickable modifier ktx
 - [FIX] Refactor `share:receive` module
+- [FIX] Bump length for server-side share link
 - [REFACTOR] Fix detekt compose issues
 - [REFACTOR] Format markdown changelog
 - [REFACTOR] Enable detekt formatting

--- a/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/viewmodel/UploaderViewModel.kt
+++ b/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/viewmodel/UploaderViewModel.kt
@@ -28,7 +28,7 @@ import tangle.viewmodel.VMInject
 import java.net.UnknownHostException
 import java.net.UnknownServiceException
 
-private const val SHORT_LINK_SIZE = 200
+private const val SHORT_LINK_SIZE = 256
 
 class UploaderViewModel @VMInject constructor(
     private val keyParser: KeyParser,


### PR DESCRIPTION
**Background**

Bump length for server-side share link

**Changes**

From 200 to 256

**Test plan**

Try share link
