### PR TITLE
Fix custom version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [FIX] Padding for self update in-app notification
 - [FIX] Settings status bar overflow content
 - [FIX] Fix TopBar above system bar in file manager file edit screen
+- [FIX] Fix custom version detection
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/api/FirmwareVersionBuilderApi.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/api/FirmwareVersionBuilderApi.kt
@@ -5,5 +5,5 @@ import com.flipperdevices.updater.model.FirmwareVersion
 
 interface FirmwareVersionBuilderApi {
     fun getFirmwareChannel(branch: String): FirmwareChannel
-    fun buildFirmwareVersionFromString(firmwareVersion: String): FirmwareVersion?
+    fun buildFirmwareVersionFromString(firmwareVersion: String): FirmwareVersion
 }

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FirmwareVersionBuilderApiImpl.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FirmwareVersionBuilderApiImpl.kt
@@ -37,10 +37,14 @@ class FirmwareVersionBuilderApiImpl @Inject constructor() : FirmwareVersionBuild
 
     override fun buildFirmwareVersionFromString(
         firmwareVersion: String
-    ): FirmwareVersion? {
+    ): FirmwareVersion {
         val unparsedArray = firmwareVersion.split(" ").filterNot { it.isBlank() }
         if (unparsedArray.size < DEVICE_VERSION_PART_COUNT) {
-            return null
+            return FirmwareVersion(
+                channel = FirmwareChannel.UNKNOWN,
+                version = firmwareVersion,
+                buildDate = null
+            )
         }
         val hash = unparsedArray[DEVICE_VERSION_COMMIT_INDEX]
         val typeVersion = unparsedArray[DEVICE_VERSION_TYPE_INDEX]

--- a/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
+++ b/components/updater/impl/src/test/kotlin/com/flipperdevices/updater/impl/FirmwareVersionBuildHelperTest.kt
@@ -58,7 +58,11 @@ class FirmwareVersionBuildHelperTest(
             ),
             arrayOf(
                 "532082f3 1784 10-07-2022",
-                null
+                FirmwareVersion(
+                    channel = FirmwareChannel.UNKNOWN,
+                    version = "532082f3 1784 10-07-2022",
+                    buildDate = null
+                )
             )
         )
     }


### PR DESCRIPTION
**Background**

Right now we have problems with custom firmware version
![image](https://github.com/flipperdevices/Flipper-Android-App/assets/5871715/23102adf-18ff-4f02-bc3f-8cbd9b40e44d)

**Changes**

Use as version full string which received from Flipper even if this string is unparselable

**Test plan**

Try use custom branch on flipper