### PR TITLE
Fix filter dev catalog apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [FIX] Ping-pong request on new ble sample
 - [FIX] Potential MD5 collision of keys
 - [FIX] Wrong error display on categories screen when no internet connection
+- [FIX] Manifest dev catalog flag on installed apps
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/faphub/installation/manifest/api/src/main/java/com/flipperdevices/faphub/installation/manifest/model/FapManifestItem.kt
+++ b/components/faphub/installation/manifest/api/src/main/java/com/flipperdevices/faphub/installation/manifest/model/FapManifestItem.kt
@@ -10,5 +10,6 @@ data class FapManifestItem(
     val fullName: String,
     val iconBase64: String?,
     val sdkApi: SemVer?,
-    val sourceFileHash: String? = null
+    val sourceFileHash: String? = null,
+    val isDevCatalog: Boolean
 )

--- a/components/faphub/installation/manifest/impl/build.gradle.kts
+++ b/components/faphub/installation/manifest/impl/build.gradle.kts
@@ -12,6 +12,9 @@ dependencies {
     implementation(projects.components.core.ktx)
     implementation(projects.components.core.data)
     implementation(projects.components.core.log)
+    implementation(projects.components.core.preference)
+
+    implementation(projects.components.settings.api)
 
     implementation(projects.components.faphub.dao.api)
     implementation(projects.components.faphub.utils)

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestParser.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestParser.kt
@@ -18,6 +18,7 @@ private const val FAP_MANIFEST_PATH_KEY = "Path"
 private const val FAP_MANIFEST_FULL_NAME_KEY = "Full Name"
 private const val FAP_MANIFEST_ICON_KEY = "Icon"
 private const val FAP_MANIFEST_API_KEY = "Version Build API"
+private const val FAP_MANIFEST_DEV_CATALOG = "DevCatalog"
 
 class FapManifestParser @Inject constructor() {
     fun parse(fileContent: ByteArray, name: String): FapManifestItem? {
@@ -33,7 +34,8 @@ class FapManifestParser @Inject constructor() {
             fullName = dict[FAP_MANIFEST_FULL_NAME_KEY] ?: applicationAlias,
             iconBase64 = dict[FAP_MANIFEST_ICON_KEY],
             sdkApi = dict[FAP_MANIFEST_API_KEY]?.let { SemVer.fromString(it) },
-            sourceFileHash = fileContent.md5()
+            sourceFileHash = fileContent.md5(),
+            isDevCatalog = dict[FAP_MANIFEST_DEV_CATALOG]?.toBooleanStrictOrNull() ?: false
         )
     }
 
@@ -54,6 +56,8 @@ class FapManifestParser @Inject constructor() {
         orderedDict.add(FAP_MANIFEST_UID_KEY to fapItem.uid)
         orderedDict.add(FAP_MANIFEST_VERSION_UID_KEY to fapItem.versionUid)
         orderedDict.add(FAP_MANIFEST_PATH_KEY to fapItem.path)
+
+        orderedDict.add(FAP_MANIFEST_DEV_CATALOG to fapItem.isDevCatalog.toString())
 
         return FlipperFileFormat(orderedDict)
     }

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestParser.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestParser.kt
@@ -56,8 +56,9 @@ class FapManifestParser @Inject constructor() {
         orderedDict.add(FAP_MANIFEST_UID_KEY to fapItem.uid)
         orderedDict.add(FAP_MANIFEST_VERSION_UID_KEY to fapItem.versionUid)
         orderedDict.add(FAP_MANIFEST_PATH_KEY to fapItem.path)
-
-        orderedDict.add(FAP_MANIFEST_DEV_CATALOG to fapItem.isDevCatalog.toString())
+        if (fapItem.isDevCatalog) {
+            orderedDict.add(FAP_MANIFEST_DEV_CATALOG to fapItem.isDevCatalog.toString())
+        }
 
         return FlipperFileFormat(orderedDict)
     }

--- a/components/faphub/installation/queue/impl/build.gradle.kts
+++ b/components/faphub/installation/queue/impl/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(projects.components.core.ktx)
     implementation(projects.components.core.log)
     implementation(projects.components.core.progress)
+    implementation(projects.components.core.preference)
+
+    implementation(projects.components.settings.api)
 
     implementation(projects.components.faphub.utils)
     implementation(projects.components.faphub.dao.api)

--- a/components/faphub/installation/queue/impl/src/main/java/com/flipperdevices/faphub/installation/queue/impl/executor/InstallationActionExecutor.kt
+++ b/components/faphub/installation/queue/impl/src/main/java/com/flipperdevices/faphub/installation/queue/impl/executor/InstallationActionExecutor.kt
@@ -1,8 +1,10 @@
 package com.flipperdevices.faphub.installation.queue.impl.executor
 
+import androidx.datastore.core.DataStore
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
+import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.core.progress.ProgressListener
 import com.flipperdevices.faphub.dao.api.FapDownloadApi
 import com.flipperdevices.faphub.dao.api.FapNetworkApi
@@ -13,6 +15,7 @@ import com.flipperdevices.faphub.installation.queue.impl.executor.actions.FapAct
 import com.flipperdevices.faphub.installation.queue.impl.executor.actions.FapIconDownloader
 import com.flipperdevices.faphub.target.model.FlipperTarget
 import com.flipperdevices.faphub.utils.FapHubConstants.FLIPPER_APPS_FOLDER
+import kotlinx.coroutines.flow.first
 import java.io.File
 import javax.inject.Inject
 
@@ -20,6 +23,7 @@ class InstallationActionExecutor @Inject constructor(
     fapDownloadApi: FapDownloadApi,
     fapUploadAction: FapActionUpload,
     fapNetworkApi: FapNetworkApi,
+    private val dataStoreSettings: DataStore<Settings>,
     private val fapManifestApi: FapManifestApi,
     private val fapIconDownloader: FapIconDownloader
 ) : PrepareFapActionExecutor(fapDownloadApi, fapUploadAction, fapNetworkApi), LogTagProvider {
@@ -48,7 +52,8 @@ class InstallationActionExecutor @Inject constructor(
                 path = finalFapPath,
                 fullName = request.applicationName,
                 iconBase64 = iconBase64Request.getOrNull(),
-                sdkApi = getSdkApi(request.applicationUid, request.toVersion)
+                sdkApi = getSdkApi(request.applicationUid, request.toVersion),
+                isDevCatalog = dataStoreSettings.data.first().useDevCatalog
             )
         )
         info { "Fap manifest added by request $request" }

--- a/components/faphub/installation/stateprovider/impl/src/test/kotlin/com/flipperdevices/faphub/installation/stateprovider/impl/api/FapInstallationStateManagerImplTest.kt
+++ b/components/faphub/installation/stateprovider/impl/src/test/kotlin/com/flipperdevices/faphub/installation/stateprovider/impl/api/FapInstallationStateManagerImplTest.kt
@@ -65,7 +65,8 @@ private val fapActionRequestUpdateMock = FapActionRequest.Update(
         fullName = "",
         iconBase64 = null,
         sdkApi = null,
-        sourceFileHash = null
+        sourceFileHash = null,
+        isDevCatalog = false
     )
 )
 
@@ -252,7 +253,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = null,
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -289,7 +291,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = null,
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -314,7 +317,8 @@ class FapInstallationStateManagerImplTest {
                     fullName = "",
                     iconBase64 = null,
                     sdkApi = null,
-                    sourceFileHash = null
+                    sourceFileHash = null,
+                    isDevCatalog = false
                 )
             ),
             fapState
