### PR TITLE
Support Unit-test for the ProgressWrapperTracker class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Refactor] Migrate to markdown renderer from upstream
 - [FIX] Replace decompose push to move safety push
 - [Refactor] Use https://github.com/IlyaGulya/anvil-utils to automatically generate and contribute assisted factories.
+- [Refactor] Add test for Progress Tracker logic
 
 # 1.6.8
 

--- a/components/core/progress/build.gradle.kts
+++ b/components/core/progress/build.gradle.kts
@@ -5,4 +5,9 @@ plugins {
 android.namespace = "com.flipperdevices.core.progress"
 
 dependencies {
+
+    // Testing
+    testImplementation(libs.junit)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.kotlin.coroutines.test)
 }

--- a/components/core/progress/build.gradle.kts
+++ b/components/core/progress/build.gradle.kts
@@ -8,6 +8,6 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
-    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.mockk)
     testImplementation(libs.kotlin.coroutines.test)
 }

--- a/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
+++ b/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
@@ -1,0 +1,65 @@
+package com.flipperdevices.core.progress
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+
+class ProgressWrapperTrackerTest {
+
+    private lateinit var subject: ProgressWrapperTracker
+
+    private val progressListener: ProgressListener = mock()
+
+    @Before
+    fun setUp() {
+        subject = ProgressWrapperTracker(progressListener, 1f, 100F)
+    }
+
+    @Test
+    fun onProgress_whenDiffIsLessThanZero_thenNotCallProgressListener() = runTest {
+        subject = ProgressWrapperTracker(progressListener, 100f, 1f)
+        subject.onProgress(1f)
+
+        verify(progressListener, never()).onProgress(any())
+    }
+
+    @Test
+    fun onProgress_whenDiffIsBiggerZero_thenCallProgressListener() = runTest {
+        subject = ProgressWrapperTracker(progressListener, 0f, 10f)
+        subject.onProgress(1f)
+
+        verify(progressListener).onProgress(any())
+    }
+
+    @Test
+    fun report_whenCurrentIsBiggerThanMax_thenReturnDefaultMaxWithDebugException() = runTest {
+        try {
+            subject.report(10, 1)
+            verify(progressListener).onProgress(100f)
+        } catch (e: Exception) {
+            Assert.assertTrue(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun report_whenMaxIsEqualToZero_thenReturnDefaultMaxWithDebugException() = runTest {
+        try {
+            subject.report(10, 0)
+            verify(progressListener).onProgress(100f)
+        } catch (e: Exception) {
+            Assert.assertTrue(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun report_whenWithCorrectValues_thenCalculateValue() = runTest {
+        subject.report(10, 20)
+
+        verify(progressListener).onProgress(1F)
+    }
+}

--- a/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
+++ b/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
@@ -1,22 +1,22 @@
 package com.flipperdevices.core.progress
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
-import org.mockito.kotlin.any
+import io.mockk.mockk
 
 class ProgressWrapperTrackerTest {
 
     private lateinit var subject: ProgressWrapperTracker
 
-    private val progressListener: ProgressListener = mock()
+    private val progressListener: ProgressListener = mockk()
 
     @Before
     fun setUp() {
+        coEvery { progressListener.onProgress(any()) } returns Unit
         subject = ProgressWrapperTracker(progressListener, 1f, 100F)
     }
 
@@ -25,7 +25,7 @@ class ProgressWrapperTrackerTest {
         subject = ProgressWrapperTracker(progressListener, 100f, 1f)
         subject.onProgress(1f)
 
-        verify(progressListener, never()).onProgress(any())
+        coVerify(exactly = 0) { progressListener.onProgress(any()) }
     }
 
     @Test
@@ -33,14 +33,14 @@ class ProgressWrapperTrackerTest {
         subject = ProgressWrapperTracker(progressListener, 0f, 10f)
         subject.onProgress(1f)
 
-        verify(progressListener).onProgress(any())
+        coVerify(exactly = 1) { progressListener.onProgress(any()) }
     }
 
     @Test
     fun report_whenCurrentIsBiggerThanMax_thenReturnDefaultMaxWithDebugException() = runTest {
         try {
             subject.report(10, 1)
-            verify(progressListener).onProgress(100f)
+            coVerify(exactly = 1) { progressListener.onProgress(100f) }
         } catch (e: Exception) {
             Assert.assertTrue(e is IllegalStateException)
         }
@@ -50,7 +50,7 @@ class ProgressWrapperTrackerTest {
     fun report_whenMaxIsEqualToZero_thenReturnDefaultMaxWithDebugException() = runTest {
         try {
             subject.report(10, 0)
-            verify(progressListener).onProgress(100f)
+            coVerify(exactly = 1) { progressListener.onProgress(100f) }
         } catch (e: Exception) {
             Assert.assertTrue(e is IllegalStateException)
         }
@@ -60,6 +60,6 @@ class ProgressWrapperTrackerTest {
     fun report_whenWithCorrectValues_thenCalculateValue() = runTest {
         subject.report(10, 20)
 
-        verify(progressListener).onProgress(1F)
+        coVerify(exactly = 1) { progressListener.onProgress(1f) }
     }
 }

--- a/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
+++ b/components/core/progress/src/test/java/com/flipperdevices/core/progress/ProgressWrapperTrackerTest.kt
@@ -2,11 +2,11 @@ package com.flipperdevices.core.progress
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import io.mockk.mockk
 
 class ProgressWrapperTrackerTest {
 


### PR DESCRIPTION
**Background**
This PR is responsible for supporting Unit-tests to improve the stability and test coverage of the project as part of the `Stability project`. It covers all cases of the `ProgressWrapperTracker` class. 

**Changes**
- Create `ProgressWrapperTrackerTest `
- Provide testing dependencies in the gradle file  

**Test plan**
- Run Unit-test of the core/progress module
