### PR TITLE
Fix crash on sf import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Refactor] Migrate to markdown renderer from upstream
 - [Refactor] Basic implementation of new transport ble 
 - [FIX] Replace decompose push to move safety push
+- [FIX] Add fallback for parse url from "Open in App" URI
 - [Refactor] Use https://github.com/IlyaGulya/anvil-utils to automatically generate and contribute assisted factories.
 - [Refactor] Add test for Progress Tracker logic
 


### PR DESCRIPTION
**Background**

Right now, when we use the "Open in App" button on the /sf share screen we see an error screen

**Changes**

- As fallback we try parse both format of deeplink

**Test plan**

Try open deeplink from "Open in App" button on browser page