### PR TITLE
Fix low resolution of saved screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [FIX] Replace Dispatchers.Default with java's work stealing pool dispatcher
 - [FIX] Fixed wrong error display when turning off flipper during update
 - [FIX] Fixed serialization of ImmutableList in screenshotspreview
+- [FIX] Fixed low resolution of saved screenshots
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/BitmapKtx.kt
+++ b/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/BitmapKtx.kt
@@ -1,0 +1,24 @@
+package com.flipperdevices.core.ktx.android
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+
+object BitmapKtx {
+    fun Bitmap.rescale(scale: Float, filter: Boolean = false): Bitmap {
+        return rescale(scaleX = scale, scaleY = scale, filter = filter)
+    }
+
+    fun Bitmap.rescale(scaleX: Float, scaleY: Float, filter: Boolean = false): Bitmap {
+        val matrix = Matrix()
+        matrix.postScale(scaleX, scaleY)
+        return Bitmap.createBitmap(
+            this,
+            0,
+            0,
+            width,
+            height,
+            matrix,
+            filter
+        )
+    }
+}

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Paint
+import com.flipperdevices.core.ktx.android.BitmapKtx.rescale
 import com.flipperdevices.core.ktx.jre.createClearNewFileWithMkDirs
 import com.flipperdevices.core.share.SharableFile
 import com.flipperdevices.core.share.ShareHelper
@@ -23,6 +24,7 @@ import com.flipperdevices.core.ui.res.R as DesignSystem
 private const val SCREENSHOT_FILE_PREFIX = "flpr"
 private const val TIMEFORMAT = "yyyy-MM-dd-HH:mm:ss"
 private const val QUALITY = 100
+private const val EXPORT_RESCALE_MULTIPLIER = 8f
 
 class UrlImageShareViewModel @Inject constructor(
     private val applicationContext: Context
@@ -69,6 +71,7 @@ class UrlImageShareViewModel @Inject constructor(
     fun shareUrlImage(url: URL) = viewModelScope.launch(Dispatchers.IO) {
         url.decodeBitmap()
             .map { bitmap -> bitmap.fillBackground() }
+            .map { bitmap -> bitmap.rescale(EXPORT_RESCALE_MULTIPLIER) }
             .onSuccess { bitmap -> shareScreenshot(bitmap) }
     }
 }

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.screenstreaming.impl.viewmodel
 import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.Matrix
+import com.flipperdevices.core.ktx.android.BitmapKtx.rescale
 import com.flipperdevices.core.ktx.jre.createClearNewFileWithMkDirs
 import com.flipperdevices.core.share.SharableFile
 import com.flipperdevices.core.share.ShareHelper
@@ -29,7 +30,7 @@ class ScreenshotViewModel @Inject constructor(
     ) = viewModelScope.launch {
         val currentSnapshotState = screenShapshot as? FlipperScreenState.Ready ?: return@launch
         var currentSnapshot = currentSnapshotState.bitmap
-        currentSnapshot = currentSnapshot.rescale()
+        currentSnapshot = currentSnapshot.rescale(EXPORT_RESCALE_MULTIPLIER)
         currentSnapshot = when (screenShapshot.orientation) {
             ScreenOrientationEnum.VERTICAL,
             ScreenOrientationEnum.VERTICAL_FLIP -> currentSnapshot.rotate(angel = 90f)
@@ -45,20 +46,6 @@ class ScreenshotViewModel @Inject constructor(
         }
         ShareHelper.shareFile(application, sharableFile, R.string.screenshot_export_title)
     }
-}
-
-private fun Bitmap.rescale(): Bitmap {
-    val matrix = Matrix()
-    matrix.postScale(EXPORT_RESCALE_MULTIPLIER, EXPORT_RESCALE_MULTIPLIER)
-    return Bitmap.createBitmap(
-        this,
-        0,
-        0,
-        width,
-        height,
-        matrix,
-        false
-    )
 }
 
 private fun Bitmap.rotate(angel: Float): Bitmap {


### PR DESCRIPTION
**Background**

When sharing screenshot on ScreenshotPreview screen it looks like screenshot very blurry. It's actually not blured, but low-resolutioned.

**Changes**

- Created BitmapKtx where rescale operation of bitmap is shared

**Test plan**

- Open flipper apps screenshots screen
- Share a screenshot 
- See screenshot now doesn't looks blurry
