### PR TITLE
Fix baseline file path

### DIFF
--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -61,7 +61,7 @@ jobs:
       - id: create_baseline_file_path
         run: |
           build_variant=${{ inputs.BUILD_VARIANT_NAME }}
-          baseline_file_path="./instances/androidApp/src/${build_variant}/generated/baselineProfiles/baseline-prof.txt"
+          baseline_file_path="./instances/android/app/src/${build_variant}/generated/baselineProfiles/baseline-prof.txt"
           echo "BASELINE_FILE_PATH=${baseline_file_path}" >> $GITHUB_OUTPUT
 
       # steps.create_baseline_task.outputs.BASELINE_TASK


### PR DESCRIPTION
**Background**

Fix wrong path for baseline file

**Changes**

- Fixed baseline file path, [example](https://github.com/makeevrserg/Flipper-Android-App/actions/runs/8848621091/job/24301163092)

**Test plan**

- Run ci
