### PR TITLE
Fix/no internet connection on hub apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Refactor] Basic implementation of new transport ble 
 - [FIX] Replace decompose push to move safety push
 - [FIX] Add fallback for parse url from "Open in App" URI
+- [FIX] Multiple internet connection placeholders on Hub Apps screen
 - [Refactor] Use https://github.com/IlyaGulya/anvil-utils to automatically generate and contribute assisted factories.
 - [Refactor] Add test for Progress Tracker logic
 

--- a/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/paging/ComposableFapsList.kt
+++ b/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/paging/ComposableFapsList.kt
@@ -25,13 +25,14 @@ import com.flipperdevices.core.ui.res.R as DesignSystem
 
 private const val DEFAULT_FAP_COUNT = 20
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "LongParameterList")
 fun LazyListScope.ComposableFapsList(
     faps: LazyPagingItems<FapItemShort>,
     onOpenFapItem: (FapItemShort) -> Unit,
     errorsRenderer: FapHubComposableErrorsRenderer,
     defaultFapErrorSize: FapErrorSize,
-    installationButton: @Composable (FapItemShort?, Modifier) -> Unit
+    installationButton: @Composable (FapItemShort?, Modifier) -> Unit,
+    shouldDisplayError: Boolean = false
 ) {
     val elementModifier = Modifier
         .fillMaxWidth()
@@ -47,7 +48,7 @@ fun LazyListScope.ComposableFapsList(
             )
         }
         return
