### PR TITLE
Using third-party Github Action Setup Android SDK for baseline profile generation

### DIFF
--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 17
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
       - run: sdkmanager --list
       # Make kvm able to launch emulator
       - name: Enable KVM group perms

--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 17
-
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - run: sdkmanager --list
       # Make kvm able to launch emulator
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 17
-      - run: sdkmanager --list
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
       # Make kvm able to launch emulator
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'ci/try_fix_baseline'
 
 concurrency:
   group: "deploy"

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'dev'
-      - 'ci/try_fix_baseline'
 
 concurrency:
   group: "deploy"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [FIX] Ping-pong request on new ble sample
 - [FIX] Potential MD5 collision of keys
 - [FIX] Wrong error display on categories screen when no internet connection
+- [FIX] Using third-party Github Action Setup Android SDK for baseline profile generation
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/build-logic/plugins/convention/src/main/kotlin/com/flipperdevices/buildlogic/ApkConfig.kt
+++ b/build-logic/plugins/convention/src/main/kotlin/com/flipperdevices/buildlogic/ApkConfig.kt
@@ -6,7 +6,7 @@ object ApkConfig {
     const val APPLICATION_ID = "com.flipperdevices.app"
 
     const val MIN_SDK_VERSION = 26
-    const val TARGET_SDK_VERSION = 33
+    const val TARGET_SDK_VERSION = 34
     const val COMPILE_SDK_VERSION = 34
 
     private const val DEBUG_VERSION = "DEBUG_VERSION"

--- a/build-logic/plugins/convention/src/main/kotlin/com/flipperdevices/buildlogic/ApkConfig.kt
+++ b/build-logic/plugins/convention/src/main/kotlin/com/flipperdevices/buildlogic/ApkConfig.kt
@@ -6,7 +6,12 @@ object ApkConfig {
     const val APPLICATION_ID = "com.flipperdevices.app"
 
     const val MIN_SDK_VERSION = 26
-    const val TARGET_SDK_VERSION = 34
+
+    /**
+     * Don't update until Google Play allows uploading WearOS apps with target sdk greater than 33
+     * https://developer.android.com/google/play/requirements/target-sdk
+     */
+    const val TARGET_SDK_VERSION = 33
     const val COMPILE_SDK_VERSION = 34
 
     private const val DEBUG_VERSION = "DEBUG_VERSION"

--- a/instances/android/baselineprofile/build.gradle.kts
+++ b/instances/android/baselineprofile/build.gradle.kts
@@ -24,8 +24,8 @@ android {
     testOptions.managedDevices.devices {
         create<ManagedVirtualDevice>("pixel6Api31") {
             device = "Pixel 6"
-            apiLevel = 31
-            systemImageSource = "aosp"
+            apiLevel = 34
+            systemImageSource = "aosp-atd"
         }
     }
 }

--- a/instances/android/baselineprofile/build.gradle.kts
+++ b/instances/android/baselineprofile/build.gradle.kts
@@ -24,7 +24,7 @@ android {
     testOptions.managedDevices.devices {
         create<ManagedVirtualDevice>("pixel6Api31") {
             device = "Pixel 6"
-            apiLevel = 34
+            apiLevel = 31
             systemImageSource = "aosp_atd"
         }
     }

--- a/instances/android/baselineprofile/build.gradle.kts
+++ b/instances/android/baselineprofile/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         create<ManagedVirtualDevice>("pixel6Api31") {
             device = "Pixel 6"
             apiLevel = 34
-            systemImageSource = "aosp-atd"
+            systemImageSource = "aosp_atd"
         }
     }
 }


### PR DESCRIPTION
**Background**

Right now we are using the default GitHub Action SDK built in as our Android SDK. This makes our builds unstable and dependent on GitHub release processes. 

**Changes**

- Use https://github.com/android-actions/setup-android for setup android sdk

**Test plan**

See https://github.com/flipperdevices/Flipper-Android-App/actions/runs/8985960551