### PR TITLE
Fix/mfkey32 initial progress state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [FIX] Text overflow on apps card
 - [FIX] SD Card error on installed screen
 - [FIX] Scrolling of zoomed screenshots in app image preview
+- [FIX] Display MfKey32 loading progress when no keys available 
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/nfc/mfkey32/api/src/main/java/com/flipperdevices/nfc/mfkey32/api/MfKey32Api.kt
+++ b/components/nfc/mfkey32/api/src/main/java/com/flipperdevices/nfc/mfkey32/api/MfKey32Api.kt
@@ -4,6 +4,13 @@ import com.flipperdevices.bridge.api.manager.FlipperRequestApi
 import kotlinx.coroutines.flow.Flow
 
 interface MfKey32Api {
+    /**
+     * Cached value of bruteforce file existing
+     *
+     * This should be updated each [checkBruteforceFileExist]
+     */
+    val isBruteforceFileExist: Boolean
+
     fun hasNotification(): Flow<Boolean>
     suspend fun checkBruteforceFileExist(requestApi: FlipperRequestApi)
 }

--- a/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/api/MfKey32ApiImpl.kt
+++ b/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/api/MfKey32ApiImpl.kt
@@ -16,6 +16,10 @@ import javax.inject.Singleton
 @Singleton
 @ContributesBinding(AppGraph::class, MfKey32Api::class)
 class MfKey32ApiImpl @Inject constructor() : MfKey32Api {
+    private var _isBruteforceFileExist: Boolean = false
+    override val isBruteforceFileExist: Boolean
+        get() = _isBruteforceFileExist
+
     private val hasNotificationFlow = MutableStateFlow(false)
     override fun hasNotification() = hasNotificationFlow
 
@@ -30,8 +34,10 @@ class MfKey32ApiImpl @Inject constructor() : MfKey32Api {
             }.wrapToRequest()
         ).first()
         if (response.hasStorageMd5SumResponse()) {
+            _isBruteforceFileExist = true
             hasNotificationFlow.emit(true)
         } else {
+            _isBruteforceFileExist = false
             hasNotificationFlow.emit(false)
         }
     }

--- a/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
+++ b/components/nfc/mfkey32/screen/src/main/java/com/flipperdevices/nfc/mfkey32/screen/viewmodel/MfKey32ViewModel.kt
@@ -142,6 +142,13 @@ class MfKey32ViewModel @Inject constructor(
 
     private suspend fun prepare(): Boolean {
         info { "Flipper connected" }
+
+        if (flipperStorageApi.listingDirectory(PATH_NONCE_LOG).isEmpty()) {
+            info { "Not found $PATH_NONCE_LOG" }
+            mfKey32StateFlow.emit(MfKey32State.Error(ErrorType.NOT_FOUND_FILE))
+            return false
+        }
+
         mfKey32StateFlow.emit(MfKey32State.DownloadingRawFile(0f))
 
         try {


### PR DESCRIPTION
**Background**

When open NFC Tools -> MIFARE Classic, it will immediately start downloading even if folder is empty

**Changes**

- Ad check for storage content

**Test plan**

- Open Mfkey32 (Detect Reader)
- See that loading now will not start if storage is empty
