### PR TITLE
Fix startup crush with inapp storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [FIX] Fix broken synchronization with changes from android
 - [FIX] Fix shadow file sharing as file
 - [FIX] Firstpair flow open by navigation graph route
+- [FIX] Fix crush with inapp storage on startup
 - [REFACTOR] Migrate bottom bar to compose navigation
 - [REFACTOR] Bump Android Gradle Plugin
 - [REFACTOR] Fix detekt compose issues

--- a/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/composable/ComposableInAppNotification.kt
+++ b/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/composable/ComposableInAppNotification.kt
@@ -1,15 +1,12 @@
 package com.flipperdevices.bottombar.impl.composable
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
 import com.flipperdevices.bottombar.impl.viewmodel.InAppNotificationState
 import com.flipperdevices.bottombar.impl.viewmodel.InAppNotificationViewModel
-import com.flipperdevices.core.ktx.android.observeAsState
 import com.flipperdevices.inappnotification.api.InAppNotificationRenderer
 import tangle.viewmodel.compose.tangleViewModel
 
@@ -21,13 +18,10 @@ fun ComposableInAppNotification(
 ) {
     val notificationState by notificationViewModel.state().collectAsState()
 
-    val lifecycleState by LocalLifecycleOwner.current.lifecycle.observeAsState()
-    LaunchedEffect(key1 = lifecycleState) {
-        when (lifecycleState) {
-            Lifecycle.Event.ON_RESUME -> notificationViewModel.onResume()
-            else -> {
-                notificationViewModel.onPause()
-            }
+    DisposableEffect(key1 = Unit) {
+        notificationViewModel.onCreate()
+        onDispose {
+            notificationViewModel.onDestroy()
         }
     }
 

--- a/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/InAppNotificationViewModel.kt
+++ b/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/InAppNotificationViewModel.kt
@@ -22,11 +22,11 @@ class InAppNotificationViewModel @VMInject constructor(
 
     fun state(): StateFlow<InAppNotificationState> = notificationState
 
-    fun onResume() {
+    fun onCreate() {
         notificationStorage.subscribe(this)
     }
 
-    fun onPause() {
+    fun onDestroy() {
         notificationStorage.unsubscribe()
     }
 

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearchingView.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearchingView.kt
@@ -1,4 +1,3 @@
-
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -12,9 +11,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
-import com.flipperdevices.core.ktx.android.observeAsState
+import com.flipperdevices.core.ktx.android.OnLifecycleEvent
 import com.flipperdevices.core.ui.dialog.composable.multichoice.FlipperMultiChoiceDialog
 import com.flipperdevices.core.ui.dialog.composable.multichoice.FlipperMultiChoiceDialogModel
 import com.flipperdevices.firstpair.impl.R
@@ -150,8 +148,7 @@ private fun ComposableSearchingInternal(
         }
     }
 
-    val lifecycleState by LocalLifecycleOwner.current.lifecycle.observeAsState()
-    LaunchedEffect(key1 = lifecycleState) {
+    OnLifecycleEvent { lifecycleState ->
         when (lifecycleState) {
             Lifecycle.Event.ON_RESUME -> invalidate()
             else -> {}

--- a/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/storage/InAppNotificationStorageImpl.kt
+++ b/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/storage/InAppNotificationStorageImpl.kt
@@ -35,7 +35,7 @@ class InAppNotificationStorageImpl @Inject constructor() :
 
     override fun subscribe(listener: InAppNotificationListener) {
         if (this.listener != null) {
-            error("For now this storage support only one listener in one time")
+            unsubscribe()
         }
         this.listener = listener
         timerTask.start()

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableStreamingScreen.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/composable/ComposableStreamingScreen.kt
@@ -1,21 +1,18 @@
 package com.flipperdevices.screenstreaming.impl.composable
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
-import com.flipperdevices.core.ktx.android.observeAsState
+import androidx.compose.runtime.DisposableEffect
 import com.flipperdevices.screenstreaming.impl.viewmodel.ScreenStreamingViewModel
 import tangle.viewmodel.compose.tangleViewModel
 
 @Composable
 fun ComposableStreamingScreen() {
     val screenStreamingViewModel: ScreenStreamingViewModel = tangleViewModel()
-    val lifecycleState by LocalLifecycleOwner.current.lifecycle.observeAsState()
-    when (lifecycleState) {
-        Lifecycle.Event.ON_RESUME -> screenStreamingViewModel.enableStreaming()
-        Lifecycle.Event.ON_PAUSE -> screenStreamingViewModel.disableStreaming()
-        else -> {}
+    DisposableEffect(key1 = Unit) {
+        screenStreamingViewModel.enableStreaming()
+        onDispose {
+            screenStreamingViewModel.disableStreaming()
+        }
     }
 
     ComposableScreen(


### PR DESCRIPTION
**Background**

Right now we crush if subscriber already exist, because our compose screens can be in situation with same screen instance on screen in one moment

**Changes**

- Not crush if subscribe already exist
- Migrate lifecycle to more safe lifecycle event API
- Use disposable when it possible

**Test plan**

Try use screenstreaming and inappstorage