### PR TITLE
Fix/apps hub categories error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [FIX] Fixed low resolution of saved screenshots
 - [FIX] Update sentry gradle to 4.5.1
 - [FIX] Ping-pong request on new ble sample
+- [FIX] Wrong error display on categories screen when no internet connection
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator


### PR DESCRIPTION
**Background**

On categories screen displayed General error when no internet connection

**Changes**

- Add exception into `FapHubNetworkCategoryApi`
- Throw it when `getAll` method called with empty `categories` list

**Test plan**

- Disable internet connection
- Open hub screen
- Open Apps screen
- See that error now displays `No Internet Connection`
