### PR TITLE
Wait disconnecting from device when restart rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [FIX] InAppNotification update redesign for font scale
 - [FIX] Decrease reconnect timeouts and lags detector timeout
 - [FIX] Device info mapping keys
+- [FIX] Wait disconnecting from device when restart rpc
 - [REFACTOR] Migrate bottom bar to compose navigation
 - [REFACTOR] Bump Android Gradle Plugin
 - [REFACTOR] Fix detekt compose issues

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/RestartRPCApi.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/RestartRPCApi.kt
@@ -1,5 +1,5 @@
 package com.flipperdevices.bridge.api.manager.service
 
 interface RestartRPCApi {
-    fun restartRpc()
+    suspend fun restartRpc()
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/utils/Constants.kt
@@ -63,7 +63,7 @@ object Constants {
     object BLE {
         private const val CONNECT_TIME_SEC = 3L
         val CONNECT_TIME_MS = TimeUnit.MILLISECONDS.convert(CONNECT_TIME_SEC, TimeUnit.SECONDS)
-        const val RECONNECT_COUNT = 1
+        const val RECONNECT_COUNT = 100
         const val RECONNECT_TIME_MS = 100L
         const val MAX_MTU = 512
 

--- a/components/bridge/impl/build.gradle.kts
+++ b/components/bridge/impl/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.components.analytics.metric.api)
 
     implementation(projects.components.bridge.api)
+    implementation(projects.components.bridge.service.api)
     implementation(projects.components.bridge.pbutils)
 
     implementation(libs.kotlin.coroutines)

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/UnsafeBleManager.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/UnsafeBleManager.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
 import android.content.Context
+import com.flipperdevices.bridge.api.manager.FlipperBleManager
 import com.flipperdevices.bridge.api.manager.ktx.providers.BondStateProvider
 import com.flipperdevices.bridge.api.manager.ktx.providers.ConnectionStateProvider
 import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
@@ -29,7 +30,11 @@ private const val UNSAFE_BLE_MANAGER_TAG = "UnsafeBleManager"
 abstract class UnsafeBleManager(
     scope: CoroutineScope,
     context: Context
-) : BleManager(context), ConnectionStateProvider, BondStateProvider, LogTagProvider {
+) : BleManager(context),
+    ConnectionStateProvider,
+    BondStateProvider,
+    LogTagProvider,
+    FlipperBleManager {
     override val TAG = UNSAFE_BLE_MANAGER_TAG
     private val connectionObservers = ConnectionObserverComposite(
         scope = scope,
@@ -51,7 +56,6 @@ abstract class UnsafeBleManager(
 
     fun setNotificationCallbackUnsafe(characteristic: BluetoothGattCharacteristic?) =
         setNotificationCallback(characteristic)
-
     fun enableNotificationsUnsafe(characteristic: BluetoothGattCharacteristic?) =
         enableNotifications(characteristic)
 

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
@@ -73,11 +73,11 @@ class FlipperSerialOverflowThrottler(
     override suspend fun reset(
         bleManager: UnsafeBleManager
     ) = withLock(mutex, "reset") {
-        bufferSizeState.emit(0)
-        pendingBytes = null
-        bleManager.setNotificationCallbackUnsafe(overflowCharacteristics) // reset (free) callback
         overflowBufferJob?.cancelAndJoin()
         overflowBufferJob = null
+        info { "Cancel overflow buffer job" }
+        bufferSizeState.emit(0)
+        pendingBytes = null
     }
 
     @VisibleForTesting

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/BridgeImplConfig.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/BridgeImplConfig.kt
@@ -1,5 +1,5 @@
 package com.flipperdevices.bridge.impl.utils
 
 object BridgeImplConfig {
-    const val BLE_VLOG = false
+    const val BLE_VLOG = true
 }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/BridgeImplConfig.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/BridgeImplConfig.kt
@@ -1,5 +1,5 @@
 package com.flipperdevices.bridge.impl.utils
 
 object BridgeImplConfig {
-    const val BLE_VLOG = true
+    const val BLE_VLOG = false
 }

--- a/components/bridge/service/api/src/main/java/com/flipperdevices/bridge/service/api/FlipperServiceApi.kt
+++ b/components/bridge/service/api/src/main/java/com/flipperdevices/bridge/service/api/FlipperServiceApi.kt
@@ -48,5 +48,5 @@ interface FlipperServiceApi {
     /**
      * An internal mechanism that allows you to restart the RPC flipper
      */
-    fun restartRPC()
+    suspend fun restartRPC()
 }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
@@ -76,14 +76,15 @@ class FlipperServiceApiImpl(
         flipperActionNotifier = flipperActionNotifier
     )
     private val bleManager: FlipperBleManager = FlipperBleManagerImpl(
-        context,
-        settingsStore,
-        scope,
-        serviceErrorListener,
-        lagsDetector,
-        flipperActionNotifier,
-        sentryApi,
-        metricApi
+        context = context,
+        settingsStore = settingsStore,
+        scope = scope,
+        serviceErrorListener = serviceErrorListener,
+        flipperLagsDetector = lagsDetector,
+        flipperActionNotifier = flipperActionNotifier,
+        sentryApi = sentryApi,
+        metricApi = metricApi,
+        serviceApi = this
     ).apply {
         connectionStateProvider.initialize(this.connectionInformationApi)
     }
@@ -149,7 +150,7 @@ class FlipperServiceApiImpl(
         bleManager.close()
     }
 
-    override fun restartRPC() {
+    override suspend fun restartRPC() {
         bleManager.restartRPCApi.restartRpc()
     }
 }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -46,12 +45,10 @@ class FlipperLagsDetectorImpl(
             ) { _, connectionState ->
                 connectionState
             }.collectLatest { connectionState ->
-                val uniqUUID = UUID.randomUUID()
-                info { "[$uniqUUID] Start waiting" }
                 delay(Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS)
                 if (pendingResponseCounter.get() > 0) {
                     error {
-                        "[$uniqUUID] We have pending commands, but flipper not respond " +
+                        "We have pending commands, but flipper not respond " +
                             "${Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS}ms. Pending commands is " +
                             pendingCommands.keys().toList().joinToString()
                     }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -32,7 +33,7 @@ class FlipperLagsDetectorImpl(
     private val connectionStateProvider: WeakConnectionStateProvider,
     private val flipperActionNotifier: FlipperActionNotifier
 ) : FlipperLagsDetector, LogTagProvider {
-    override val TAG = "FlipperLagsDetector"
+    override val TAG = "FlipperLagsDetector-${hashCode()}"
 
     private val pendingCommands = ConcurrentHashMap<FlipperRequest, Unit>()
     private val pendingResponseCounter = AtomicInteger(0)
@@ -45,17 +46,22 @@ class FlipperLagsDetectorImpl(
             ) { _, connectionState ->
                 connectionState
             }.collectLatest { connectionState ->
+                val uniqUUID = UUID.randomUUID()
+                info { "[$uniqUUID] Start waiting" }
                 delay(Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS)
                 if (pendingResponseCounter.get() > 0) {
                     error {
-                        "We have pending commands, but flipper not respond " +
+                        "[$uniqUUID] We have pending commands, but flipper not respond " +
                             "${Constants.LAGS_FLIPPER_DETECT_TIMEOUT_MS}ms. Pending commands is " +
                             pendingCommands.keys().toList().joinToString()
                     }
                     if (connectionState is ConnectionState.Ready &&
                         connectionState.supportedState == FlipperSupportedState.READY
                     ) {
+                        info { "Start restart RPC" }
                         serviceApi.restartRPC()
+                    } else {
+                        info { "Flipper not connected, so ignore it" }
                     }
                 } else if (pendingResponseCounter.get() < 0) {
                     pendingResponseCounter.set(0)
@@ -107,9 +113,6 @@ class FlipperLagsDetectorImpl(
     private suspend fun incrementPendingCounter(tag: String) {
         val pendingCount = pendingResponseCounter.getAndIncrement()
         verbose { "Increase pending response command $tag, current size is ${pendingCount + 1}" }
-        if (pendingCount == 0) {
-            info { "Pending response count is zero, so we launch pending flow" }
-            flipperActionNotifier.notifyAboutAction()
-        }
+        flipperActionNotifier.notifyAboutAction()
     }
 }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
@@ -88,7 +88,9 @@ class DebugViewModel @VMInject constructor(
 
     fun restartRpc() {
         serviceProvider.provideServiceApi(this) {
-            it.restartRPC()
+            viewModelScope.launch {
+                it.restartRPC()
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ ktx-testing = "1.1.5" # https://developer.android.com/jetpack/androidx/releases/
 lifecycle = "2.6.1" # https://developer.android.com/jetpack/androidx/releases/lifecycle
 # https://github.com/vigna/fastutil/issues/136
 fastutil = "7.2.1"
-ble = "2.6.0" # https://github.com/NordicSemiconductor/Android-BLE-Library/releases
+ble = "2.6.1" # https://github.com/NordicSemiconductor/Android-BLE-Library/releases
 ble-scan = "1.6.0" # https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library/releases
 lottie = "6.0.0" # https://github.com/airbnb/lottie/blob/master/android-compose.md
 material = "1.8.0" # https://github.com/material-components/material-components-android/releases


### PR DESCRIPTION
**Background**

Right now reset api work incorrectly

**Changes**

- Invalidate lags detector more ofter
- Wait for disconnect when restart rpc
- Request reconnect when restart rpc
- Migrate to not deprecated approach in FlipperBleManager
- Fix reset in flipper serial overflow throttler

**Test plan**

Try press on restart rpc in debug options