### PR TITLE
Fix sd card not mounted display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [FIX] Fix TopBar above system bar in file manager file edit screen
 - [FIX] Fix custom version detection
 - [FIX] Text overflow on apps card
+- [FIX] SD Card error on installed screen
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
@@ -104,6 +104,7 @@ class FapManifestsLoader @AssistedInject constructor(
 
     fun getManifestLoaderState() = manifestLoaderState.asStateFlow()
 
+    @Suppress("LongMethod")
     private suspend fun loadInternal(
         connectionState: ConnectionState,
         storageInformation: FlipperStorageInformation
@@ -118,6 +119,12 @@ class FapManifestsLoader @AssistedInject constructor(
         if (externalStorageStatus == null || externalStorageStatus.data !is StorageStats.Loaded) {
             throw NoSdCardException()
         }
+        manifestLoaderState.emit(
+            FapManifestLoaderState.Loaded(
+                items = persistentListOf(),
+                isLoading = true
+            )
+        )
         info { "Start load manifests" }
         val cacheResult = cacheLoader.loadCache()
         info { "Cache load result is toLoad: ${cacheResult.toLoadNames}, cached: ${cacheResult.cachedNames}" }


### PR DESCRIPTION
**Background**

On Hub->Installed sd card error displayed even if it's loaded. This happens because of long `cacheLoader.loadCache` operation

**Changes**

- Added initial state before `cacheLoader.loadCache` operation

**Test plan**

- Open Hub->Installed
- See SD Card error now does not display as long as before
- Additionaly add more logs ore debug breakpoint into `FapManifestsLoader` to see `NoSdCardException` message
