### PR TITLE
Migrate VersionApi to isSupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [REFACTOR] Replace some clickable to card function + reuse orange app bar
 - [REFACTOR] Google Compose Navigation (archive, firstpair, widgets(composable entry), updater, import)
 - [REFACTOR] Migrate to new device info api
+- [REFACTOR] Migrate to isSupported in version api
 
 # 1.4.1
 

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/FlipperVersionApi.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/FlipperVersionApi.kt
@@ -3,6 +3,13 @@ package com.flipperdevices.bridge.api.manager.service
 import com.flipperdevices.core.data.SemVer
 import kotlinx.coroutines.flow.StateFlow
 
+private const val VERSION_WAITING_TIMEOUT_MS = 30 * 1000L // 10 sec
+
 interface FlipperVersionApi {
     fun getVersionInformationFlow(): StateFlow<SemVer?>
+
+    suspend fun isSupported(
+        version: SemVer,
+        timeout: Long = VERSION_WAITING_TIMEOUT_MS
+    ): Boolean
 }

--- a/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/FlipperRpcInformationApiImpl.kt
+++ b/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/FlipperRpcInformationApiImpl.kt
@@ -18,8 +18,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -66,10 +64,9 @@ class FlipperRpcInformationApiImpl @Inject constructor(
         serviceApi: FlipperServiceApi
     ) {
         rpcInformationFlow.emit(FlipperInformationStatus.InProgress(FlipperRpcInformation()))
-        val version = serviceApi.flipperVersionApi.getVersionInformationFlow()
-            .filterNotNull()
-            .first()
-        val flipperFullInfoRpcApi = if (version >= Constants.API_SUPPORTED_GET_REQUEST) {
+        val flipperFullInfoRpcApi = if (
+            serviceApi.flipperVersionApi.isSupported(Constants.API_SUPPORTED_GET_REQUEST)
+        ) {
             NewFlipperFullInfoRpcApi()
         } else {
             DeprecatedFlipperFullInfoRpcApi()

--- a/components/keyscreen/emulate/src/main/java/com/flipperdevices/keyscreen/emulate/viewmodel/helpers/FlipperErrorHelper.kt
+++ b/components/keyscreen/emulate/src/main/java/com/flipperdevices/keyscreen/emulate/viewmodel/helpers/FlipperErrorHelper.kt
@@ -4,14 +4,12 @@ import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
-import com.flipperdevices.core.data.SemVer
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.keyscreen.emulate.model.FlipperAppError
 import com.flipperdevices.protobuf.Flipper
 import com.flipperdevices.protobuf.app.getErrorRequest
 import com.flipperdevices.protobuf.main
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
@@ -30,11 +28,7 @@ class FlipperAppErrorHandlerImpl @Inject constructor() : FlipperAppErrorHelper {
     ): FlipperAppError {
         val requestApi = serviceApi.requestApi
 
-        val currentFlipperVersion = getCurrentFlipperVersion(serviceApi)
-        if (
-            currentFlipperVersion == null ||
-            currentFlipperVersion < Constants.API_SUPPORTED_FLIPPER_ERROR
-        ) {
+        if (!serviceApi.flipperVersionApi.isSupported(Constants.API_SUPPORTED_FLIPPER_ERROR)) {
             return FlipperAppError.NotSupportedApi
         }
 
@@ -53,9 +47,5 @@ class FlipperAppErrorHandlerImpl @Inject constructor() : FlipperAppErrorHelper {
             }
             else -> FlipperAppError.BadResponse
         }
-    }
-
-    private suspend fun getCurrentFlipperVersion(serviceApi: FlipperServiceApi): SemVer? {
-        return serviceApi.flipperVersionApi.getVersionInformationFlow().first()
     }
 }

--- a/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SkipProvisioningHelper.kt
+++ b/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SkipProvisioningHelper.kt
@@ -12,10 +12,8 @@ import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.property.getRequest
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 interface SkipProvisioningHelper {
@@ -25,7 +23,6 @@ interface SkipProvisioningHelper {
 }
 
 private const val RPC_KEY_HARDWARE_REGION = "hardware.region.builtin"
-private const val RPC_INFORMATION_TIMEOUT_MS = 1_000L * 60 // 10 seconds
 
 @ContributesBinding(AppGraph::class, SkipProvisioningHelper::class)
 class SkipProvisioningHelperImpl @Inject constructor(
@@ -43,13 +40,7 @@ class SkipProvisioningHelperImpl @Inject constructor(
             return false
         }
         info { "Try receive version" }
-        val semVer = withTimeoutOrNull(RPC_INFORMATION_TIMEOUT_MS) {
-            serviceApi.flipperVersionApi.getVersionInformationFlow().filter {
-                it != null
-            }.first()
-        }
-        info { "Receive version: $semVer" }
-        if (semVer == null || semVer < Constants.API_SUPPORTED_GET_REQUEST) {
+        if (!serviceApi.flipperVersionApi.isSupported(Constants.API_SUPPORTED_GET_REQUEST)) {
             info { "Version less then ${Constants.API_SUPPORTED_GET_REQUEST}, so return false" }
             return false
         }

--- a/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SkipProvisioningHelperTest.kt
+++ b/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SkipProvisioningHelperTest.kt
@@ -3,7 +3,7 @@ package com.flipperdevices.updater.subghz.tasks
 import androidx.datastore.core.DataStore
 import com.flipperdevices.bridge.api.manager.FlipperRequestApi
 import com.flipperdevices.bridge.api.manager.service.FlipperVersionApi
-import com.flipperdevices.core.data.SemVer
+import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.core.ktx.jre.TimeHelper
 import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.protobuf.main
@@ -14,7 +14,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -56,9 +55,9 @@ class SkipProvisioningHelperTest {
         )
 
         val versionApi = mockk<FlipperVersionApi> {
-            every {
-                getVersionInformationFlow()
-            } returns MutableStateFlow(null)
+            coEvery {
+                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
+            } returns false
         }
 
         val shouldProvide = underTest.shouldSkipProvisioning(
@@ -79,9 +78,9 @@ class SkipProvisioningHelperTest {
         )
 
         val versionApi = mockk<FlipperVersionApi> {
-            every {
-                getVersionInformationFlow()
-            } returns MutableStateFlow(SemVer(0, 0))
+            coEvery {
+                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
+            } returns false
         }
 
         val shouldProvide = underTest.shouldSkipProvisioning(
@@ -102,9 +101,9 @@ class SkipProvisioningHelperTest {
         )
 
         val versionApi = mockk<FlipperVersionApi> {
-            every {
-                getVersionInformationFlow()
-            } returns MutableStateFlow(SemVer(0, 14))
+            coEvery {
+                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
+            } returns true
         }
         val mockRequestApi = mockk<FlipperRequestApi> {
             coEvery { request(any(), any()) } returns main {}
@@ -129,9 +128,9 @@ class SkipProvisioningHelperTest {
         )
 
         val versionApi = mockk<FlipperVersionApi> {
-            every {
-                getVersionInformationFlow()
-            } returns MutableStateFlow(SemVer(0, 14))
+            coEvery {
+                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
+            } returns true
         }
         val mockRequestApi = mockk<FlipperRequestApi> {
             coEvery { request(any(), any()) } returns main {
@@ -160,9 +159,9 @@ class SkipProvisioningHelperTest {
         )
 
         val versionApi = mockk<FlipperVersionApi> {
-            every {
-                getVersionInformationFlow()
-            } returns MutableStateFlow(SemVer(0, 14))
+            coEvery {
+                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
+            } returns true
         }
         val mockRequestApi = mockk<FlipperRequestApi> {
             coEvery { request(any(), any()) } returns main {


### PR DESCRIPTION
**Background**

Right now we each time request version and wait until version is provided

**Changes**

- Share this logic in version api class
- Use isSupported method 

**Test plan**

Try launch application and check version support