### PR TITLE
Fix customize button when set widget state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [FIX] Wait for disconnect while update
 - [FIX] Fix mfkey32
 - [FIX] Use CurrentActivityHolder for get activity in updater(replace Context cast)
+- [FIX] Fix customize button when set widget state
 - [REFACTOR] Migrate bottom bar to compose navigation
 - [REFACTOR] Bump Android Gradle Plugin
 - [REFACTOR] Fix detekt compose issues

--- a/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
+++ b/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
@@ -78,6 +78,7 @@ class WidgetSelectViewModel @VMInject constructor(
         info { "#onSelectKey for $widgetId $keyPath" }
         viewModelScope.launch {
             widgetDataApi.updateKeyForWidget(widgetId, keyPath)
+            widgetApi.resetStateOfWidget(widgetId)
             widgetApi.invalidate()
             notifyActivityAboutResult(currentActivity)
 


### PR DESCRIPTION
**Background**

Right now when we set state with customize button on widget screen we don't update widget state

**Changes**

Reset widget state after change key associated

**Test plan**

Try emulate key which not synchronized and then change key with customize button