### PR TITLE
Fix/update turned off flipper wrong message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [FIX] Update flipper is busy image
 - [FIX] Fixed ComposableWearEmulate narrow layout 
 - [FIX] Fixed wearOS blocking operations in WearableCommand streams
+- [FIX] Fixed wrong error display when turning off flipper during update
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdateContent.kt
+++ b/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdateContent.kt
@@ -88,10 +88,10 @@ fun ComposableUpdateContent(
             percent = null
         )
         is UpdaterScreenState.Failed -> when (updaterScreenState.failedReason) {
+            FailedReason.FAILED_SUB_GHZ_PROVISIONING,
             FailedReason.UPLOAD_ON_FLIPPER -> ComposableFailedUploadContent()
             FailedReason.DOWNLOAD_FROM_NETWORK -> ComposableFailedDownloadContent(onRetry)
             FailedReason.OUTDATED_APP -> ComposableOutdatedApp()
-            FailedReason.FAILED_SUB_GHZ_PROVISIONING,
             FailedReason.FAILED_INT_STORAGE -> ComposableInternalFlashFailed()
             FailedReason.FAILED_INTERNAL_UPDATE -> ComposableInternalUpdateFailed()
         }

--- a/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdaterScreen.kt
+++ b/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/composable/ComposableUpdaterScreen.kt
@@ -82,7 +82,6 @@ private fun ColumnScope.UpdaterScreenHeader(
 
     if (updaterScreenState is UpdaterScreenState.Failed) {
         when (updaterScreenState.failedReason) {
-            FailedReason.FAILED_SUB_GHZ_PROVISIONING,
             FailedReason.FAILED_INT_STORAGE -> ComposableFlipperMockup(
                 flipperColor = flipperColor,
                 isActive = false,


### PR DESCRIPTION
**Background**

Mobile application display wrong error message when disable flipper during update phase

**Changes**

- Fix when cases of `FAILED_SUB_GHZ_PROVISIONING`

**Test plan**

- Open mobile application
- Waith for flipper to sync
- Select random update channel
- Click install
- After downloading/installing started immediatly start reloading/disabling flipper
- See that error now displayed correctly
