### PR TITLE
Fix/in app notification selfupdate paddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [FIX] Wrong error display on categories screen when no internet connection
 - [FIX] Using third-party Github Action Setup Android SDK for baseline profile generation
 - [FIX] Manifest dev catalog flag on installed apps
+- [FIX] Padding for self update in-app notification
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/composable/type/ComposableInAppNotificationSelfUpdateReady.kt
+++ b/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/composable/type/ComposableInAppNotificationSelfUpdateReady.kt
@@ -21,6 +21,7 @@ internal fun ComposableInAppNotificationSelfUpdateReady(
 ) {
     ComposableInAppNotificationBase(
         icon = null,
+        modifier = Modifier.padding(horizontal = 12.dp),
         titleId = R.string.ready_update_title,
         descId = R.string.ready_update_desc,
         actionButton = {


### PR DESCRIPTION
**Background**

In-app notification snackbar doesn't have horizontal paddings

**Changes**

- Add horizontal paddings for  `ComposableInAppNotificationSelfUpdateReady`

**Test plan**

- Mock version of application to see this notification
