### PR TITLE
Crash application on cancel update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 1.5.2 - In Progress
 
+- [FIX] Crash application on cancel update
 - [FIX] White Screen after import key
 - [FIX] Add confirm delete dialog and some small fixes
 - [FIX] Hide self updater dialog on click, add self updater in debug mode, remove nfc mfkey32 from options

--- a/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdaterScreen.kt
+++ b/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdaterScreen.kt
@@ -126,7 +126,7 @@ private fun CancelButton(
                 modifier = Modifier.padding(vertical = 8.dp),
                 color = LocalPallet.current.accentSecond
             )
-            return@Box
+            return
         }
         Text(
             modifier = Modifier


### PR DESCRIPTION
**Background**

Now, if we click cancel update, application crashes

**Changes**
* return function, not Box scope

**Test plan**

Try update Flipper and click cancel on diff states
