### PR TITLE
Not send empty report in faphub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Feature] Add transparent flipper mockup with fixed templates
 - [Feature] Add fap manifest caching
+- [Feature] Not send empty report in faphub
 - [CI] Add apk artifacts to Pull Requests
 - [CI] Fix failed build in merge_group
 - [CI] Bump deps except Sentry-gradle

--- a/components/faphub/fapscreen/impl/src/main/res/drawable/ic_report.xml
+++ b/components/faphub/fapscreen/impl/src/main/res/drawable/ic_report.xml
@@ -6,7 +6,7 @@
   <path
       android:pathData="M21,12C21,16.971 16.971,21 12,21C10.229,21 8.577,20.488 7.185,19.605L3,21L4.395,16.815C3.512,15.423 3,13.771 3,12C3,7.029 7.029,3 12,3C16.971,3 21,7.029 21,12Z"
       android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
+      android:strokeWidth="2"
       android:fillColor="#00000000"
       android:strokeColor="#F63F3F"
       android:strokeLineCap="round"/>

--- a/components/faphub/fapscreen/impl/src/main/res/values/strings.xml
+++ b/components/faphub/fapscreen/impl/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="fapscreen_developer_title">Developer</string>
     <string name="fapscreen_developer_github">View on GitHub</string>
     <string name="fapscreen_developer_manifest">Manifest</string>
-    <string name="fapscreen_developer_report">Report an App</string>
+    <string name="fapscreen_developer_report">Report App</string>
     <string name="fapscreen_building_state_ready_text">Runs on latest firmware Release</string>
     <string name="fapscreen_building_state_building_text">App is rebuilding…</string>
     <string name="fapscreen_building_state_outdated_app_text">Outdated app</string>

--- a/components/faphub/fapscreen/impl/src/main/res/values/strings.xml
+++ b/components/faphub/fapscreen/impl/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="fapscreen_developer_github">View on GitHub</string>
     <string name="fapscreen_developer_manifest">Manifest</string>
     <string name="fapscreen_developer_report">Report App</string>
-    <string name="fapscreen_developer_report">Report an App</string>
     <string name="fapscreen_developer_hide">Hide App</string>
     <string name="fapscreen_developer_unhide">Unhide App</string>
     <string name="fapscreen_developer_dialog_title">Hide App?</string>

--- a/components/faphub/report/impl/src/main/kotlin/com/flipperdevices/faphub/report/impl/composable/ComposableReadyToReport.kt
+++ b/components/faphub/report/impl/src/main/kotlin/com/flipperdevices/faphub/report/impl/composable/ComposableReadyToReport.kt
@@ -60,7 +60,18 @@ internal fun ComposableReadyToReport(
             .fillMaxWidth()
             .padding(bottom = 16.dp),
         text = stringResource(R.string.fap_report_field_btn),
-        onClick = { submit(text) },
-        enabled = text.isNotEmpty()
+        onClick = {
+            if (validateReportText(text)) {
+                submit(text)
+            }
+        },
+        enabled = validateReportText(text)
     )
+}
+
+private const val REPORT_TEXT_SIZE_MIN = 5
+
+private fun validateReportText(text: String): Boolean {
+    val trimmedText = text.trim()
+    return trimmedText.length >= REPORT_TEXT_SIZE_MIN
 }

--- a/components/faphub/report/impl/src/main/res/values/strings.xml
+++ b/components/faphub/report/impl/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="fap_report_title">Report an App</string>
+    <string name="fap_report_title">Report App</string>
     <string name="fap_report_field_title">Description</string>
-    <string name="fap_report_field_desc">Describe why are you reporting this app</string>
+    <string name="fap_report_field_desc">Describe why are you reporting this app (enter at least 5 characters)</string>
     <string name="fap_report_field_btn">Submit</string>
 </resources>


### PR DESCRIPTION
**Background**

Right now we can send empty report from faphub

**Changes**

- Update report app icon
- Change Report App title

**Test plan**

Try report empty description 