### PR TITLE
Fix/wearable command streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [FIX] Find already paired Flipper devices without state filter
 - [FIX] Update flipper is busy image
 - [FIX] Fixed ComposableWearEmulate narrow layout 
+- [FIX] Fixed wearOS blocking operations in WearableCommand streams
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandInputStream.kt
+++ b/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandInputStream.kt
@@ -10,8 +10,8 @@ import com.google.protobuf.GeneratedMessageLite
 import com.google.protobuf.InvalidProtocolBufferException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,15 +23,20 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import java.io.InputStream
+import java.util.concurrent.Executors
 
 private const val READ_TIMEOUT_MS = 100L
+private const val POOL_THREADS_AMOUNT = 2
 
 class WearableCommandInputStream<T : GeneratedMessageLite<*, *>>(
     private val channelClient: ChannelClient,
     private val parser: (InputStream) -> T?
 ) : LogTagProvider {
     override val TAG = "WearableCommandInputStream-${hashCode()}"
+
+    private val dispatcher = Executors.newFixedThreadPool(POOL_THREADS_AMOUNT).asCoroutineDispatcher()
 
     private val mutex = Mutex()
     private val requests = MutableSharedFlow<T>()
@@ -46,7 +51,7 @@ class WearableCommandInputStream<T : GeneratedMessageLite<*, *>>(
 
         launchWithLock(mutex, scope, "open_channel") {
             parserJob?.cancelAndJoin()
-            parserJob = scope.launch(Dispatchers.Default) {
+            parserJob = scope.launch(dispatcher) {
                 channelClient.getInputStream(channel).await().use {
                     parseLoopJob(this, it)
                 }
@@ -63,7 +68,9 @@ class WearableCommandInputStream<T : GeneratedMessageLite<*, *>>(
     private suspend fun parseLoopJob(scope: CoroutineScope, inputStream: InputStream) {
         while (scope.isActive) {
             try {
-                val main = parser(inputStream)
+                val main = withContext(dispatcher) {
+                    parser(inputStream)
+                }
                 if (main == null) {
                     delay(READ_TIMEOUT_MS)
                     continue


### PR DESCRIPTION
**Background**

Currently wearOS application has a bug, which is looks like problem with connectivity. It happened because of `WearableCommandInputStream.parser` and `WearableCommandOutputStream.sendLoopJob` jobs with streams which is blocking Default dispatcher.

**Changes**

- Created fixedThreadPool dispatcher for both `WearableCommandInputStream` and `WearableCommandOutputStream`

**Test plan**

- Open wearOS application
- Select a remote
- Open remote and see that UI state and connectivity now displayed correctly 
