### PR TITLE
Add pull to refresh update for update card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 1.6.2 - In progress
 
+- [Feature] Add pull to refresh update for update card
+
 # 1.6.1
 
 - [FIX] FapHub build status layout

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/screens/ComposableDeviceInfoScreen.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/compose/screens/ComposableDeviceInfoScreen.kt
@@ -6,8 +6,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.flipperdevices.core.ui.ktx.elements.SwipeRefresh
 import com.flipperdevices.info.impl.compose.bar.ComposableDeviceBar
 import com.flipperdevices.info.impl.compose.elements.ComposableConnectedDeviceActionCard
 import com.flipperdevices.info.impl.compose.elements.ComposableFirmwareUpdate
@@ -25,23 +30,33 @@ fun ComposableDeviceInfoScreen(
     onStartUpdateRequest: (UpdateRequest) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
-        ComposableDeviceBar()
-        updaterCardApi.ComposableUpdaterCard(
-            modifier = Modifier.padding(top = 14.dp),
-            onStartUpdateRequest = onStartUpdateRequest
-        )
-        ComposableFirmwareUpdate(modifier = Modifier.padding(top = 14.dp))
-        ComposableInfoCard(
-            modifier = Modifier.padding(top = 14.dp),
-            onOpenFullDeviceInfo = onOpenFullDeviceInfo
-        )
-        ComposableOptionsCard(
-            modifier = Modifier
-                .padding(top = 14.dp),
-            onOpenOptions = onOpenOptions
-        )
-        ComposableConnectedDeviceActionCard(modifier = Modifier.padding(top = 14.dp))
-        ComposablePairDeviceActionCard(modifier = Modifier.padding(top = 14.dp, bottom = 14.dp))
+    var refreshRequested: Boolean by remember { mutableStateOf(false) }
+
+    SwipeRefresh(onRefresh = { refreshRequested = true }) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            ComposableDeviceBar()
+            updaterCardApi.ComposableUpdaterCard(
+                modifier = Modifier.padding(top = 14.dp),
+                onStartUpdateRequest = onStartUpdateRequest,
+                requestRefresh = refreshRequested,
+                onRefreshRequestExecuted = { refreshRequested = false }
+            )
+            ComposableFirmwareUpdate(modifier = Modifier.padding(top = 14.dp))
+            ComposableInfoCard(
+                modifier = Modifier.padding(top = 14.dp),
+                onOpenFullDeviceInfo = onOpenFullDeviceInfo
+            )
+            ComposableOptionsCard(
+                modifier = Modifier
+                    .padding(top = 14.dp),
+                onOpenOptions = onOpenOptions
+            )
+            ComposableConnectedDeviceActionCard(modifier = Modifier.padding(top = 14.dp))
+            ComposablePairDeviceActionCard(modifier = Modifier.padding(top = 14.dp, bottom = 14.dp))
+        }
     }
 }

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/api/UpdaterCardApi.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/api/UpdaterCardApi.kt
@@ -5,6 +5,12 @@ import androidx.compose.ui.Modifier
 import com.flipperdevices.updater.model.UpdateRequest
 
 interface UpdaterCardApi {
+    @Suppress("ComposableNaming")
     @Composable
-    fun ComposableUpdaterCard(modifier: Modifier, onStartUpdateRequest: (UpdateRequest) -> Unit)
+    fun ComposableUpdaterCard(
+        modifier: Modifier,
+        onStartUpdateRequest: (UpdateRequest) -> Unit,
+        requestRefresh: Boolean,
+        onRefreshRequestExecuted: () -> Unit
+    )
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdaterCardApiImpl.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdaterCardApiImpl.kt
@@ -1,18 +1,42 @@
 package com.flipperdevices.updater.card.api
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.api.UpdaterCardApi
 import com.flipperdevices.updater.card.composable.ComposableUpdaterCardInternal
+import com.flipperdevices.updater.card.viewmodel.UpdateCardViewModel
+import com.flipperdevices.updater.card.viewmodel.UpdateStateViewModel
 import com.flipperdevices.updater.model.UpdateRequest
 import com.squareup.anvil.annotations.ContributesBinding
+import tangle.viewmodel.compose.tangleViewModel
 import javax.inject.Inject
 
 @ContributesBinding(AppGraph::class)
 class UpdaterCardApiImpl @Inject constructor() : UpdaterCardApi {
     @Composable
-    override fun ComposableUpdaterCard(modifier: Modifier, onStartUpdateRequest: (UpdateRequest) -> Unit) {
-        ComposableUpdaterCardInternal(modifier, onStartUpdateRequest = onStartUpdateRequest)
+    override fun ComposableUpdaterCard(
+        modifier: Modifier,
+        onStartUpdateRequest: (UpdateRequest) -> Unit,
+        requestRefresh: Boolean,
+        onRefreshRequestExecuted: () -> Unit
+    ) {
+        val updateStateViewModel: UpdateStateViewModel = tangleViewModel()
+        val updateCardViewModel: UpdateCardViewModel = tangleViewModel()
+
+        LaunchedEffect(requestRefresh) {
+            if (requestRefresh) {
+                updateCardViewModel.refresh()
+                onRefreshRequestExecuted()
+            }
+        }
+
+        ComposableUpdaterCardInternal(
+            modifier = modifier,
+            onStartUpdateRequest = onStartUpdateRequest,
+            updateStateViewModel = updateStateViewModel,
+            updateCardViewModel = updateCardViewModel
+        )
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/composable/ComposableUpdaterCard.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/composable/ComposableUpdaterCard.kt
@@ -26,14 +26,13 @@ import com.flipperdevices.updater.model.OfficialFirmware
 import com.flipperdevices.updater.model.UpdateCardState
 import com.flipperdevices.updater.model.UpdateErrorType
 import com.flipperdevices.updater.model.UpdateRequest
-import tangle.viewmodel.compose.tangleViewModel
 
 @Composable
 @Suppress("ModifierReused")
 internal fun ComposableUpdaterCardInternal(
+    updateStateViewModel: UpdateStateViewModel,
+    updateCardViewModel: UpdateCardViewModel,
     modifier: Modifier = Modifier,
-    updateStateViewModel: UpdateStateViewModel = tangleViewModel(),
-    updateCardViewModel: UpdateCardViewModel = tangleViewModel(),
     onStartUpdateRequest: (UpdateRequest) -> Unit = {},
 ) {
     val updateState by updateStateViewModel.getUpdateState().collectAsState()
@@ -50,13 +49,16 @@ internal fun ComposableUpdaterCardInternal(
             localDeviceStatus.version,
             updateStateViewModel::onDismissUpdateDialog
         )
+
         is FlipperUpdateState.Failed -> ComposableFailedUpdate(
             localDeviceStatus.version,
             updateStateViewModel::onDismissUpdateDialog
         )
+
         FlipperUpdateState.Ready,
         FlipperUpdateState.ConnectingInProgress -> {
         }
+
         FlipperUpdateState.NotConnected -> return
         else -> error("Can't find this device status")
     }
@@ -66,7 +68,7 @@ internal fun ComposableUpdaterCardInternal(
         modifier = modifier,
         cardStateLocal = cardState,
         onSelectChannel = updateCardViewModel::onSelectChannel,
-        retryUpdate = updateCardViewModel::retry,
+        retryUpdate = updateCardViewModel::refresh,
         onStartUpdateRequest = onStartUpdateRequest,
     )
 }
@@ -90,24 +92,28 @@ private fun ComposableUpdaterCard(
                     retryUpdate = retryUpdate
                 )
             }
+
             UpdateCardState.InProgress -> ComposableFirmwareUpdaterContent(
                 version = null,
                 updateCardState = cardStateLocal,
                 onSelectFirmwareChannel = onSelectChannel,
                 onStartUpdateRequest = onStartUpdateRequest
             )
+
             is UpdateCardState.NoUpdate -> ComposableFirmwareUpdaterContent(
                 version = cardStateLocal.flipperVersion,
                 updateCardState = cardStateLocal,
                 onSelectFirmwareChannel = onSelectChannel,
                 onStartUpdateRequest = onStartUpdateRequest
             )
+
             is UpdateCardState.UpdateAvailable -> ComposableFirmwareUpdaterContent(
                 version = cardStateLocal.update.updateTo,
                 updateCardState = cardStateLocal,
                 onSelectFirmwareChannel = onSelectChannel,
                 onStartUpdateRequest = onStartUpdateRequest
             )
+
             is UpdateCardState.UpdateFromFile -> ComposableFirmwareUpdaterContent(
                 version = cardStateLocal.updateVersion,
                 updateCardState = cardStateLocal,

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -43,8 +43,7 @@ class UpdateCardViewModel @VMInject constructor(
     private val storageExistHelper: StorageExistHelper,
     @TangleParam(DeeplinkConstants.KEY)
     private val deeplink: Deeplink?
-) :
-    LifecycleViewModel(),
+) : LifecycleViewModel(),
     FlipperBleServiceConsumer,
     LogTagProvider {
     override val TAG = "UpdateCardViewModel"
@@ -87,7 +86,7 @@ class UpdateCardViewModel @VMInject constructor(
         }
     }
 
-    fun retry() {
+    fun refresh() {
         serviceProvider.provideServiceApi(this) {
             launchWithLock(mutex, viewModelScope, "retry") {
                 // in this case we get heavy information from fw server and flipper


### PR DESCRIPTION
**Background**

Right now we can't invalidate info screen

**Changes**

Refresh updater card when pull

**Test plan**

Try use pull to refresh on info screen