### PR TITLE
Replace Dispatchers.Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
 - [FIX] Multiple internet connection placeholders on Hub Apps screen
 - [FIX] Find already paired Flipper devices without state filter
 - [FIX] Update flipper is busy image
-- [FIX] Fixed ComposableWearEmulate narrow layout 
+- [FIX] Fixed ComposableWearEmulate narrow layout
 - [FIX] Fixed wearOS blocking operations in WearableCommand streams
+- [FIX] Replace Dispatchers.Default with java's work stealing pool dispatcher
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/clickhouse/ClickhouseApiImpl.kt
+++ b/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/clickhouse/ClickhouseApiImpl.kt
@@ -61,7 +61,7 @@ class ClickhouseApiImpl @Inject constructor(
 ) : ClickhouseApi, LogTagProvider {
     override val TAG = "ClickhouseApi"
 
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
     private val sessionUUID by lazy { UUID.randomUUID() }
 
     @Suppress("CyclomaticComplexMethod")
@@ -90,7 +90,7 @@ class ClickhouseApiImpl @Inject constructor(
             SimpleEvent.HIDE_FAPHUB_APP -> OpenOuterClass.Open.OpenTarget.HIDE_FAPHUB_APP
         }
 
-        scope.launch(FlipperDispatchers.workStealingDispatcher) {
+        scope.launch {
             reportToServerSafe(
                 metricEventsCollection {
                     open = open {
@@ -216,7 +216,7 @@ class ClickhouseApiImpl @Inject constructor(
             error { "Can't process event $complexEvent" }
             return
         }
-        scope.launch(FlipperDispatchers.workStealingDispatcher) {
+        scope.launch {
             reportToServerSafe(event)
         }
     }

--- a/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/clickhouse/ClickhouseApiImpl.kt
+++ b/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/clickhouse/ClickhouseApiImpl.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.metric.impl.clickhouse
 import androidx.datastore.core.DataStore
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.ApplicationParams
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.verbose
@@ -42,7 +43,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -90,7 +90,7 @@ class ClickhouseApiImpl @Inject constructor(
             SimpleEvent.HIDE_FAPHUB_APP -> OpenOuterClass.Open.OpenTarget.HIDE_FAPHUB_APP
         }
 
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             reportToServerSafe(
                 metricEventsCollection {
                     open = open {
@@ -216,7 +216,7 @@ class ClickhouseApiImpl @Inject constructor(
             error { "Can't process event $complexEvent" }
             return
         }
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             reportToServerSafe(event)
         }
     }

--- a/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/countly/CountlyApiImpl.kt
+++ b/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/countly/CountlyApiImpl.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.metric.impl.countly
 import android.app.Application
 import androidx.datastore.core.DataStore
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.toIntSafe
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -13,7 +14,6 @@ import com.flipperdevices.metric.api.events.SessionState
 import com.flipperdevices.metric.impl.BuildConfig
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -39,7 +39,7 @@ class CountlyApiImpl @Inject constructor(
         id: String,
         params: Map<String, Any?>?
     ) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             try {
                 reportEventUnsafe(id, params)
             } catch (e: Exception) {

--- a/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/countly/CountlyApiImpl.kt
+++ b/components/analytics/metric/impl/src/main/java/com/flipperdevices/metric/impl/countly/CountlyApiImpl.kt
@@ -31,7 +31,7 @@ class CountlyApiImpl @Inject constructor(
 ) : CountlyApi, LogTagProvider {
     override val TAG = "CountlyApi"
 
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
 
     private val countly by lazy { initCountly() }
 
@@ -39,7 +39,7 @@ class CountlyApiImpl @Inject constructor(
         id: String,
         params: Map<String, Any?>?
     ) {
-        scope.launch(FlipperDispatchers.workStealingDispatcher) {
+        scope.launch {
             try {
                 reportEventUnsafe(id, params)
             } catch (e: Exception) {

--- a/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/viewmodel/Shake2ReportViewModel.kt
+++ b/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/viewmodel/Shake2ReportViewModel.kt
@@ -45,7 +45,7 @@ class Shake2ReportViewModel @Inject constructor(
         name: String,
         description: String,
         addLogs: Boolean
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         if (shake2ReportStateFlow.value !is Shake2ReportState.Pending) {
             return@launch
         }

--- a/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/CategoryViewModel.kt
+++ b/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/CategoryViewModel.kt
@@ -27,7 +27,7 @@ class CategoryViewModel @AssistedInject constructor(
     private val categoryState = MutableStateFlow<CategoryState>(CategoryState.Loading)
 
     init {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             when (categoryType) {
                 is CategoryType.ByFileType -> simpleKeyApi.getExistKeysAsFlow(categoryType.fileType)
                 CategoryType.Deleted -> deleteKeyApi.getDeletedKeyAsFlow()

--- a/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/CategoryViewModel.kt
+++ b/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/CategoryViewModel.kt
@@ -11,7 +11,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/CategoryViewModel.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/CategoryViewModel.kt
@@ -41,7 +41,7 @@ class CategoryViewModel @Inject constructor(
     )
 
     init {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             subscribeOnCategoriesCount()
         }
         categoriesMapFlow.onEach {
@@ -63,7 +63,7 @@ class CategoryViewModel @Inject constructor(
                     categoryType = CategoryType.Deleted
                 )
             )
-        }.launchIn(viewModelScope + Dispatchers.Default)
+        }.launchIn(viewModelScope)
 
         FlipperKeyType.entries.forEach { fileType ->
             simpleKeyApi.getExistKeysAsFlow(fileType).onEach { keys ->
@@ -77,7 +77,7 @@ class CategoryViewModel @Inject constructor(
                     )
                     return@update mutableMap
                 }
-            }.launchIn(viewModelScope + Dispatchers.Default)
+            }.launchIn(viewModelScope)
         }
     }
 }

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/CategoryViewModel.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/CategoryViewModel.kt
@@ -11,7 +11,6 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/GeneralTabViewModel.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/GeneralTabViewModel.kt
@@ -9,7 +9,6 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine

--- a/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/GeneralTabViewModel.kt
+++ b/components/archive/impl/src/main/java/com/flipperdevices/archive/impl/viewmodel/GeneralTabViewModel.kt
@@ -30,7 +30,7 @@ class GeneralTabViewModel @Inject constructor(
         MutableStateFlow<SynchronizationState>(SynchronizationState.NotStarted)
 
     init {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             simpleKeyApi.getExistKeysAsFlow(null)
                 .combine(favoriteApi.getFavoritesFlow()) { keyList, favoriteKeysList ->
                     val favoriteKeyPaths = favoriteKeysList.map { it.path }.toSet()
@@ -38,10 +38,10 @@ class GeneralTabViewModel @Inject constructor(
                         keyList.filterNot { favoriteKeyPaths.contains(it.path) }
                     keys.emit(keysExceptFavorite.toImmutableList())
                     favoriteKeys.emit(favoriteKeysList.toImmutableList())
-                }.launchIn(viewModelScope + Dispatchers.Default)
+                }.launchIn(viewModelScope)
             synchronizationApi.getSynchronizationState().onEach {
                 synchronizationState.emit(it)
-            }.launchIn(viewModelScope + Dispatchers.Default)
+            }.launchIn(viewModelScope)
         }
     }
 
@@ -54,7 +54,7 @@ class GeneralTabViewModel @Inject constructor(
     }
 
     fun cancelSynchronization() {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             synchronizationApi.stop()
         }
     }

--- a/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
+++ b/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
@@ -7,7 +7,6 @@ import com.flipperdevices.bridge.synchronization.api.SynchronizationState
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.keyparser.api.KeyParser
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn

--- a/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
+++ b/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
@@ -32,7 +32,7 @@ class SearchViewModel @Inject constructor(
                 .collect {
                     searchState.emit(SearchState.Loaded(it.toImmutableList()))
                 }
-        }.launchIn(viewModelScope + Dispatchers.Default)
+        }.launchIn(viewModelScope)
     }
 
     fun getState(): StateFlow<SearchState> = searchState
@@ -41,7 +41,7 @@ class SearchViewModel @Inject constructor(
         synchronizationApi.getSynchronizationState()
 
     fun onChangeText(text: String) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             queryFlow.emit(text)
         }
     }

--- a/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/BottomBarViewModel.kt
+++ b/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/BottomBarViewModel.kt
@@ -2,7 +2,6 @@ package com.flipperdevices.bottombar.impl.viewmodel
 
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.hub.api.HubApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn

--- a/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/BottomBarViewModel.kt
+++ b/components/bottombar/impl/src/main/java/com/flipperdevices/bottombar/impl/viewmodel/BottomBarViewModel.kt
@@ -18,7 +18,7 @@ class BottomBarViewModel @Inject constructor(
     init {
         hubApi.hasNotification(viewModelScope).onEach {
             hasNotificationHubStateFlow.emit(it)
-        }.launchIn(viewModelScope + Dispatchers.Default)
+        }.launchIn(viewModelScope)
     }
 
     fun hasNotificationHubState(): StateFlow<Boolean> = hasNotificationHubStateFlow

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/observers/ConnectionObserverComposite.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/observers/ConnectionObserverComposite.kt
@@ -1,11 +1,11 @@
 package com.flipperdevices.bridge.api.manager.observers
 
 import android.bluetooth.BluetoothDevice
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.forEachIterable
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.nordicsemi.android.ble.observer.ConnectionObserver
 
@@ -37,7 +37,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceConnecting(device: BluetoothDevice) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceConnecting(device)
             }
         }
@@ -46,7 +46,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceConnected(device: BluetoothDevice) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceConnected(device)
             }
         }
@@ -55,7 +55,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceFailedToConnect(device, reason)
             }
         }
