### PR TITLE
Replace wearOS default dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - [FIX] Multiple internet connection placeholders on Hub Apps screen
 - [FIX] Find already paired Flipper devices without state filter
 - [FIX] Update flipper is busy image
-- [FIX] Fixed ComposableWearEmulate narrow layout 
+- [FIX] Fixed ComposableWearEmulate narrow layout
+- [FIX] Replace Default dispatcher in wearos modules with workStealingPool dispatcher
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
@@ -15,9 +15,6 @@ object FlipperDispatchers {
         return Executors.newWorkStealingPool().asCoroutineDispatcher()
     }
 
-    /**
-     * This dispatcher is used to bypass limitations of [Dispatchers.Default] on wearOS
-     */
     val workStealingDispatcher: CoroutineDispatcher by lazy {
         createNewWorkStealingDispatcher()
     }

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
@@ -1,10 +1,24 @@
 package com.flipperdevices.core.ktx.jre
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 
 /**
  * To be able to mock dispatchers
  */
 object FlipperDispatchers {
     fun getDefault() = Dispatchers.Default
+
+    fun createNewWorkStealingDispatcher(): CoroutineDispatcher {
+        return Executors.newWorkStealingPool().asCoroutineDispatcher()
+    }
+
+    /**
+     * This dispatcher is used to bypass limitations of [Dispatchers.Default] on wearOS
+     */
+    val workStealingDispatcher: CoroutineDispatcher by lazy {
+        createNewWorkStealingDispatcher()
+    }
 }

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
@@ -11,11 +11,7 @@ import java.util.concurrent.Executors
 object FlipperDispatchers {
     fun getDefault() = Dispatchers.Default
 
-    fun createNewWorkStealingDispatcher(): CoroutineDispatcher {
-        return Executors.newWorkStealingPool().asCoroutineDispatcher()
-    }
-
     val workStealingDispatcher: CoroutineDispatcher by lazy {
-        createNewWorkStealingDispatcher()
+        Executors.newWorkStealingPool().asCoroutineDispatcher()
     }
 }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
