### PR TITLE
Replace radio type to radio sub number in device info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - [FIX] Decrease reconnect timeouts and lags detector timeout
 - [FIX] Device info mapping keys
 - [FIX] Wait disconnecting from device when restart rpc
-- [FIX] Remove radio type number from device info
+- [FIX] Replace radio type to sub number in device info
 - [REFACTOR] Migrate bottom bar to compose navigation
 - [REFACTOR] Bump Android Gradle Plugin
 - [REFACTOR] Fix detekt compose issues

--- a/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/states/ComposableReportError.kt
+++ b/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/states/ComposableReportError.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.analytics.shake2report.impl.composable.states
 
-import com.flipperdevices.core.ui.res.R as SharedResources
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,6 +20,7 @@ import com.flipperdevices.core.markdown.ClickableUrlText
 import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.core.ui.theme.LocalTypography
+import com.flipperdevices.core.ui.res.R as SharedResources
 
 @Composable
 internal fun ComposableReportError(

--- a/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/states/ComposableReportSuccessful.kt
+++ b/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/states/ComposableReportSuccessful.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.analytics.shake2report.impl.composable.states
 
-import com.flipperdevices.core.ui.res.R as SharedResources
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -25,6 +24,7 @@ import com.flipperdevices.core.ui.ktx.clickableRipple
 import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.core.ui.theme.LocalTypography
+import com.flipperdevices.core.ui.res.R as SharedResources
 
 @Composable
 internal fun ComposableReportSuccessful(

--- a/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/DeprecatedFlipperRpcInfoMapper.kt
+++ b/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/DeprecatedFlipperRpcInfoMapper.kt
@@ -31,6 +31,7 @@ private const val DEVICE_INFO_MINOR = "device_info_minor"
 private const val RADIO_STACK_MAJOR = "radio_stack_major"
 private const val RADIO_STACK_MINOR = "radio_stack_minor"
 private const val RADIO_STACK_TYPE = "radio_stack_type"
+private const val RADIO_STACK_SUB = "radio_stack_sub"
 
 // This fields uses in NOT other section
 private val usedFields = setOf(
@@ -38,7 +39,7 @@ private val usedFields = setOf(
     HARDWARE_VERSION, HARDWARE_OTP_VERSION, SERIAL_NUMBER,
     FIRMWARE_COMMIT, FIRMWARE_BRANCH, FIRMWARE_BUILD_DATE,
     FIRMWARE_TARGET, PROTOBUF_MAJOR, PROTOBUF_MINOR,
-    RADIO_STACK_MAJOR, RADIO_STACK_MINOR, RADIO_STACK_TYPE,
+    RADIO_STACK_MAJOR, RADIO_STACK_MINOR, RADIO_STACK_TYPE, RADIO_STACK_SUB,
     DEVICE_INFO_MAJOR, DEVICE_INFO_MINOR
 )
 
@@ -80,10 +81,11 @@ internal class DeprecatedFlipperRpcInfoMapper : FlipperRpcInfoMapper {
         val radioMajor = fields[RADIO_STACK_MAJOR]
         val radioMinor = fields[RADIO_STACK_MINOR]
         val radioType = fields[RADIO_STACK_TYPE]
+        val radioSub = fields[RADIO_STACK_SUB]
 
         val radioStackInfo = RadioStackInfo(
             type = radioType(radioType),
-            radioFirmware = radioFirmware(radioMajor, radioMinor, radioType)
+            radioFirmware = radioFirmware(radioMajor, radioMinor, radioSub)
         )
 
         return FlipperRpcInformation(

--- a/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/NewFlipperRpcInfoMapper.kt
+++ b/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/NewFlipperRpcInfoMapper.kt
@@ -26,6 +26,7 @@ private const val DEVICE_INFO_MINOR = "devinfo_format.minor"
 private const val RADIO_STACK_MAJOR = "devinfo_radio.stack.major"
 private const val RADIO_STACK_MINOR = "devinfo_radio.stack.minor"
 private const val RADIO_STACK_TYPE = "devinfo_radio.stack.type"
+private const val RADIO_STACK_SUB = "devinfo_radio.stack.sub"
 
 // This fields uses in NOT other section
 private val usedFields = setOf(
@@ -33,7 +34,7 @@ private val usedFields = setOf(
     HARDWARE_VERSION, HARDWARE_OTP_VERSION, SERIAL_NUMBER,
     FIRMWARE_COMMIT, FIRMWARE_BRANCH, FIRMWARE_BUILD_DATE,
     FIRMWARE_TARGET, PROTOBUF_MAJOR, PROTOBUF_MINOR,
-    RADIO_STACK_MAJOR, RADIO_STACK_MINOR, RADIO_STACK_TYPE,
+    RADIO_STACK_MAJOR, RADIO_STACK_MINOR, RADIO_STACK_TYPE, RADIO_STACK_SUB,
     DEVICE_INFO_MAJOR, DEVICE_INFO_MINOR
 )
 
@@ -77,13 +78,14 @@ internal class NewFlipperRpcInfoMapper : FlipperRpcInfoMapper {
         val radioMajor = fields[RADIO_STACK_MAJOR]
         val radioMinor = fields[RADIO_STACK_MINOR]
         val radioType = fields[RADIO_STACK_TYPE]
+        val radioSub = fields[RADIO_STACK_SUB]
 
         val radioStackInfo = RadioStackInfo(
             type = RpcInformationInfoHelper.radioType(radioType),
             radioFirmware = RpcInformationInfoHelper.radioFirmware(
                 radioMajor,
                 radioMinor,
-                radioType
+                radioSub
             )
         )
 

--- a/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/RpcInformationInfoHelper.kt
+++ b/components/bridge/rpcinfo/impl/src/main/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/RpcInformationInfoHelper.kt
@@ -40,14 +40,14 @@ object RpcInformationInfoHelper {
         }
     }
 
-    // radio Major.Minor.Type
+    // radio Major.Minor.Sub
     fun radioFirmware(
         radioMajor: String?,
         radioMinor: String?,
-        radioType: String?
+        radioSub: String?,
     ): String? {
-        return if (isNotNull(radioMajor, radioMinor, radioType)) {
-            "$radioMajor.$radioMinor.$radioType"
+        return if (isNotNull(radioMajor, radioMinor, radioSub)) {
+            "$radioMajor.$radioMinor.$radioSub"
         } else {
             null
         }

--- a/components/bridge/rpcinfo/impl/src/test/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/DeviceInfoHelperTest.kt
+++ b/components/bridge/rpcinfo/impl/src/test/java/com/flipperdevices/bridge/rpcinfo/impl/mapper/DeviceInfoHelperTest.kt
@@ -53,6 +53,7 @@ class DeviceInfoHelperTest(
                     "radio_stack_major" to "3",
                     "radio_stack_minor" to "5",
                     "radio_stack_type" to "7",
+                    "radio_stack_sub" to "7",
                     "other_fields_1" to "1",
                     "other_fields_2" to "2"
                 ),
@@ -98,6 +99,7 @@ class DeviceInfoHelperTest(
                     "radio_stack_major" to "3",
                     "radio_stack_minor" to "5",
                     "radio_stack_type" to "4",
+                    "radio_stack_sub" to "4",
                     "other_fields_1" to "1"
                 ),
                 FlipperRpcInformation(


### PR DESCRIPTION
**Background**

Replace radio type to radio type number from device info

**Changes**

For example, in previous variant we have Major.Minor.Type(Type Name)
And now we have Major.Minor.Sub(Type Name)

**Test plan**

Try open device info and see radio stack in Major.Minor.Sub(Type Name) format
