### PR TITLE
Fix file manager edit file screen padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [FIX] Wrong error display on categories screen when no internet connection
 - [FIX] Using third-party Github Action Setup Android SDK for baseline profile generation
 - [FIX] Manifest dev catalog flag on installed apps
+- [FIX] Fix TopBar above system bar in file manager file edit screen
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/composable/bar/ComposableEditorTopBar.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/composable/bar/ComposableEditorTopBar.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.filemanager.impl.composable.bar
 
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.TopAppBar
@@ -16,7 +17,7 @@ fun ComposableEditorTopBar(
     modifier: Modifier = Modifier
 ) {
     TopAppBar(
-        modifier = modifier,
+        modifier = modifier.statusBarsPadding(),
         title = {
             ComposableEllipsizeStartText(
                 text = path


### PR DESCRIPTION
**Background**

Edit File screen in FileManager currently doesn't have paddings for systembar

**Changes**

- Added system bar padding for Edit File screen on FileManager

**Test plan**

- Open  File manager
- Open some file to edit
- See TopBar now doesn't collapse inside systembar