@@ -58,7 +58,7 @@ class UpdateRequestViewModelTest {
     @Before
     fun setup() {
         mockkObject(FlipperDispatchers)
-        every { FlipperDispatchers.getDefault() } returns Dispatchers.Main.immediate
+        every { FlipperDispatchers.workStealingDispatcher } returns Dispatchers.Main.immediate
         mockkStatic("com.flipperdevices.core.ktx.jre.UriKtxKt")
 
         serviceProvider = mockk(relaxUnitFun = true)

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
@@ -58,7 +58,7 @@ class UpdateRequestViewModelTest {
     @Before
     fun setup() {
         mockkObject(FlipperDispatchers)
-        every { FlipperDispatchers.workStealingDispatcher } returns Dispatchers.Main.immediate
+        every { FlipperDispatchers.getDefault() } returns Dispatchers.Main.immediate
         mockkStatic("com.flipperdevices.core.ktx.jre.UriKtxKt")
 
         serviceProvider = mockk(relaxUnitFun = true)

--- a/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandOutputStream.kt
+++ b/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandOutputStream.kt
@@ -1,7 +1,6 @@
 package com.flipperdevices.wearable.emulate.common
 
 import com.flipperdevices.bridge.protobuf.toDelimitedBytes
-import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -13,6 +12,7 @@ import com.google.protobuf.InvalidProtocolBufferException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -20,15 +20,19 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.io.OutputStream
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedTransferQueue
 import java.util.concurrent.TimeUnit
 
 private const val TIMEOUT_MS = 100L
+private const val POOL_THREADS_AMOUNT = 2
 
 class WearableCommandOutputStream<T : GeneratedMessageLite<*, *>>(
     private val channelClient: ChannelClient
 ) : LogTagProvider {
     override val TAG = "WearableCommandOutputStream-${hashCode()}"
+
+    private val dispatcher = Executors.newFixedThreadPool(POOL_THREADS_AMOUNT).asCoroutineDispatcher()
 
     private val queue = LinkedTransferQueue<T>()
     private val mutex = Mutex()
@@ -37,7 +41,7 @@ class WearableCommandOutputStream<T : GeneratedMessageLite<*, *>>(
     fun onOpenChannel(scope: CoroutineScope, channel: Channel) {
         launchWithLock(mutex, scope, "open_channel") {
             sendJob?.cancelAndJoin()
-            sendJob = scope.launch(FlipperDispatchers.workStealingDispatcher) {
+            sendJob = scope.launch(dispatcher) {
                 channelClient.getOutputStream(channel).await().use {
                     sendLoopJob(this, it)
                 }
@@ -64,7 +68,7 @@ class WearableCommandOutputStream<T : GeneratedMessageLite<*, *>>(
                 }.getOrNull() ?: continue
                 info { "Receive $request" }
 
-                withContext(FlipperDispatchers.createNewWorkStealingDispatcher()) {
+                withContext(dispatcher) {
                     outputStream.write(request.toDelimitedBytes())
                 }
             } catch (ignored: CancellationException) {

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableFlipperStatusProcessor.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableFlipperStatusProcessor.kt
@@ -4,6 +4,7 @@ import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
 import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.di.SingleIn
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.common.WearableCommandInputStream
@@ -14,7 +15,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.ConnectSta
 import com.flipperdevices.wearable.emulate.handheld.impl.di.WearHandheldGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -42,7 +42,7 @@ class WearableFlipperStatusProcessor @Inject constructor(
             }
         }.launchIn(scope)
 
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             flipperServiceProvider
                 .getServiceApi()
                 .connectionInformationApi

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
@@ -6,11 +6,11 @@ import android.os.IBinder
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.flipperdevices.core.di.ComponentHolder
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.handheld.impl.di.WearServiceComponent
 import com.google.android.gms.wearable.ChannelClient.Channel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.plus
 
 private const val NOTIFICATION_ID = 100
@@ -19,7 +19,7 @@ class WearRequestForegroundService : LifecycleService(), WearRequestChannelBinde
     override val TAG = "WearRequestForegroundService-${hashCode()}"
     private val wearServiceComponent = WearServiceComponent.ManualFactory.create(
         ComponentHolder.component(),
-        lifecycleScope + Dispatchers.Default
+        lifecycleScope + FlipperDispatchers.workStealingDispatcher
     )
     private val binder = WearRequestBinder(this)
 

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/ConnectionHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/ConnectionHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -12,7 +13,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.pingReques
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -50,7 +50,7 @@ class ConnectionHelperImpl @Inject constructor(
 
     override fun reset(scope: CoroutineScope) {
         info { "reset" }
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(ConnectionTesterState.NOT_CONNECTED)
         }
     }

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/EmulateHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/EmulateHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -16,7 +17,6 @@ import com.flipperdevices.wearable.emulate.impl.viewmodel.KeyToEmulate
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -60,7 +60,7 @@ class EmulateHelperImpl @Inject constructor(
     }
 
     override fun reset(scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(Emulate.EmulateStatus.UNRECOGNIZED)
         }
     }

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/FlipperStatusHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/FlipperStatusHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -13,7 +14,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.subscribeO
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -51,7 +51,7 @@ class FlipperStatusHelperImpl @Inject constructor(
     }
 
     override fun reset(scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(ConnectStatusOuterClass.ConnectStatus.UNRECOGNIZED)
         }
     }

--- a/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
+++ b/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.flipperdevices.bridge.dao.api.delegates.FavoriteApi
 import com.flipperdevices.bridge.dao.api.delegates.key.SimpleKeyApi
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.pmap
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
@@ -14,7 +15,6 @@ import com.flipperdevices.wearable.sync.handheld.api.SyncWearableApi
 import com.google.android.gms.wearable.PutDataRequest
 import com.google.android.gms.wearable.Wearable
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -30,7 +30,7 @@ class SyncWearableApiImpl @Inject constructor(
 
     private val dataClient by lazy { Wearable.getDataClient(application) }
 
-    override suspend fun updateWearableIndex() = withContext(Dispatchers.Default) {
+    override suspend fun updateWearableIndex() = withContext(FlipperDispatchers.workStealingDispatcher) {
         val flipperKeys = simpleKeyApi.getAllKeys()
         val itemsToSync = flipperKeys.map { flipperKey ->
             WearableSyncItem(


### PR DESCRIPTION
**Background**

Currently wearOS application has a bug, which is looks like problem with connectivity. It happened because `WearableCommandInputStream.parser` and `WearableCommandOutputStream.sendLoopJob` which is working with streams is blocking dispatchers.

**Changes**

- Create workStealingDispatcher which is using java's `newWorkStealingPool`
- Create new workStealing Dispatchers inside streams operations

**Test plan**

- Open wearOS application
- Select a remote
- Open remote and see that UI state now displayed correctly 