@@ -338,7 +342,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = SemVer(32, 1),
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -375,7 +380,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = SemVer(32, 1),
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -412,7 +418,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = SemVer(32, 2),
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -436,7 +443,8 @@ class FapInstallationStateManagerImplTest {
                     fullName = "",
                     iconBase64 = null,
                     sdkApi = SemVer(32, 2),
-                    sourceFileHash = null
+                    sourceFileHash = null,
+                    isDevCatalog = false
                 )
             ),
             fapState
@@ -460,7 +468,8 @@ class FapInstallationStateManagerImplTest {
                         fullName = "",
                         iconBase64 = null,
                         sdkApi = null,
-                        sourceFileHash = null
+                        sourceFileHash = null,
+                        isDevCatalog = false
                     )
                 ),
                 inProgress = false
@@ -484,7 +493,8 @@ class FapInstallationStateManagerImplTest {
                     fullName = "",
                     iconBase64 = null,
                     sdkApi = null,
-                    sourceFileHash = null
+                    sourceFileHash = null,
+                    isDevCatalog = false
                 )
             ),
             fapState

--- a/components/faphub/installedtab/impl/src/test/kotlin/com/flipperdevices/faphub/installedtab/impl/viewmodel/TestManifestBuilder.kt
+++ b/components/faphub/installedtab/impl/src/test/kotlin/com/flipperdevices/faphub/installedtab/impl/viewmodel/TestManifestBuilder.kt
@@ -17,7 +17,8 @@ internal fun getTestManifest(uid: String) = FapManifestItem(
     fullName = "",
     iconBase64 = null,
     sdkApi = null,
-    sourceFileHash = null
+    sourceFileHash = null,
+    isDevCatalog = false
 )
 
 internal fun getTestFapItemShort(uid: String, name: String = "") = FapItemShort(


### PR DESCRIPTION
**Background**

Right now flipper mobile app doesn't filter aps from prod/dev catalog. Because of this, after switching do dev catalog, apps from prod is displayed and vice versa

**Changes**
- Provided changes are the same as in [Flipper-iOS-App](https://github.com/flipperdevices/Flipper-iOS-App/commit/26553e7b7099ff349a631d39993571aa426c19d4)
- Added flag `isDevCatalog` to `FapManifestItem`
- Add filter inside `FapManifestsLoader` for `isDevCatalog`

> [!WARNING]  
> All installed apps which doesn't has a flag of `isDevCatalog` will return `isDevCatalog=false`

**Test plan**

1. [Optionally] delete all other apps for easier testing
2. Turn on usage of dev catalog
3. Install dev catalog apps
4. Turn off dev catalog
5. Open installed apps and see no dev-catalog apps present
6. Repeat steps 2-5 for prod-catalog
