### PR TITLE
FlipperRpcStatsCollector checks rpc version before request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [FIX] Fix 101% issue on update screen
 - [FIX] Fix build for fdroid
+- [FIX] Fix rpc request/update for 0.64.3 firmware
 
 # 1.6.2
 


### PR DESCRIPTION
**Background**

Right now we can't update via bluetooth from 0.64.3
https://www.youtube.com/watch?v=kqxCcuQkvTc

**Changes**

- Check in FlipperRpcStatsCollector RPC

**Test plan**

Try update from https://update.flipperzero.one/builds/firmware/0.64.3/?C=S&O=A