### PR TITLE
Migrate to markdown renderer from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [KMP] Migration logger
 - [Feature] Add ready app updates popup and notification dot
+- [Refactor] Migrate to markdown renderer from upstream
 - [FIX] Replace decompose push to move safety push
 
 # 1.6.8

--- a/components/core/markdown/build.gradle.kts
+++ b/components/core/markdown/build.gradle.kts
@@ -18,7 +18,9 @@ dependencies {
     implementation(libs.compose.material)
 
     implementation(libs.flexmark.core)
-    api(libs.markdown.renderer)
+    implementation(libs.markdown.renderer) {
+        exclude(libs.fastutil.get().group)
+    }
 
     // Testing
     testImplementation(projects.components.core.test)

--- a/components/core/markdown/src/main/java/com/flipperdevices/core/markdown/ComposableMarkdown.kt
+++ b/components/core/markdown/src/main/java/com/flipperdevices/core/markdown/ComposableMarkdown.kt
@@ -4,14 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.core.ui.theme.LocalTypography
 import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.model.DefaultMarkdownColors
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownPadding
 
 @Composable
 fun ComposableMarkdown(
@@ -19,7 +20,11 @@ fun ComposableMarkdown(
     modifier: Modifier = Modifier,
     typography: MarkdownTypography = markdownTypography(),
     colors: MarkdownColors = markdownColors(),
-    paddings: MarkdownPadding = markdownPadding()
+    paddings: MarkdownPadding = markdownPadding(
+        block = 2.dp,
+        indentList = 4.dp,
+        list = 1.dp
+    )
 ) {
     Markdown(
         content = content,
@@ -34,15 +39,16 @@ fun ComposableMarkdown(
 fun markdownColors(
     backgroundCode: Color = LocalPallet.current.text20,
     text: Color = LocalPallet.current.text100,
-    link: Color = LocalPallet.current.accentSecond
-): MarkdownColors {
-    return object : MarkdownColors {
-        override val backgroundCode = backgroundCode
-        override val text = text
-        override val markdownLink: Color = link
-        override val autoLink: Color = link
-    }
-}
+    link: Color = LocalPallet.current.accentSecond,
+    dividerColor: Color = LocalPallet.current.divider12
+) = DefaultMarkdownColors(
+    text = text,
+    codeText = text,
+    linkText = link,
+    codeBackground = backgroundCode,
+    inlineCodeBackground = backgroundCode,
+    dividerColor = dividerColor
+)
 
 @Composable
 fun markdownTypography(
@@ -75,18 +81,5 @@ fun markdownTypography(
         override val paragraph = paragraphStyle.merge(additionalTextStyle)
         override val quote = quoteStyle.merge(additionalTextStyle)
         override val text = textStyle.merge(additionalTextStyle)
-    }
-}
-
-@Composable
-fun markdownPadding(
-    block: Dp = 2.dp,
-    indentList: Dp = 4.dp,
-    list: Dp = 1.dp
-): MarkdownPadding {
-    return object : MarkdownPadding {
-        override val block: Dp = block
-        override val indentList: Dp = indentList
-        override val list: Dp = list
     }
 }

--- a/components/faphub/fapscreen/impl/build.gradle.kts
+++ b/components/faphub/fapscreen/impl/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.lifecycle.compose)
     implementation(libs.bundles.decompose)
+    implementation(libs.markdown.renderer) {
+        exclude(libs.fastutil.get().group)
+    }
 
     implementation(projects.components.inappnotification.api)
     implementation(projects.components.rootscreen.api)

--- a/components/faphub/report/impl/build.gradle.kts
+++ b/components/faphub/report/impl/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
     implementation(libs.bundles.decompose)
+    implementation(libs.markdown.renderer) {
+        exclude(libs.fastutil.get().group)
+    }
 
     // ViewModel
     implementation(libs.lifecycle.compose)

--- a/components/updater/screen/build.gradle.kts
+++ b/components/updater/screen/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
 
     implementation(libs.kotlin.immutable.collections)
     implementation(libs.kotlin.serialization.json)
+    implementation(libs.markdown.renderer) {
+        exclude(libs.fastutil.get().group)
+    }
 
     // Compose
     implementation(libs.compose.ui)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ appcompat = "1.6.1" # https://developer.android.com/jetpack/androidx/releases/ap
 datastore = "1.0.0" # https://developer.android.com/topic/libraries/architecture/datastore
 # https://github.com/vsch/flexmark-java/issues/442
 flexmark = "0.42.14"
-markdown = "0.1.9" # https://github.com/Programistich/multiplatform-markdown-renderer
+markdown = "0.13.0" # https://github.com/Programistich/multiplatform-markdown-renderer
 ktor = "2.3.8" # https://ktor.io/
 apache-compress = "1.25.0" # https://commons.apache.org/proper/commons-compress/
 apache-codec = "1.16.0" # https://mvnrepository.com/artifact/commons-codec/commons-codec
@@ -144,7 +144,7 @@ coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
 
 # Markdown
 flexmark-core = { module = "com.vladsch.flexmark:flexmark", version.ref = "flexmark" }
-markdown-renderer = { module = "com.github.Programistich.multiplatform-markdown-renderer:multiplatform-markdown-renderer-android", version.ref = "markdown" }
+markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdown" }
 
 # Storage
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }


### PR DESCRIPTION
**Background**

Right now we use programistich's fork for markdown

**Changes**

Use upstream markdown renderer library

**Test plan**

Try build and see how markdown looks