-    } else if (faps.loadState.refresh is LoadState.Error) {
+    } else if (faps.loadState.refresh is LoadState.Error && shouldDisplayError) {
         val loadState = faps.loadState.refresh as? LoadState.Error ?: return
         with(errorsRenderer) {
             ComposableThrowableErrorListItem(

--- a/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/paging/ComposableFapsList.kt
+++ b/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/paging/ComposableFapsList.kt
@@ -32,7 +32,7 @@ fun LazyListScope.ComposableFapsList(
     errorsRenderer: FapHubComposableErrorsRenderer,
     defaultFapErrorSize: FapErrorSize,
     installationButton: @Composable (FapItemShort?, Modifier) -> Unit,
-    shouldDisplayError: Boolean = false
+    shouldDisplayError: Boolean = true
 ) {
     val elementModifier = Modifier
         .fillMaxWidth()

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/ComposableCatalogTab.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/ComposableCatalogTab.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.paging.LoadState
@@ -21,6 +22,9 @@ import com.flipperdevices.faphub.dao.api.model.FapCategory
 import com.flipperdevices.faphub.dao.api.model.FapItemShort
 import com.flipperdevices.faphub.errors.api.FapErrorSize
 import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
+import com.flipperdevices.faphub.errors.api.throwable.toFapHubError
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
 
 @Composable
 fun ComposableCatalogTabScreen(
@@ -35,6 +39,12 @@ fun ComposableCatalogTabScreen(
     val fapsList = fapsListViewModel.getFapsFlow().collectAsLazyPagingItems()
     val sortType by fapsListViewModel.getSortTypeFlow().collectAsState()
     val categoriesLoadState by categoriesViewModel.getCategoriesLoadState().collectAsState()
+
+    val categoriesFapHubError by remember {
+        categoriesViewModel.getCategoriesLoadState()
+            .filterIsInstance<CategoriesLoadState.Error>()
+            .map { categoriesErrorLoadState -> categoriesErrorLoadState.throwable.toFapHubError() }
+    }.collectAsState(initial = null)
 
     val refreshAll = {
         fapsListViewModel.refreshManifest()
@@ -66,14 +76,16 @@ fun ComposableCatalogTabScreen(
                 errorsRenderer = errorsRenderer,
                 installationButton = installationButton,
                 defaultFapErrorSize = FapErrorSize.IN_LIST,
-                shouldDisplayError = categoriesLoadState !is CategoriesLoadState.Error
+                shouldDisplayError = categoriesFapHubError == null
             )
 
-            ComposableFullScreenError(
-                categoriesLoadState = categoriesLoadState,
-                errorsRenderer = errorsRenderer,
-                onRetry = refreshAll
-            )
+            categoriesFapHubError?.let { categoriesFapHubError ->
+                ComposableFullScreenError(
+                    fapHubError = categoriesFapHubError,
+                    errorsRenderer = errorsRenderer,
+                    onRetry = refreshAll
+                )
+            }
         }
     }
 }

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/ComposableCatalogTab.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/ComposableCatalogTab.kt
@@ -13,6 +13,7 @@ import com.flipperdevices.faphub.appcard.composable.paging.ComposableFapsList
 import com.flipperdevices.faphub.appcard.composable.paging.ComposableSortChoice
 import com.flipperdevices.faphub.catalogtab.impl.R
 import com.flipperdevices.faphub.catalogtab.impl.composable.categories.ComposableCategories
+import com.flipperdevices.faphub.catalogtab.impl.composable.categories.ComposableFullScreenError
 import com.flipperdevices.faphub.catalogtab.impl.model.CategoriesLoadState
 import com.flipperdevices.faphub.catalogtab.impl.viewmodel.CategoriesViewModel
 import com.flipperdevices.faphub.catalogtab.impl.viewmodel.FapsListViewModel
@@ -20,7 +21,6 @@ import com.flipperdevices.faphub.dao.api.model.FapCategory
 import com.flipperdevices.faphub.dao.api.model.FapItemShort
 import com.flipperdevices.faphub.errors.api.FapErrorSize
 import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
-import com.flipperdevices.faphub.errors.api.throwable.toFapHubError
 
 @Composable
 fun ComposableCatalogTabScreen(
@@ -69,19 +69,11 @@ fun ComposableCatalogTabScreen(
                 shouldDisplayError = categoriesLoadState !is CategoriesLoadState.Error
             )
 
-            (categoriesLoadState as? CategoriesLoadState.Error)
-                ?.throwable
-                ?.toFapHubError()
-                ?.let { fapHubError ->
-                    with(errorsRenderer) {
-                        ComposableThrowableErrorListItem(
-                            modifier = Modifier,
-                            throwable = fapHubError,
-                            onRetry = refreshAll,
-                            fapErrorSize = FapErrorSize.FULLSCREEN
-                        )
-                    }
-                }
+            ComposableFullScreenError(
+                categoriesLoadState = categoriesLoadState,
+                errorsRenderer = errorsRenderer,
+                onRetry = refreshAll
+            )
         }
     }
 }

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableCategories.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableCategories.kt
@@ -1,8 +1,6 @@
 package com.flipperdevices.faphub.catalogtab.impl.composable.categories
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
@@ -10,9 +8,6 @@ import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.ktx.clickableRipple
 import com.flipperdevices.faphub.catalogtab.impl.model.CategoriesLoadState
 import com.flipperdevices.faphub.dao.api.model.FapCategory
-import com.flipperdevices.faphub.errors.api.FapErrorSize
-import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
-import com.flipperdevices.faphub.errors.api.throwable.toFapHubError
 
 private const val DEFAULT_CATEGORIES_SIZE = 12
 private const val COLUMN_COUNT = 3
@@ -21,8 +16,6 @@ private const val COLUMN_COUNT = 3
 fun LazyListScope.ComposableCategories(
     loadState: CategoriesLoadState,
     onCategoryClick: (FapCategory) -> Unit,
-    onRetry: () -> Unit,
-    errorsRenderer: FapHubComposableErrorsRenderer
 ) {
     when (loadState) {
         is CategoriesLoadState.Loaded -> ComposableCategoriesGridItems(
@@ -37,17 +30,7 @@ fun LazyListScope.ComposableCategories(
             onClick = onCategoryClick
         )
 
-        is CategoriesLoadState.Error -> with(errorsRenderer) {
-            ComposableThrowableErrorListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 14.dp)
-                    .height(height = 250.dp),
-                throwable = loadState.throwable.toFapHubError(),
-                onRetry = onRetry,
-                fapErrorSize = FapErrorSize.IN_LIST
-            )
-        }
+        is CategoriesLoadState.Error -> Unit
     }
 }
 

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableFullScreenError.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableFullScreenError.kt
@@ -2,29 +2,23 @@ package com.flipperdevices.faphub.catalogtab.impl.composable.categories
 
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
-import com.flipperdevices.faphub.catalogtab.impl.model.CategoriesLoadState
 import com.flipperdevices.faphub.errors.api.FapErrorSize
 import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
-import com.flipperdevices.faphub.errors.api.throwable.toFapHubError
+import com.flipperdevices.faphub.errors.api.throwable.FapHubError
 
 @Suppress("FunctionNaming")
 internal fun LazyListScope.ComposableFullScreenError(
-    categoriesLoadState: CategoriesLoadState,
+    fapHubError: FapHubError,
     errorsRenderer: FapHubComposableErrorsRenderer,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    (categoriesLoadState as? CategoriesLoadState.Error)
-        ?.throwable
-        ?.toFapHubError()
-        ?.let { fapHubError ->
-            with(errorsRenderer) {
-                ComposableThrowableErrorListItem(
-                    modifier = modifier,
-                    throwable = fapHubError,
-                    onRetry = onRetry,
-                    fapErrorSize = FapErrorSize.FULLSCREEN
-                )
-            }
-        }
+    with(errorsRenderer) {
+        ComposableThrowableErrorListItem(
+            modifier = modifier,
+            throwable = fapHubError,
+            onRetry = onRetry,
+            fapErrorSize = FapErrorSize.FULLSCREEN
+        )
+    }
 }

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableFullScreenError.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableFullScreenError.kt
@@ -1,0 +1,30 @@
+package com.flipperdevices.faphub.catalogtab.impl.composable.categories
+
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.Modifier
+import com.flipperdevices.faphub.catalogtab.impl.model.CategoriesLoadState
+import com.flipperdevices.faphub.errors.api.FapErrorSize
+import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
+import com.flipperdevices.faphub.errors.api.throwable.toFapHubError
+
+@Suppress("FunctionNaming")
+internal fun LazyListScope.ComposableFullScreenError(
+    categoriesLoadState: CategoriesLoadState,
+    errorsRenderer: FapHubComposableErrorsRenderer,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    (categoriesLoadState as? CategoriesLoadState.Error)
+        ?.throwable
+        ?.toFapHubError()
+        ?.let { fapHubError ->
+            with(errorsRenderer) {
+                ComposableThrowableErrorListItem(
+                    modifier = modifier,
+                    throwable = fapHubError,
+                    onRetry = onRetry,
+                    fapErrorSize = FapErrorSize.FULLSCREEN
+                )
+            }
+        }
+}


### PR DESCRIPTION
Background

On Hub/Apps screen displayed multiple error placeholders when categories and list could not be loaded. There's should be either displayed categories with list error or fullscreen error in case categories could not be loaded

Changes

- Removed entirely error placeholder from ComposableCategories as it's not required now
- Block list error display when categories error happened
- Add fullscreen LazyColumn error display

Test plan

- Get Charles or HTTP Toolkit to simultate url timeouts or just disable internet on phone
- Open Hub>Apps
- Await categories loaded and simulate error for list below to see it's error placeholder
- Restart app with no internet to see fullscreen error placeholder on this screen when categories not loaded