@@ -64,7 +64,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceReady(device: BluetoothDevice) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceReady(device)
             }
         }
@@ -73,7 +73,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceDisconnecting(device: BluetoothDevice) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceDisconnecting(device)
             }
         }
@@ -82,7 +82,7 @@ class ConnectionObserverComposite(
     @Synchronized
     override fun onDeviceDisconnected(device: BluetoothDevice, reason: Int) {
         observers.forEachIterable {
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 it.onDeviceDisconnected(device, reason)
             }
         }

--- a/components/bridge/connection/ble/impl/src/main/java/com/flipperdevices/bridge/connection/ble/impl/serial/FSerialDeviceApiWrapper.kt
+++ b/components/bridge/connection/ble/impl/src/main/java/com/flipperdevices/bridge/connection/ble/impl/serial/FSerialDeviceApiWrapper.kt
@@ -2,6 +2,7 @@ package com.flipperdevices.bridge.connection.ble.impl.serial
 
 import com.flipperdevices.bridge.connection.ble.api.FBleDeviceSerialConfig
 import com.flipperdevices.bridge.connection.common.api.serial.FSerialDeviceApi
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.WaitNotifyLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
@@ -10,7 +11,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -39,7 +39,7 @@ class FSerialDeviceApiWrapper @AssistedInject constructor(
 
                 serialApiScope?.cancel()
                 val newSerialApiScope = CoroutineScope(
-                    Dispatchers.Default + SupervisorJob(scope.coroutineContext.job)
+                    FlipperDispatchers.workStealingDispatcher + SupervisorJob(scope.coroutineContext.job)
                 ).also { serialApiScope = it }
 
                 if (services == null) {

--- a/components/bridge/connection/ble/impl/src/main/java/com/flipperdevices/bridge/connection/ble/impl/serial/SpeedMeter.kt
+++ b/components/bridge/connection/ble/impl/src/main/java/com/flipperdevices/bridge/connection/ble/impl/serial/SpeedMeter.kt
@@ -1,7 +1,7 @@
 package com.flipperdevices.bridge.connection.ble.impl.serial
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +18,7 @@ class SpeedMeter(scope: CoroutineScope) {
     private var bytesCollected = AtomicLong(0)
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             calculateSpeedEachSecond()
         }
     }
@@ -29,7 +29,7 @@ class SpeedMeter(scope: CoroutineScope) {
         bytesCollected.addAndGet(bytesCount.toLong())
     }
 
-    private suspend fun calculateSpeedEachSecond() = withContext(Dispatchers.Default) {
+    private suspend fun calculateSpeedEachSecond() = withContext(FlipperDispatchers.workStealingDispatcher) {
         while (isActive) {
             delay(DELAY_MS)
             val totalBytes = bytesCollected.getAndSet(0)

--- a/components/bridge/connection/orchestrator/impl/src/main/kotlin/com/flipperdevices/bridge/connection/ble/impl/FDeviceHolder.kt
+++ b/components/bridge/connection/orchestrator/impl/src/main/kotlin/com/flipperdevices/bridge/connection/ble/impl/FDeviceHolder.kt
@@ -4,10 +4,10 @@ import com.flipperdevices.bridge.connection.common.api.FConnectedDeviceApi
 import com.flipperdevices.bridge.connection.common.api.FDeviceConnectionConfig
 import com.flipperdevices.bridge.connection.common.api.FTransportConnectionStatusListener
 import com.flipperdevices.bridge.connection.connectionbuilder.api.FDeviceConfigToConnection
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
@@ -39,7 +39,7 @@ class FDeviceHolder<API : FConnectedDeviceApi>(
 ) : LogTagProvider {
     override val TAG = "FDeviceHolder-$config"
 
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val scope = CoroutineScope(FlipperDispatchers.workStealingDispatcher)
     private var deviceApi: API? = null
     private val connectJob: Job = scope.launch {
         deviceApi = deviceConnectionHelper.connect(

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/PeripheralResponseReader.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/PeripheralResponseReader.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.bridge.impl.manager
 import com.flipperdevices.bridge.api.manager.service.RestartRPCApi
 import com.flipperdevices.bridge.impl.utils.BridgeImplConfig.BLE_VLOG
 import com.flipperdevices.bridge.impl.utils.ByteEndlessInputStream
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -12,7 +13,6 @@ import com.flipperdevices.shake2report.api.Shake2ReportApi
 import com.google.protobuf.InvalidProtocolBufferException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -37,7 +37,7 @@ class PeripheralResponseReader(
 
     suspend fun initialize() = withLock(mutex, "initialize") {
         responseReaderJob?.cancelAndJoin()
-        responseReaderJob = scope.launch(Dispatchers.Default) {
+        responseReaderJob = scope.launch(FlipperDispatchers.workStealingDispatcher) {
             val byteInputStreamLocal = ByteEndlessInputStream(this)
             byteInputStream = byteInputStreamLocal
             parseLoopJob(byteInputStreamLocal)
@@ -65,7 +65,7 @@ class PeripheralResponseReader(
                 if (BLE_VLOG) {
                     info { "Receive $main response" }
                 }
-                scope.launch(Dispatchers.Default) {
+                scope.launch(FlipperDispatchers.workStealingDispatcher) {
                     responses.emit(main)
                 }
             } catch (ignored: CancellationException) {

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
@@ -9,11 +9,11 @@ import com.flipperdevices.bridge.impl.manager.UnsafeBleManager
 import com.flipperdevices.bridge.impl.manager.service.BluetoothGattServiceWrapper
 import com.flipperdevices.bridge.impl.manager.service.getCharacteristicOrLog
 import com.flipperdevices.bridge.impl.manager.service.getServiceOrLog
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -87,7 +87,7 @@ class FlipperSerialOverflowThrottler(
         val remainingInternal = ByteBuffer.wrap(bytes).int
         info { "Invalidate buffer size. New size: $remainingInternal" }
 
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             bufferSizeState.emit(remainingInternal)
         }
     }
@@ -143,7 +143,7 @@ class FlipperSerialOverflowThrottler(
     }
 
     private fun getOverflowBufferJob(): Job {
-        return scope.launch(Dispatchers.Default) {
+        return scope.launch(FlipperDispatchers.workStealingDispatcher) {
             bufferSizeState.collectLatest { bufferSize ->
                 sendCommandsWhileBufferNotEnd(bufferSize)
             }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/FlipperInformationApiImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/FlipperInformationApiImpl.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.bridge.api.model.FlipperGATTInformation
 import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.bridge.impl.manager.UnsafeBleManager
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.preference.pb.PairSettings
@@ -15,7 +16,6 @@ import com.flipperdevices.metric.api.MetricApi
 import com.flipperdevices.metric.api.events.complex.FlipperGattInfoEvent
 import com.flipperdevices.shake2report.api.Shake2ReportApi
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -49,7 +49,7 @@ class FlipperInformationApiImpl @Inject constructor(
     init {
         informationState.onEach {
             shake2ReportApi.updateGattInformation(it)
-        }.launchIn(scope + Dispatchers.Default)
+        }.launchIn(scope + FlipperDispatchers.workStealingDispatcher)
     }
 
     override fun onServiceReceived(gatt: BluetoothGatt): Boolean {
@@ -173,7 +173,7 @@ class FlipperInformationApiImpl @Inject constructor(
     }
 
     private fun onDeviceNameReceived(deviceName: String) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             dataStoreFirstPair.updateData {
                 var deviceNameFormatted = deviceName.trim()
                 if (deviceNameFormatted.startsWith(Constants.DEVICENAME_PREFIX)) {

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperSerialApiUnsafeImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperSerialApiUnsafeImpl.kt
@@ -12,11 +12,11 @@ import com.flipperdevices.bridge.impl.manager.service.getCharacteristicOrLog
 import com.flipperdevices.bridge.impl.manager.service.getServiceOrLog
 import com.flipperdevices.bridge.impl.utils.BridgeImplConfig.BLE_VLOG
 import com.flipperdevices.bridge.impl.utils.SpeedMeter
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.log.verbose
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -74,7 +74,7 @@ class FlipperSerialApiUnsafeImpl(
             }
             val bytes = data.value ?: return@with
             rxSpeed.onReceiveBytes(bytes.size)
-            scope.launch(Dispatchers.Default) {
+            scope.launch(FlipperDispatchers.workStealingDispatcher) {
                 receiveBytesFlow.emit(bytes)
             }
         }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/ByteEndlessInputStream.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/ByteEndlessInputStream.kt
@@ -1,10 +1,10 @@
 package com.flipperdevices.bridge.impl.utils
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.verbose
 import it.unimi.dsi.fastutil.bytes.ByteArrayFIFOQueue
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.isActive
@@ -22,7 +22,7 @@ class ByteEndlessInputStream(
     private var balancer = 0
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             try {
                 awaitCancellation()
             } finally {

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/SpeedMeter.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/SpeedMeter.kt
@@ -1,7 +1,7 @@
 package com.flipperdevices.bridge.impl.utils
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +18,7 @@ class SpeedMeter(scope: CoroutineScope) {
     private var bytesCollected = AtomicLong(0)
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             calculateSpeedEachSecond()
         }
     }
@@ -29,7 +29,7 @@ class SpeedMeter(scope: CoroutineScope) {
         bytesCollected.addAndGet(bytesCount.toLong())
     }
 
-    private suspend fun calculateSpeedEachSecond() = withContext(Dispatchers.Default) {
+    private suspend fun calculateSpeedEachSecond() = withContext(FlipperDispatchers.workStealingDispatcher) {
         while (isActive) {
             delay(MS_IN_SEC)
             val totalBytes = bytesCollected.getAndSet(0)

--- a/components/bridge/rpc/impl/src/main/java/com/flipperdevices/bridge/rpc/impl/api/FlipperStorageApiImpl.kt
+++ b/components/bridge/rpc/impl/src/main/java/com/flipperdevices/bridge/rpc/impl/api/FlipperStorageApiImpl.kt
@@ -10,6 +10,7 @@ import com.flipperdevices.bridge.rpc.impl.delegates.FlipperUploadDelegate
 import com.flipperdevices.bridge.rpc.impl.delegates.MkDirDelegate
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.progress.ProgressListener
@@ -17,7 +18,6 @@ import com.flipperdevices.protobuf.Flipper
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.storage.deleteRequest
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -33,12 +33,12 @@ class FlipperStorageApiImpl @Inject constructor(
 ) : FlipperStorageApi, LogTagProvider {
     override val TAG = "FlipperStorageApi"
 
-    override suspend fun mkdirs(path: String) = withContext(Dispatchers.Default) {
+    override suspend fun mkdirs(path: String) = withContext(FlipperDispatchers.workStealingDispatcher) {
         mkDirDelegate.mkdir(flipperServiceProvider.getServiceApi().requestApi, path)
     }
 
     override suspend fun delete(path: String, recursive: Boolean) =
-        withContext(Dispatchers.Default) {
+        withContext(FlipperDispatchers.workStealingDispatcher) {
             val requestApi = flipperServiceProvider.getServiceApi().requestApi
             val response = requestApi.request(
                 main {
@@ -59,7 +59,7 @@ class FlipperStorageApiImpl @Inject constructor(
         pathOnFlipper: String,
         fileOnAndroid: File,
         progressListener: ProgressListener
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         flipperDownloadDelegate.download(
             requestApi = flipperServiceProvider.getServiceApi().requestApi,
             pathOnFlipper = pathOnFlipper,
@@ -72,7 +72,7 @@ class FlipperStorageApiImpl @Inject constructor(
         pathOnFlipper: String,
         fileOnAndroid: File,
         progressListener: ProgressListener
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         flipperUploadDelegate.upload(
             requestApi = flipperServiceProvider.getServiceApi().requestApi,
             pathOnFlipper = pathOnFlipper,

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
@@ -14,10 +14,10 @@ import com.flipperdevices.bridge.service.impl.provider.error.CompositeFlipperSer
 import com.flipperdevices.bridge.service.impl.provider.lifecycle.FlipperServiceLifecycleListener
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.runBlockingWithLog
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -31,7 +31,7 @@ class FlipperService : LifecycleService(), LogTagProvider {
         FlipperBleServiceComponent.ManualFactory.create(
             deps = ComponentHolder.component(),
             context = this,
-            scope = lifecycleScope + Dispatchers.Default,
+            scope = lifecycleScope + FlipperDispatchers.workStealingDispatcher,
             serviceErrorListener = listener
         )
     }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperServiceApiImpl.kt
@@ -7,6 +7,7 @@ import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.impl.delegate.FlipperSafeConnectWrapper
 import com.flipperdevices.core.di.SingleIn
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
@@ -16,7 +17,6 @@ import com.flipperdevices.core.preference.pb.PairSettings
 import com.flipperdevices.unhandledexception.api.UnhandledExceptionApi
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -60,7 +60,7 @@ class FlipperServiceApiImpl @Inject constructor(
         info { "Internal init and try connect" }
 
         var previousDeviceId: String? = null
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             pairSettingsStore.data.map { it.deviceId }.collectLatest { deviceId ->
                 withLock(mutex, "connect") {
                     if (!unhandledExceptionApi.isBleConnectionForbiddenFlow().first() &&

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperActionNotifierImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperActionNotifierImpl.kt
@@ -3,9 +3,9 @@ package com.flipperdevices.bridge.service.impl.delegate
 import com.flipperdevices.bridge.api.di.FlipperBleServiceGraph
 import com.flipperdevices.bridge.api.manager.delegates.FlipperActionNotifier
 import com.flipperdevices.core.di.SingleIn
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -21,7 +21,7 @@ class FlipperActionNotifierImpl @Inject constructor(
     override fun getActionFlow(): Flow<Unit> = actionFlow
 
     override fun notifyAboutAction() {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             actionFlow.emit(Unit)
         }
     }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -10,6 +10,7 @@ import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.core.di.SingleIn
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.BuildConfig
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -17,7 +18,6 @@ import com.flipperdevices.core.log.info
 import com.flipperdevices.core.log.verbose
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -48,7 +48,7 @@ class FlipperLagsDetectorImpl @Inject constructor(
     private val pendingResponseCounter = AtomicInteger(0)
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             combine(
                 flipperActionNotifier.getActionFlow(),
                 serviceApi.connectionInformationApi.getConnectionStateFlow()

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperSafeConnectWrapper.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperSafeConnectWrapper.kt
@@ -3,12 +3,12 @@ package com.flipperdevices.bridge.service.impl.delegate
 import com.flipperdevices.bridge.api.error.FlipperBleServiceError
 import com.flipperdevices.bridge.api.error.FlipperServiceErrorListener
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.isActive
@@ -39,7 +39,7 @@ class FlipperSafeConnectWrapper @Inject constructor(
         info { "Call cancel and join to current job" }
         currentConnectingJob?.cancelAndJoin()
         info { "Job canceled! Call connect again" }
-        currentConnectingJob = scope.launch(Dispatchers.Default) {
+        currentConnectingJob = scope.launch(FlipperDispatchers.workStealingDispatcher) {
             var errorOnDeviceUpdate: Throwable?
             do {
                 errorOnDeviceUpdate = runCatching {

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/SynchronizationTask.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/SynchronizationTask.kt
@@ -12,6 +12,7 @@ import com.flipperdevices.bridge.synchronization.impl.di.TaskSynchronizationComp
 import com.flipperdevices.bridge.synchronization.impl.model.RestartSynchronizationException
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.ComponentHolder
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -23,7 +24,6 @@ import com.flipperdevices.nfc.mfkey32.api.MfKey32Api
 import com.flipperdevices.wearable.sync.handheld.api.SyncWearableApi
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filter
@@ -139,7 +139,7 @@ class SynchronizationTaskImpl(
     private suspend fun launch(
         serviceApi: FlipperServiceApi,
         progressTracker: ProgressWrapperTracker
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         val startSynchronizationTime = System.currentTimeMillis()
         val taskComponent = TaskSynchronizationComponent.ManualFactory
             .create(

--- a/components/connection/impl/src/main/java/com/flipperdevices/connection/impl/viewmodel/ConnectionStatusViewModel.kt
+++ b/components/connection/impl/src/main/java/com/flipperdevices/connection/impl/viewmodel/ConnectionStatusViewModel.kt
@@ -66,7 +66,7 @@ class ConnectionStatusViewModel @Inject constructor(
             if (it is ConnectionStatusState.Synchronized &&
                 switchFromSynchronizedJob == null
             ) {
-                switchFromSynchronizedJob = viewModelScope.launch(Dispatchers.Default) {
+                switchFromSynchronizedJob = viewModelScope.launch {
                     delay(TIMEOUT_SYNCHRONIZED_STATUS_MS)
                     statusState.update {
                         if (it is ConnectionStatusState.Synchronized) {

--- a/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/jre/CoroutineLogKtx.kt
+++ b/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/jre/CoroutineLogKtx.kt
@@ -5,7 +5,6 @@ import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.log.verbose
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -37,7 +36,7 @@ fun LogTagProvider.launchWithLock(
     tag: String? = null,
     action: suspend () -> Unit
 ) {
-    scope.launch(Dispatchers.Default) {
+    scope.launch(FlipperDispatchers.workStealingDispatcher) {
         withLock(mutex, tag, action)
     }
 }

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/CancelableCoroutineKtx.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/CancelableCoroutineKtx.kt
@@ -1,13 +1,12 @@
 package com.flipperdevices.core.ktx.jre
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 
 suspend inline fun <T> withCoroutineScope(
     crossinline block: suspend (CoroutineScope) -> T
 ): T {
-    val scope = CoroutineScope(Dispatchers.Default)
+    val scope = CoroutineScope(FlipperDispatchers.workStealingDispatcher)
     return try {
         block(scope)
     } finally {

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
@@ -1,10 +1,15 @@
 package com.flipperdevices.core.ktx.jre
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 
 /**
  * To be able to mock dispatchers
  */
 object FlipperDispatchers {
-    fun getDefault() = Dispatchers.Default
+    val workStealingDispatcher: CoroutineDispatcher by lazy {
+        Executors.newWorkStealingPool().asCoroutineDispatcher()
+    }
 }

--- a/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
+++ b/components/core/ktx/src/commonMain/kotlin/com/flipperdevices/core/ktx/jre/FlipperDispatchers.kt
@@ -1,7 +1,6 @@
 package com.flipperdevices.core.ktx.jre
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
 

--- a/components/core/ui/lifecycle/src/commonMain/kotlin/com/flipperdevices/core/ui/lifecycle/DecomposeViewModel.kt
+++ b/components/core/ui/lifecycle/src/commonMain/kotlin/com/flipperdevices/core/ui/lifecycle/DecomposeViewModel.kt
@@ -14,7 +14,7 @@ abstract class DecomposeViewModel : InstanceKeeper.Instance, LifecycleOwner {
 
     protected val viewModelScope = DecomposeViewModelCoroutineScopeProvider.provideCoroutineScope(
         lifecycleOwner = this@DecomposeViewModel,
-        context = SupervisorJob() + FlipperDispatchers.getDefault()
+        context = SupervisorJob() + FlipperDispatchers.workStealingDispatcher
     )
 
     init {

--- a/components/debug/stresstest/src/main/java/com/flipperdevices/debug/stresstest/viewmodel/StressTestViewModel.kt
+++ b/components/debug/stresstest/src/main/java/com/flipperdevices/debug/stresstest/viewmodel/StressTestViewModel.kt
@@ -9,6 +9,7 @@ import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.bridge.protobuf.ProtobufConstants
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.split
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.debug.stresstest.model.LogLine
@@ -121,7 +122,7 @@ class StressTestViewModel @Inject constructor(
 
     private suspend fun sendBufferToFile(
         requestApi: FlipperRequestApi
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         val splittedBytes = byteBuffer
             .split(ProtobufConstants.MAX_FILE_DATA)
         val requests = splittedBytes

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/CategoriesViewModel.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/CategoriesViewModel.kt
@@ -37,7 +37,7 @@ class CategoriesViewModel @Inject constructor(
 
     fun onRefresh() = launchWithLock(mutex, viewModelScope, "refresh") {
         refreshJob?.cancelAndJoin()
-        refreshJob = viewModelScope.launch(Dispatchers.Default) {
+        refreshJob = viewModelScope.launch {
             targetProviderApi.getFlipperTarget().collectLatest { target ->
                 if (target == null) {
                     categoriesLoadStateFlow.emit(CategoriesLoadState.Loading)

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/CategoriesViewModel.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/CategoriesViewModel.kt
@@ -8,7 +8,6 @@ import com.flipperdevices.faphub.catalogtab.impl.model.CategoriesLoadState
 import com.flipperdevices.faphub.dao.api.FapNetworkApi
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
@@ -63,7 +63,7 @@ class FapsListViewModel @Inject constructor(
     fun getFapsFlow(): Flow<PagingData<FapItemShort>> = faps
 
     fun onSelectSortType(sortType: SortType) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             dataStoreSettings.updateData {
                 it.toBuilder()
                     .setSelectedCatalogSort(sortType.toSelectedSortType())

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
@@ -15,7 +15,6 @@ import com.flipperdevices.faphub.dao.api.model.SortType
 import com.flipperdevices.faphub.dao.api.model.SortType.Companion.toSortType
 import com.flipperdevices.faphub.installation.manifest.api.FapManifestApi
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
+++ b/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
@@ -61,7 +61,7 @@ class FapHubCategoryViewModel @AssistedInject constructor(
     fun getFapsFlow() = faps
 
     fun onSelectSortType(sortType: SortType) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             dataStoreSettings.updateData {
                 it.toBuilder()
                     .setSelectedCatalogSort(sortType.toSelectedSortType())

--- a/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
+++ b/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
@@ -16,7 +16,6 @@ import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine

--- a/components/faphub/fapscreen/impl/src/main/java/com/flipperdevices/faphub/fapscreen/impl/viewmodel/FapScreenViewModel.kt
+++ b/components/faphub/fapscreen/impl/src/main/java/com/flipperdevices/faphub/fapscreen/impl/viewmodel/FapScreenViewModel.kt
@@ -89,7 +89,7 @@ class FapScreenViewModel @AssistedInject constructor(
             SimpleEvent.HIDE_FAPHUB_APP,
             loadingState.fapItem.applicationAlias
         )
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             if (isHidden) {
                 fapHubHideApi.unHideItem(loadingState.fapItem.id)
             } else {
@@ -117,7 +117,7 @@ class FapScreenViewModel @AssistedInject constructor(
 
     fun onRefresh() = launchWithLock(mutex, viewModelScope, "refresh") {
         downloadFapJob?.cancelAndJoin()
-        downloadFapJob = viewModelScope.launch(Dispatchers.Default) {
+        downloadFapJob = viewModelScope.launch {
             fapScreenLoadingStateFlow.emit(FapScreenLoadingState.Loading)
             controlStateFlow.emit(FapDetailedControlState.Loading)
             targetProviderApi.getFlipperTarget().collectLatest { target ->
@@ -141,7 +141,7 @@ class FapScreenViewModel @AssistedInject constructor(
                         currentVersion = fapItem.upToDateVersion
                     ).onEach { state ->
                         controlStateFlow.emit(state.toControlState(fapItem))
-                    }.launchIn(viewModelScope + Dispatchers.Default)
+                    }.launchIn(viewModelScope)
                 }.onFailure {
                     error(it) { "Failed fetch single application" }
                     if (it !is CancellationException) {

--- a/components/faphub/installation/all/impl/src/main/kotlin/com/flipperdevices/faphub/installation/all/impl/api/FapInstallationAllImpl.kt
+++ b/components/faphub/installation/all/impl/src/main/kotlin/com/flipperdevices/faphub/installation/all/impl/api/FapInstallationAllImpl.kt
@@ -13,12 +13,10 @@ import com.flipperdevices.faphub.installation.queue.api.FapInstallationQueueApi
 import com.flipperdevices.faphub.installation.queue.api.model.FapActionRequest
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 private const val CHUNK_RECEIVED_COUNT = 50
@@ -32,7 +30,7 @@ class FapInstallationAllImpl @Inject constructor(
 ) : FapInstallationAllApi, LogTagProvider {
     override val TAG = "FapInstallationAllApi"
 
-    override suspend fun installAll() = withContext(Dispatchers.Default) {
+    override suspend fun installAll() {
         info { "Start receive installed apps" }
         val alreadyInstalledApps = manifestApi.getManifestFlow()
             .filter { it is FapManifestState.Loaded && !it.inProgress }

--- a/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
+++ b/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
@@ -6,6 +6,7 @@ import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.data.SemVer
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.faphub.dao.api.model.FapBuildState
@@ -70,7 +71,7 @@ class OpenFapHelperImpl @Inject constructor(
     }
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             val serviceApi = serviceProvider.getServiceApi()
             serviceApi.flipperVersionApi.getVersionInformationFlow().collectLatest {
                 rpcVersionFlow.emit(it)

--- a/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/viewmodel/OpenFapViewModel.kt
+++ b/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/viewmodel/OpenFapViewModel.kt
@@ -29,7 +29,7 @@ class OpenFapViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             openFapHelper.loadFap(
                 config = config,
                 onResult = { processOpenFapResult(it, onOpenScreenStreaming) }

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/api/FapManifestApiImpl.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/api/FapManifestApiImpl.kt
@@ -111,7 +111,7 @@ class FapManifestApiImpl @Inject constructor(
 
     override fun invalidateAsync() = launchWithLock(jobInvalidateMutex, scope) {
         val oldJob = job
-        job = scope.launch(FlipperDispatchers.workStealingDispatcher) {
+        job = scope.launch {
             oldJob?.cancelAndJoin()
             loader.invalidate()
             loader.getManifestLoaderState()

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/api/FapManifestApiImpl.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/api/FapManifestApiImpl.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.faphub.installation.manifest.impl.api
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
@@ -15,7 +16,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
@@ -37,7 +37,7 @@ class FapManifestApiImpl @Inject constructor(
 ) : FapManifestApi, LogTagProvider {
     override val TAG = "FapManifestApi"
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
     private val loader = loaderFactory(scope)
 
     private val fapManifestStateFlow = MutableStateFlow<FapManifestState>(
@@ -111,7 +111,7 @@ class FapManifestApiImpl @Inject constructor(
 
     override fun invalidateAsync() = launchWithLock(jobInvalidateMutex, scope) {
         val oldJob = job
-        job = scope.launch(Dispatchers.Default) {
+        job = scope.launch(FlipperDispatchers.workStealingDispatcher) {
             oldJob?.cancelAndJoin()
             loader.invalidate()
             loader.getManifestLoaderState()

--- a/components/faphub/installation/queue/impl/src/main/java/com/flipperdevices/faphub/installation/queue/impl/api/FapQueueRunner.kt
+++ b/components/faphub/installation/queue/impl/src/main/java/com/flipperdevices/faphub/installation/queue/impl/api/FapQueueRunner.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.faphub.installation.queue.impl.api
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.ktx.jre.withLockResult
 import com.flipperdevices.core.log.LogTagProvider
@@ -14,7 +15,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
@@ -32,7 +32,7 @@ class FapQueueRunner @Inject constructor(
 ) : LogTagProvider {
     override val TAG = "FapQueueRunner"
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
 
     private val mutex = Mutex()
     private val pendingTaskFlow =

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsFromNetworkProducer.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsFromNetworkProducer.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.faphub.installedtab.impl.viewmodel
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -19,7 +20,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -57,7 +57,7 @@ class InstalledFapsFromNetworkProducer @Inject constructor(
         info { "Call refresh $force" }
         installedFapsUidsProducer.refresh(globalScope, force)
         val oldJob = fetchFromNetworkJob
-        fetchFromNetworkJob = globalScope.launch(Dispatchers.Default) {
+        fetchFromNetworkJob = globalScope.launch(FlipperDispatchers.workStealingDispatcher) {
             oldJob?.cancelAndJoin()
             if (force) {
                 applicationFromNetworkStateFlow.emit(

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsUidsProducer.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsUidsProducer.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.faphub.installedtab.impl.viewmodel
 
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.faphub.installation.manifest.api.FapManifestApi
 import com.flipperdevices.faphub.installation.manifest.model.FapManifestState
@@ -10,7 +11,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,7 +41,7 @@ class InstalledFapsUidsProducer @Inject constructor(
             fapManifestApi.invalidateAsync()
         }
         val oldJob = applicationUidJob
-        applicationUidJob = scope.launch(Dispatchers.Default) {
+        applicationUidJob = scope.launch(FlipperDispatchers.workStealingDispatcher) {
             oldJob?.cancelAndJoin()
             if (force) {
                 applicationUidsStateFlow.emit(

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsViewModel.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsViewModel.kt
@@ -72,7 +72,7 @@ class InstalledFapsViewModel @Inject constructor(
 
     fun getFapBatchUpdateButtonState() = batchUpdateButtonState.asStateFlow()
 
-    fun updateAll() = viewModelScope.launch(Dispatchers.Default) {
+    fun updateAll() = viewModelScope.launch {
         val state = installedFapsStateFlow.first()
         if (state !is FapInstalledInternalLoadingState.Loaded) {
             info { "State is $state, so just return" }
@@ -100,7 +100,7 @@ class InstalledFapsViewModel @Inject constructor(
         }
     }
 
-    fun cancelAll() = viewModelScope.launch(Dispatchers.Default) {
+    fun cancelAll() = viewModelScope.launch {
         val state = installedFapsStateFlow.first()
         if (state !is FapInstalledInternalLoadingState.Loaded) {
             info { "State is $state, so just return" }

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsViewModel.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsViewModel.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.faphub.installedtab.impl.viewmodel
 
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -18,7 +19,6 @@ import com.flipperdevices.faphub.installedtab.impl.model.toScreenState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -115,7 +115,7 @@ class InstalledFapsViewModel @Inject constructor(
     fun refresh(force: Boolean) {
         fapsStateProducer.refresh(force)
         val oldJob = fetcherJob
-        fetcherJob = viewModelScope.launch(Dispatchers.Default) {
+        fetcherJob = viewModelScope.launch(FlipperDispatchers.workStealingDispatcher) {
             oldJob?.cancelAndJoin()
             installedFapsStateFlow.emit(
                 FapInstalledInternalLoadingState.Loaded(

--- a/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
+++ b/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
@@ -39,7 +39,7 @@ class FapHubSearchViewModel @Inject constructor(
     fun getSearchRequest() = searchRequestFlow.asStateFlow()
 
     fun onChangeSearchText(text: String) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             searchRequestFlow.emit(text)
         }
     }

--- a/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
+++ b/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
@@ -8,7 +8,6 @@ import com.flipperdevices.core.pager.loadingPagingDataFlow
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.faphub.dao.api.FapNetworkApi
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine

--- a/components/faphub/target/impl/build.gradle.kts
+++ b/components/faphub/target/impl/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(projects.components.faphub.target.api)
 
     implementation(projects.components.core.di)
+    implementation(projects.components.core.ktx)
     implementation(projects.components.core.log)
     implementation(projects.components.core.data)
 

--- a/components/faphub/target/impl/src/main/java/com/flipperdevices/faphub/target/impl/api/FlipperTargetProviderApiImpl.kt
+++ b/components/faphub/target/impl/src/main/java/com/flipperdevices/faphub/target/impl/api/FlipperTargetProviderApiImpl.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.faphub.target.impl.api
 import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
@@ -33,7 +34,7 @@ class FlipperTargetProviderApiImpl @Inject constructor(
     private val targetFlow = MutableStateFlow<FlipperTarget?>(null)
 
     init {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             subscribe()
         }
     }

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ReceiveViewModel.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ReceiveViewModel.kt
@@ -57,10 +57,10 @@ class ReceiveViewModel @AssistedInject constructor(
     fun getReceiveState(): StateFlow<ShareState> = receiveStateFlow
 
     override fun onServiceApiReady(serviceApi: FlipperServiceApi) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             startUpload(serviceApi)
         }
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             serviceApi.requestApi.getSpeed().onEach { serialSpeed ->
                 receiveStateFlow.update {
                     it.copy(
@@ -69,7 +69,7 @@ class ReceiveViewModel @AssistedInject constructor(
                         )
                     )
                 }
-            }.launchIn(viewModelScope + Dispatchers.Default)
+            }.launchIn(viewModelScope)
         }
     }
 

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/helpers/DownloadFileHelper.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/helpers/DownloadFileHelper.kt
@@ -4,9 +4,9 @@ import com.flipperdevices.bridge.api.manager.FlipperRequestApi
 import com.flipperdevices.bridge.api.model.FlipperRequest
 import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.storage.readRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -16,7 +16,7 @@ class DownloadFileHelper {
         pathOnFlipper: String,
         file: File,
         onUpdateIncrement: (Long) -> Unit
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         requestApi.request(getRequest(pathOnFlipper)).collect {
             val data = it.storageReadResponse.file.data
             file.appendBytes(data.toByteArray())

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/helpers/UploadFileHelper.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/helpers/UploadFileHelper.kt
@@ -6,13 +6,13 @@ import com.flipperdevices.bridge.api.model.FlipperRequest
 import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.bridge.protobuf.streamToCommandFlow
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.deeplink.model.DeeplinkContent
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.storage.file
 import com.flipperdevices.protobuf.storage.writeRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -28,7 +28,7 @@ class UploadFileHelper(private val contentResolver: ContentResolver) : LogTagPro
         deeplinkContent: DeeplinkContent,
         filePath: String,
         onUpdateIncrement: (Long?) -> Unit
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         deeplinkContent.openStream(contentResolver).use { fileStream ->
             val stream = fileStream ?: return@use
             val requestFlow = streamToCommandFlow(

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/connecting/PairDeviceViewModel.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/connecting/PairDeviceViewModel.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
 import com.flipperdevices.bridge.api.manager.ktx.stateAsFlow
 import com.flipperdevices.bridge.api.scanner.DiscoveredBluetoothDevice
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -12,7 +13,6 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.firstpair.impl.model.DevicePairState
 import com.flipperdevices.firstpair.impl.storage.FirstPairStorage
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
@@ -41,7 +41,7 @@ class PairDeviceViewModel(
         firstPairBleManagerFactory: FirstPairBleManager.Factory,
         firstPairStorage: FirstPairStorage,
         deviceColorSaver: DeviceColorSaver
-    ) : this(firstPairBleManagerFactory, firstPairStorage, deviceColorSaver, Dispatchers.Default)
+    ) : this(firstPairBleManagerFactory, firstPairStorage, deviceColorSaver, FlipperDispatchers.workStealingDispatcher)
 
     override val TAG = "PairDeviceViewModel"
 

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/searching/BLEDeviceViewModel.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/searching/BLEDeviceViewModel.kt
@@ -7,7 +7,6 @@ import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.firstpair.impl.model.ScanState
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +14,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Provider
@@ -52,7 +50,7 @@ class BLEDeviceViewModel @Inject constructor(
         }
     }
 
-    private suspend fun startBLEDiscover() = withContext(Dispatchers.Default) {
+    private suspend fun startBLEDiscover() {
         info { "Start ble scan" }
         state.emit(ScanState.Searching)
         scanner.findFlipperDevices()

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
@@ -55,7 +55,7 @@ class BasicInfoViewModel @Inject constructor(
             when (it) {
                 is ConnectionState.Ready -> if (it.supportedState == FlipperSupportedState.READY) {
                     flipperStorageInformationApi.invalidate(
-                        viewModelScope + Dispatchers.Default,
+                        viewModelScope,
                         serviceApi,
                         force = true
                     )
@@ -70,7 +70,7 @@ class BasicInfoViewModel @Inject constructor(
 
         jobs += viewModelScope.launch {
             flipperStorageInformationApi.invalidate(
-                viewModelScope + Dispatchers.Default,
+                viewModelScope,
                 serviceApi
             )
         }

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
@@ -12,7 +12,6 @@ import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.info.impl.model.FlipperBasicInfo
 import com.flipperdevices.updater.api.FlipperVersionProviderApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
@@ -13,7 +13,6 @@ import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.updater.api.FirmwareVersionBuilderApi
 import com.flipperdevices.updater.model.FirmwareChannel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
@@ -59,7 +59,7 @@ class FullInfoViewModel @Inject constructor(
             when (it) {
                 is ConnectionState.Ready -> if (it.supportedState == FlipperSupportedState.READY) {
                     flipperRpcInformationApi.invalidate(
-                        viewModelScope + Dispatchers.Default,
+                        viewModelScope,
                         serviceApi,
                         force = true
                     )
@@ -74,7 +74,7 @@ class FullInfoViewModel @Inject constructor(
 
         jobs += viewModelScope.launch {
             flipperRpcInformationApi.invalidate(
-                viewModelScope + Dispatchers.Default,
+                viewModelScope,
                 serviceApi
             )
         }

--- a/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredEditorViewModel.kt
+++ b/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredEditorViewModel.kt
@@ -63,7 +63,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
     }
 
     private fun invalidate() {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             val flipperKey = simpleKeyApi.getKey(keyPath)
             if (flipperKey == null) {
                 keyStateFlow.emit(InfraredEditorState.Error(R.string.infrared_editor_not_found_key))
@@ -93,7 +93,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
     fun processSave(
         currentState: InfraredEditorState.Ready,
         onExitScreen: () -> Unit
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         if (isDirtyKey(currentState).not()) {
             withContext(Dispatchers.Main) {
                 onExitScreen()
@@ -141,7 +141,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
     fun processCancel(
         currentState: InfraredEditorState,
         onExitScreen: () -> Unit
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         if (isDirtyKey(currentState)) {
             dialogStateFlow.emit(true)
         } else {
@@ -154,7 +154,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
     fun processDeleteRemote(
         currentState: InfraredEditorState.Ready,
         index: Int
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         val remotes = currentState.remotes.toMutableList()
         remotes.removeAt(index)
 
@@ -178,7 +178,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
         currentState: InfraredEditorState.Ready,
         from: Int,
         to: Int
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         val remotes = currentState.remotes.toMutableList()
         remotes.add(to, remotes.removeAt(from))
 
@@ -200,7 +200,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
             value = value.substring(0, MAX_SIZE_REMOTE_LENGTH)
             vibrator?.vibrateCompat(VIBRATOR_TIME_MS)
         }
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             val remotes = currentState.remotes.toMutableList()
             remotes[index] = remotes[index].copy(name = value)
 
@@ -217,7 +217,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
     fun processChangeIndexEditor(
         currentState: InfraredEditorState.Ready,
         index: Int
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         keyStateFlow.emit(
             InfraredEditorState.Ready(
                 remotes = currentState.remotes,

--- a/components/keyedit/api/src/main/java/com/flipperdevices/keyedit/api/NotSavedFlipperKey.kt
+++ b/components/keyedit/api/src/main/java/com/flipperdevices/keyedit/api/NotSavedFlipperKey.kt
@@ -28,7 +28,7 @@ data class NotSavedFlipperFile(
 
 suspend fun FlipperFile.toNotSavedFlipperFile(
     context: Context
-): NotSavedFlipperFile = withContext(Dispatchers.Default) {
+): NotSavedFlipperFile = withContext(Dispatchers.IO) {
     val localContent = content
     if (localContent is FlipperKeyContent.InternalFile) {
         return@withContext NotSavedFlipperFile(path, localContent)

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/helpers/EmulateHelperImpl.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/helpers/EmulateHelperImpl.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.keyemulate.helpers
 import com.flipperdevices.bridge.api.manager.FlipperRequestApi
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.TimeHelper
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.ktx.jre.withLock
@@ -14,7 +15,6 @@ import com.flipperdevices.keyemulate.api.EmulateHelper
 import com.flipperdevices.keyemulate.model.EmulateConfig
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -95,7 +95,7 @@ class EmulateHelperImpl @Inject constructor(
             stopEmulateInternal(requestApi)
             return@withLock
         }
-        stopJob = scope.launch(Dispatchers.Default) {
+        stopJob = scope.launch(FlipperDispatchers.workStealingDispatcher) {
             try {
                 while (TimeHelper.getNow() < stopEmulateTimeAllowedMs) {
                     val delayMs = max(0, stopEmulateTimeAllowedMs - TimeHelper.getNow())

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/EmulateViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/EmulateViewModel.kt
@@ -26,7 +26,6 @@ import com.flipperdevices.keyemulate.model.LoadingState
 import com.flipperdevices.keyemulate.tasks.CloseEmulateAppTaskHolder
 import com.flipperdevices.protobuf.app.Application
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/EmulateViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/EmulateViewModel.kt
@@ -75,7 +75,7 @@ abstract class EmulateViewModel(
         }
 
         serviceProvider.provideServiceApi(this) {
-            viewModelScope.launch(Dispatchers.Default) {
+            viewModelScope.launch {
                 onStartEmulateInternal(this, it, config)
             }
         }
@@ -118,7 +118,7 @@ abstract class EmulateViewModel(
     fun onStopEmulate(force: Boolean = false) {
         info { "#onStopEmulate" }
         serviceProvider.provideServiceApi(this) {
-            viewModelScope.launch(Dispatchers.Default) {
+            viewModelScope.launch {
                 if (force) {
                     emulateHelper.stopEmulateForce(it.requestApi)
                 } else {

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/InfraredViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/InfraredViewModel.kt
@@ -56,7 +56,7 @@ class InfraredViewModel @Inject constructor(
         }
 
         serviceProvider.provideServiceApi(this) { serviceApi ->
-            viewModelScope.launch(Dispatchers.Default) {
+            viewModelScope.launch {
                 processSinglePress(serviceApi, this, config)
             }
         }

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/InfraredViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/InfraredViewModel.kt
@@ -16,7 +16,6 @@ import com.flipperdevices.keyemulate.model.EmulateButtonState
 import com.flipperdevices.keyemulate.model.EmulateConfig
 import com.flipperdevices.keyemulate.model.EmulateProgress
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/SubGhzViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/SubGhzViewModel.kt
@@ -67,7 +67,7 @@ class SubGhzViewModel @Inject constructor(
         }
 
         serviceProvider.provideServiceApi(this) {
-            viewModelScope.launch(Dispatchers.Default) {
+            viewModelScope.launch {
                 startEmulateInternal(this, it, config)
             }
         }

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/SubGhzViewModel.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/viewmodel/SubGhzViewModel.kt
@@ -16,7 +16,6 @@ import com.flipperdevices.keyemulate.model.EmulateButtonState
 import com.flipperdevices.keyemulate.model.EmulateConfig
 import com.flipperdevices.keyemulate.model.EmulateProgress
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/components/keyemulate/impl/src/test/kotlin/com/flipperdevices/keyscreen/emulate/viewmodel/helpers/EmulateHelperTest.kt
+++ b/components/keyemulate/impl/src/test/kotlin/com/flipperdevices/keyscreen/emulate/viewmodel/helpers/EmulateHelperTest.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyType
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.core.data.SemVer
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.test.TimberRule
 import com.flipperdevices.keyemulate.api.EmulateHelper
 import com.flipperdevices.keyemulate.helpers.AppEmulateHelper
@@ -27,7 +28,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -119,7 +119,7 @@ class EmulateHelperTest {
                 responseOk
             }
         )
-        var startJob = launch(Dispatchers.Default) {
+        var startJob = launch(FlipperDispatchers.workStealingDispatcher) {
             mockAfterStart(this)
             underTest.startEmulate(
                 this,
@@ -128,7 +128,7 @@ class EmulateHelperTest {
             )
         }
         startJob.join()
-        startJob = launch(Dispatchers.Default) {
+        startJob = launch(FlipperDispatchers.workStealingDispatcher) {
             mockAfterStart(this)
             underTest.startEmulate(
                 this,
@@ -141,7 +141,7 @@ class EmulateHelperTest {
             underTest.stopEmulate(this@runTest, requestTestApi)
         }
         stopJob.join()
-        startJob = launch(Dispatchers.Default) {
+        startJob = launch(FlipperDispatchers.workStealingDispatcher) {
             mockAfterStart(this)
             underTest.startEmulate(
                 this,

--- a/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
+++ b/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
@@ -81,7 +81,7 @@ class MfKey32ViewModel @Inject constructor(
         viewModelScope.launch {
             mutex.withLock {
                 val localJob = stateJob
-                stateJob = viewModelScope.launch(Dispatchers.Default) {
+                stateJob = viewModelScope.launch {
                     localJob?.cancelAndJoin()
                     serviceApi
                         .connectionInformationApi

--- a/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
+++ b/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
@@ -27,7 +27,6 @@ import com.flipperdevices.nfc.tools.api.NfcToolsApi
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.storage.deleteRequest
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorViewModel.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorViewModel.kt
@@ -50,7 +50,7 @@ class NfcEditorViewModel @AssistedInject constructor(
     fun getCurrentActiveCellState() = textUpdaterHelper.getActiveCellState()
 
     init {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             val flipperKey =
                 requireNotNull(simpleKeyApi.getKey(flipperKeyPath)) { "Not find key by $flipperKeyPath" }
             flipperKeyFlow.emit(flipperKey)

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorViewModel.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/NfcEditorViewModel.kt
@@ -20,7 +20,6 @@ import com.flipperdevices.nfceditor.impl.model.NfcEditorState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first

--- a/components/notification/impl/src/main/java/com/flipperdevices/notification/api/FlipperAppNotificationApiImpl.kt
+++ b/components/notification/impl/src/main/java/com/flipperdevices/notification/api/FlipperAppNotificationApiImpl.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import androidx.datastore.core.DataStore
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -25,7 +26,6 @@ import com.google.firebase.Firebase
 import com.google.firebase.messaging.messaging
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,7 +91,7 @@ class FlipperAppNotificationApiImpl @Inject constructor(
         scope: CoroutineScope,
         withNotificationSuccess: Boolean
     ) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             setSubscribeToUpdate(isSubscribe, onRetry = {
                 setSubscribeToUpdateAsync(isSubscribe, scope)
             }, withNotificationSuccess)

--- a/components/rootscreen/impl/build.gradle.kts
+++ b/components/rootscreen/impl/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(projects.components.rootscreen.api)
 
     implementation(projects.components.core.di)
+    implementation(projects.components.core.ktx)
     implementation(projects.components.core.log)
     implementation(projects.components.core.ui.theme)
     implementation(projects.components.core.ui.decompose)

--- a/components/rootscreen/impl/src/main/kotlin/com/flipperdevices/rootscreen/impl/api/RootDecomposeComponentImpl.kt
+++ b/components/rootscreen/impl/src/main/kotlin/com/flipperdevices/rootscreen/impl/api/RootDecomposeComponentImpl.kt
@@ -15,6 +15,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
 import com.flipperdevices.bottombar.api.BottomBarDecomposeComponent
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.deeplink.model.Deeplink
 import com.flipperdevices.faphub.screenshotspreview.api.ScreenshotsPreviewDecomposeComponent
 import com.flipperdevices.firstpair.api.FirstPairApi
@@ -54,7 +55,7 @@ class RootDecomposeComponentImpl @AssistedInject constructor(
     private val keyScreenFactory: KeyScreenDecomposeComponent.Factory,
     private val screenshotsPreviewFactory: ScreenshotsPreviewDecomposeComponent.Factory
 ) : RootDecomposeComponent, ComponentContext by componentContext {
-    private val scope = coroutineScope(Dispatchers.Default)
+    private val scope = coroutineScope(FlipperDispatchers.workStealingDispatcher)
     private val navigation = StackNavigation<RootScreenConfig>()
 
     private val stack: Value<ChildStack<RootScreenConfig, DecomposeComponent>> = childStack(

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
@@ -10,7 +10,6 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.screenstreaming.impl.R
 import com.flipperdevices.screenstreaming.impl.model.FlipperScreenState
 import com.flipperdevices.screenstreaming.impl.model.ScreenOrientationEnum
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
@@ -27,7 +27,7 @@ class ScreenshotViewModel @Inject constructor(
 ) : DecomposeViewModel() {
     fun shareScreenshot(
         screenShapshot: FlipperScreenState
-    ) = viewModelScope.launch(Dispatchers.Default) {
+    ) = viewModelScope.launch {
         val currentSnapshotState = screenShapshot as? FlipperScreenState.Ready ?: return@launch
         var currentSnapshot = currentSnapshotState.bitmap
         currentSnapshot = currentSnapshot.rescale()

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
@@ -61,7 +61,7 @@ class DebugViewModel @Inject constructor(
     }
 
     private fun onSwitchIgnoreSupportedVersion(ignored: Boolean) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             settingsDataStore.updateData {
                 it.toBuilder()
                     .setIgnoreUnsupportedVersion(ignored)
@@ -73,7 +73,7 @@ class DebugViewModel @Inject constructor(
     }
 
     private fun onSwitchIgnoreUpdaterVersion(alwaysUpdate: Boolean) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             settingsDataStore.updateData {
                 it.toBuilder()
                     .setAlwaysUpdate(alwaysUpdate)
@@ -83,7 +83,7 @@ class DebugViewModel @Inject constructor(
     }
 
     private fun onSwitchIgnoreSubGhzProvisioning(ignoreSubGhzProvisioningOnZeroRegion: Boolean) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             settingsDataStore.updateData {
                 it.toBuilder()
                     .setIgnoreSubghzProvisioningOnZeroRegion(ignoreSubGhzProvisioningOnZeroRegion)
@@ -93,7 +93,7 @@ class DebugViewModel @Inject constructor(
     }
 
     private fun onSwitchSkipAutoSync(skipAutoSync: Boolean) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             settingsDataStore.updateData {
                 it.toBuilder()
                     .setSkipAutoSyncInDebug(skipAutoSync)

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/VersionViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/VersionViewModel.kt
@@ -30,7 +30,7 @@ class VersionViewModel @Inject constructor(
 
     fun onCheckUpdates() {
         info { "#onCheckUpdates" }
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             val result = selfUpdaterApi.startCheckUpdate(manual = true)
             info { "#onCheckUpdates result: $result" }
             when (result) {
@@ -41,7 +41,7 @@ class VersionViewModel @Inject constructor(
     }
 
     fun dismissDialog() {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             dialogFlow.emit(false)
         }
     }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/VersionViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/VersionViewModel.kt
@@ -6,7 +6,6 @@ import com.flipperdevices.core.log.info
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.selfupdater.api.SelfUpdaterApi
 import com.flipperdevices.selfupdater.models.SelfUpdateResult
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch

--- a/components/share/receive/src/main/java/com/flipperdevices/share/receive/viewmodels/KeyReceiveViewModel.kt
+++ b/components/share/receive/src/main/java/com/flipperdevices/share/receive/viewmodels/KeyReceiveViewModel.kt
@@ -48,7 +48,7 @@ class KeyReceiveViewModel @AssistedInject constructor(
     init {
         job = internalDeeplinkFlow.onEach {
             parseFlipperKey(it)
-        }.launchIn(viewModelScope + Dispatchers.Default)
+        }.launchIn(viewModelScope)
     }
 
     private suspend fun parseFlipperKey(deeplink: Deeplink.RootLevel.SaveKey) {
@@ -88,7 +88,7 @@ class KeyReceiveViewModel @AssistedInject constructor(
 
     fun onRetry() {
         val oldJob = job
-        job = viewModelScope.launch(Dispatchers.Default) {
+        job = viewModelScope.launch {
             oldJob?.cancelAndJoin()
             internalDeeplinkFlow.collect {
                 state.emit(ReceiveState.NotStarted)

--- a/components/share/receive/src/main/java/com/flipperdevices/share/receive/viewmodels/KeyReceiveViewModel.kt
+++ b/components/share/receive/src/main/java/com/flipperdevices/share/receive/viewmodels/KeyReceiveViewModel.kt
@@ -19,7 +19,6 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
@@ -17,6 +17,7 @@ import com.arkivanov.decompose.defaultComponentContext
 import com.arkivanov.decompose.extensions.compose.stack.animation.LocalStackAnimationProvider
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.ktx.android.toFullString
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -34,7 +35,6 @@ import com.flipperdevices.rootscreen.api.RootDecomposeComponent
 import com.flipperdevices.singleactivity.impl.di.SingleActivityComponent
 import com.flipperdevices.singleactivity.impl.utils.FlipperStackAnimationProvider
 import com.flipperdevices.singleactivity.impl.utils.OnCreateHandlerDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -109,7 +109,7 @@ class SingleActivity : AppCompatActivity(), LogTagProvider {
         if (intent == null) {
             return
         }
-        lifecycleScope.launch(Dispatchers.Default) {
+        lifecycleScope.launch(FlipperDispatchers.workStealingDispatcher) {
             deeplinkParser.parseOrLog(this@SingleActivity, intent)?.let {
                 rootDecomposeComponent?.handleDeeplink(it)
             }

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/utils/OnCreateHandlerDispatcher.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/utils/OnCreateHandlerDispatcher.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.metric.api.MetricApi
 import com.flipperdevices.metric.api.events.SimpleEvent
 import com.flipperdevices.selfupdater.api.SelfUpdaterApi
 import com.flipperdevices.unhandledexception.api.UnhandledExceptionApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -36,7 +36,7 @@ class OnCreateHandlerDispatcher @Inject constructor(
             error(throwable) { "Failed init unhandledExceptionApi" }
         }
 
-        lifecycleOwner.lifecycleScope.launch(Dispatchers.Default) {
+        lifecycleOwner.lifecycleScope.launch(FlipperDispatchers.workStealingDispatcher) {
             lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 try {
                     selfUpdaterApiProvider.get().startCheckUpdate()

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -107,7 +107,7 @@ class UpdateCardViewModel @AssistedInject constructor(
     private suspend fun invalidateUnsafe(serviceApi: FlipperServiceApi) {
         cardStateJob?.cancelAndJoin()
         cardStateJob = null
-        cardStateJob = viewModelScope.launch(Dispatchers.Default) {
+        cardStateJob = viewModelScope.launch {
             storageExistHelper.invalidate(this, serviceApi, force = false)
             val latestVersionAsync = async {
                 val result = runCatching { downloaderApi.getLatestVersion() }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -21,7 +21,6 @@ import com.flipperdevices.updater.model.UpdateCardState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
@@ -58,7 +58,7 @@ class UpdateRequestViewModelTest {
     @Before
     fun setup() {
         mockkObject(FlipperDispatchers)
-        every { FlipperDispatchers.getDefault() } returns Dispatchers.Main.immediate
+        every { FlipperDispatchers.workStealingDispatcher } returns Dispatchers.Main.immediate
         mockkStatic("com.flipperdevices.core.ktx.jre.UriKtxKt")
 
         serviceProvider = mockk(relaxUnitFun = true)

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
@@ -5,6 +5,7 @@ import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.bridge.rpc.api.FlipperStorageApi
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.md5
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
@@ -20,7 +21,6 @@ import com.flipperdevices.protobuf.system.updateRequest
 import com.flipperdevices.updater.impl.model.IntFlashFullException
 import com.flipperdevices.updater.model.UpdatingState
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -52,7 +52,7 @@ class UploadToFlipperHelperImpl @Inject constructor(
             updaterFolder,
             flipperPath
         ) { percent ->
-            withContext(Dispatchers.Default) {
+            withContext(FlipperDispatchers.workStealingDispatcher) {
                 stateListener(
                     UpdatingState.UploadOnFlipper(
                         percent = percent

--- a/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
+++ b/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
@@ -5,6 +5,7 @@ import com.flipperdevices.bridge.api.utils.Constants
 import com.flipperdevices.bridge.protobuf.streamToCommandFlow
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.metric.api.MetricApi
@@ -21,7 +22,6 @@ import com.flipperdevices.updater.subghz.model.RegionProvisioning
 import com.flipperdevices.updater.subghz.model.RegionProvisioningSource
 import com.google.protobuf.ByteString
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
@@ -54,7 +54,7 @@ class SubGhzProvisioningHelperImpl @Inject constructor(
 
     override suspend fun provideAndUploadSubGhz(
         serviceApi: FlipperServiceApi
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (skipProvisioningHelper.shouldSkipProvisioning(serviceApi)) {
             info { "Skip provisioning" }
             return@withContext

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableFlipperStatusProcessor.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableFlipperStatusProcessor.kt
@@ -4,6 +4,7 @@ import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
 import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.di.SingleIn
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.common.WearableCommandInputStream
@@ -14,7 +15,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.ConnectSta
 import com.flipperdevices.wearable.emulate.handheld.impl.di.WearHandheldGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -42,7 +42,7 @@ class WearableFlipperStatusProcessor @Inject constructor(
             }
         }.launchIn(scope)
 
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             flipperServiceProvider
                 .getServiceApi()
                 .connectionInformationApi

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
@@ -6,11 +6,11 @@ import android.os.IBinder
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.flipperdevices.core.di.ComponentHolder
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.handheld.impl.di.WearServiceComponent
 import com.google.android.gms.wearable.ChannelClient.Channel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.plus
 
 private const val NOTIFICATION_ID = 100
@@ -19,7 +19,7 @@ class WearRequestForegroundService : LifecycleService(), WearRequestChannelBinde
     override val TAG = "WearRequestForegroundService-${hashCode()}"
     private val wearServiceComponent = WearServiceComponent.ManualFactory.create(
         ComponentHolder.component(),
-        lifecycleScope + Dispatchers.Default
+        lifecycleScope + FlipperDispatchers.workStealingDispatcher
     )
     private val binder = WearRequestBinder(this)
 

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/ConnectionHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/ConnectionHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -12,7 +13,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.pingReques
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -50,7 +50,7 @@ class ConnectionHelperImpl @Inject constructor(
 
     override fun reset(scope: CoroutineScope) {
         info { "reset" }
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(ConnectionTesterState.NOT_CONNECTED)
         }
     }

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/EmulateHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/EmulateHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -16,7 +17,6 @@ import com.flipperdevices.wearable.emulate.impl.viewmodel.KeyToEmulate
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -60,7 +60,7 @@ class EmulateHelperImpl @Inject constructor(
     }
 
     override fun reset(scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(Emulate.EmulateStatus.UNRECOGNIZED)
         }
     }

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/FlipperStatusHelper.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/helper/FlipperStatusHelper.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.wearable.emulate.impl.helper
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.api.HandheldProcessor
@@ -13,7 +14,6 @@ import com.flipperdevices.wearable.emulate.common.ipcemulate.requests.subscribeO
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -51,7 +51,7 @@ class FlipperStatusHelperImpl @Inject constructor(
     }
 
     override fun reset(scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+        scope.launch(FlipperDispatchers.workStealingDispatcher) {
             state.emit(ConnectStatusOuterClass.ConnectStatus.UNRECOGNIZED)
         }
     }

--- a/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
+++ b/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
@@ -30,7 +30,7 @@ class SyncWearableApiImpl @Inject constructor(
 
     private val dataClient by lazy { Wearable.getDataClient(application) }
 
-    override suspend fun updateWearableIndex() = withContext(FlipperDispatchers.workStealingDispatcherefault) {
+    override suspend fun updateWearableIndex() = withContext(FlipperDispatchers.workStealingDispatcher) {
         val flipperKeys = simpleKeyApi.getAllKeys()
         val itemsToSync = flipperKeys.map { flipperKey ->
             WearableSyncItem(

--- a/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
+++ b/components/wearable/sync/handheld/impl/src/main/java/com/flipperdevices/wearable/sync/handheld/impl/api/SyncWearableApiImpl.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.flipperdevices.bridge.dao.api.delegates.FavoriteApi
 import com.flipperdevices.bridge.dao.api.delegates.key.SimpleKeyApi
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.pmap
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
@@ -14,7 +15,6 @@ import com.flipperdevices.wearable.sync.handheld.api.SyncWearableApi
 import com.google.android.gms.wearable.PutDataRequest
 import com.google.android.gms.wearable.Wearable
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -30,7 +30,7 @@ class SyncWearableApiImpl @Inject constructor(
 
     private val dataClient by lazy { Wearable.getDataClient(application) }
 
-    override suspend fun updateWearableIndex() = withContext(Dispatchers.Default) {
+    override suspend fun updateWearableIndex() = withContext(FlipperDispatchers.workStealingDispatcherefault) {
         val flipperKeys = simpleKeyApi.getAllKeys()
         val itemsToSync = flipperKeys.map { flipperKey ->
             WearableSyncItem(

--- a/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
+++ b/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
@@ -48,7 +48,7 @@ class WidgetSelectViewModel @AssistedInject constructor(
         MutableStateFlow<SynchronizationState>(SynchronizationState.NotStarted)
 
     init {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             simpleKeyApi.getExistKeysAsFlow(null)
                 .combine(favoriteApi.getFavoritesFlow()) { keyList, favoriteKeysList ->
                     val favoriteKeyPaths = favoriteKeysList.map { it.path }.toSet()

--- a/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
+++ b/components/widget/screen/src/main/java/com/flipperdevices/widget/screen/viewmodel/WidgetSelectViewModel.kt
@@ -22,7 +22,6 @@ import dagger.assisted.AssistedInject
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect

--- a/instances/app/src/main/java/com/flipperdevices/app/FlipperApplication.kt
+++ b/instances/app/src/main/java/com/flipperdevices/app/FlipperApplication.kt
@@ -10,19 +10,19 @@ import com.flipperdevices.core.activityholder.CurrentActivityHolder
 import com.flipperdevices.core.di.ApplicationParams
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.singleactivity.impl.SingleActivity
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import timber.log.Timber
 
 class FlipperApplication : Application(), ImageLoaderFactory, LogTagProvider {
     override val TAG = "FlipperApplication"
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val applicationScope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
     override fun onCreate() {
         super.onCreate()
 


### PR DESCRIPTION
**Background**

Right now, `Dispatchers.Default` is used in whole application, including `viewModelScope`. As it turns out, jvm Dispatcher created with `newWorkStealingPool` provides better perfomance than `Dispatchers.Default` itself.

**Changes**

- Replaced `Dispatchers.Default` with `FlipperDispatchers.workStealingDispatcher`

**Test plan**

- This PR requires to check every aspect of the application 😢 , but there's shouldn't be visible changes
