### PR TITLE
Fix/text overflow apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [FIX] Settings status bar overflow content
 - [FIX] Fix TopBar above system bar in file manager file edit screen
 - [FIX] Fix custom version detection
+- [FIX] Text overflow on apps card
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/AppCard.kt
+++ b/components/faphub/appcard/composable/src/main/java/com/flipperdevices/faphub/appcard/composable/AppCard.kt
@@ -100,7 +100,9 @@ private fun AppCardTop(
                 modifier = if (fapItem == null) Modifier.placeholderConnecting() else Modifier,
                 text = fapItem?.name ?: DEFAULT_NAME,
                 style = LocalTypography.current.buttonM16,
-                color = LocalPallet.current.text100
+                color = LocalPallet.current.text100,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             ComposableAppCategory(
                 category = fapItem?.category,


### PR DESCRIPTION
**Background**

When there's more than two lines of text, the button will fill entire height

**Changes**

- Add `maxLines=1` as in design

**Test plan**

- Open apps
- Find app with long text
- See that text now has dots instead of next lines
- See that buttons are now the same
