### PR TITLE
Fix/settings statusbar padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [FIX] Wrong error display on categories screen when no internet connection
 - [FIX] Using third-party Github Action Setup Android SDK for baseline profile generation
 - [FIX] Manifest dev catalog flag on installed apps
+- [FIX] Settings status bar overflow content
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
@@ -2,14 +2,19 @@ package com.flipperdevices.settings.impl.composable
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.ktx.OrangeAppBar
@@ -47,45 +52,75 @@ fun ComposableSettings(
     val exportState by settingsViewModel.getExportState().collectAsState()
     val notificationState by notificationViewModel.getNotificationToggleState().collectAsState()
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .background(LocalPallet.current.background),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
-    ) {
-        OrangeAppBar(R.string.options, onBack = onBack)
-        AppCategory(
-            theme = settings.selectedTheme,
-            onSelectTheme = settingsViewModel::onChangeSelectedTheme,
-            notificationState = notificationState,
-            onChangeNotificationState = notificationViewModel::switchToggle
-        )
-        if (settings.expertMode) {
-            DebugCategory(
+    SafeStatusBarBox(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .background(LocalPallet.current.background),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            OrangeAppBar(R.string.options, onBack = onBack)
+            AppCategory(
+                theme = settings.selectedTheme,
+                onSelectTheme = settingsViewModel::onChangeSelectedTheme,
+                notificationState = notificationState,
+                onChangeNotificationState = notificationViewModel::switchToggle
+            )
+            if (settings.expertMode) {
+                DebugCategory(
+                    settings = settings,
+                    onSwitchDebug = settingsViewModel::onSwitchDebug,
+                    onAction = onDebugAction,
+                    onDebugSettingSwitch = debugViewModel::onSwitch
+                )
+            }
+            ExperimentalCategory(
                 settings = settings,
-                onSwitchDebug = settingsViewModel::onSwitchDebug,
-                onAction = onDebugAction,
-                onDebugSettingSwitch = debugViewModel::onSwitch
+                onSwitchExperimental = settingsViewModel::onSwitchExperimental,
+                onOpenFM = { onOpen(SettingsNavigationConfig.FileManager) }
+            )
+            ExportKeysCategory(
+                exportState = exportState,
+                onExport = { settingsViewModel.onMakeExport(context) }
+            )
+            OtherSettingsCategory(
+                s2rInitialized = s2rInitialized,
+                onReportBug = { onOpen(SettingsNavigationConfig.Shake2Report) }
+            )
+            @Suppress("ViewModelForwarding")
+            VersionCategory(
+                onActivateExpertMode = settingsViewModel::onExpertModeActivate,
+                versionViewModel = versionViewModel
             )
         }
-        ExperimentalCategory(
-            settings = settings,
-            onSwitchExperimental = settingsViewModel::onSwitchExperimental,
-            onOpenFM = { onOpen(SettingsNavigationConfig.FileManager) }
-        )
-        ExportKeysCategory(
-            exportState = exportState,
-            onExport = { settingsViewModel.onMakeExport(context) }
-        )
-        OtherSettingsCategory(
-            s2rInitialized = s2rInitialized,
-            onReportBug = { onOpen(SettingsNavigationConfig.Shake2Report) }
-        )
-        @Suppress("ViewModelForwarding")
-        VersionCategory(
-            onActivateExpertMode = settingsViewModel::onExpertModeActivate,
-            versionViewModel = versionViewModel
-        )
+    }
+}
+
+@Composable
+private fun SafeStatusBarBox(
+    modifier: Modifier = Modifier,
+    statusBarColor: Color = LocalPallet.current.accent,
+    backgroundColor: Color = LocalPallet.current.background,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(statusBarColor)
+            .statusBarsPadding()
+            .background(backgroundColor)
+    ) {
+        // Used to fill overflow color on top of StatusBars
+        if (statusBarColor != backgroundColor) {
+            Box(
+                modifier = Modifier
+                    .background(statusBarColor)
+                    .statusBarsPadding()
+                    .fillMaxWidth()
+                    .padding(vertical = 20.dp)
+            )
+        }
+        content.invoke()
     }
 }


### PR DESCRIPTION
**Background**

On settings/options screen Composable doesn't have `statusBarsPaddings`

**Changes**

- Added `SafeStatusBarBox` to handle both overscroll effect and different colors for status bar, background content

**Test plan**

- Open options screen
- Scroll down
- See there's now status bar on top
