### PR TITLE
Fix unable to save screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [FIX] Replace Dispatchers.Default with java's work stealing pool dispatcher
 - [FIX] Fixed wrong error display when turning off flipper during update
 - [FIX] Fixed serialization of ImmutableList in screenshotspreview
+- [FIX] Fixed wrong format of saved images on screenshotspreview and remote control
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
@@ -21,7 +21,7 @@ import javax.inject.Inject
 import com.flipperdevices.core.ui.res.R as DesignSystem
 
 private const val SCREENSHOT_FILE_PREFIX = "flpr"
-private const val TIMEFORMAT = "yyyy-MM-dd-HH:mm:ss"
+private const val TIMEFORMAT = "yyyy-MM-dd-HH-mm-ss"
 private const val QUALITY = 100
 
 class UrlImageShareViewModel @Inject constructor(

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenshotViewModel.kt
@@ -17,7 +17,7 @@ import java.util.Locale
 import javax.inject.Inject
 
 private const val SCREENSHOT_FILE_PREFIX = "flpr"
-private const val TIMEFORMAT = "yyyy-MM-dd-HH:mm:ss"
+private const val TIMEFORMAT = "yyyy-MM-dd-HH-mm-ss"
 private const val QUALITY = 100
 private const val EXPORT_RESCALE_MULTIPLIER = 8f
 


### PR DESCRIPTION
**Background**

The format of saved files on remote control and screenshots preview can't be saved [via TotalCommander](https://ghisler.ch/board/viewtopic.php?t=52215&start=15) and on some devices with Google Photo

**Changes**

- Fixed format of files just like in `ShareFullInfoFileViewModel` `"yyyy-MM-dd-HH-mm-ss"`

**Test plan**

- Open Remote Control on screenshots preview
- Click share image and save it via TotalCommander
- See now the format is `"yyyy-MM-dd-HH-mm-ss"` and it saved correctly
