### PR TITLE
Fix/scroll of zoomed screenshotpreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [FIX] Fix custom version detection
 - [FIX] Text overflow on apps card
 - [FIX] SD Card error on installed screen
+- [FIX] Scrolling of zoomed screenshots in app image preview
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/api/FullScreenScreenshotDecomposeComponentImpl.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/api/FullScreenScreenshotDecomposeComponentImpl.kt
@@ -7,6 +7,7 @@ import com.flipperdevices.core.ui.lifecycle.viewModelWithFactory
 import com.flipperdevices.faphub.screenshotspreview.api.ScreenshotsPreviewDecomposeComponent
 import com.flipperdevices.faphub.screenshotspreview.api.model.ScreenshotsPreviewParam
 import com.flipperdevices.faphub.screenshotspreview.impl.composable.ComposableFullScreenshotScreen
+import com.flipperdevices.faphub.screenshotspreview.impl.viewmodel.ImageSelectViewModel
 import com.flipperdevices.faphub.screenshotspreview.impl.viewmodel.UrlImageShareViewModel
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
 import dagger.assisted.Assisted
@@ -20,6 +21,7 @@ class FullScreenScreenshotDecomposeComponentImpl @AssistedInject constructor(
     @Assisted private val param: ScreenshotsPreviewParam,
     @Assisted private val onBack: DecomposeOnBackParameter,
     private val urlImageShareViewModelProvider: Provider<UrlImageShareViewModel>,
+    private val imageSelectViewModelProvider: Provider<ImageSelectViewModel>,
 ) : ScreenshotsPreviewDecomposeComponent(componentContext) {
 
     @Composable
@@ -28,8 +30,12 @@ class FullScreenScreenshotDecomposeComponentImpl @AssistedInject constructor(
         val urlImageShareViewModel = viewModelWithFactory(null) {
             urlImageShareViewModelProvider.get()
         }
+        val imageSelectViewModel = viewModelWithFactory(null) {
+            imageSelectViewModelProvider.get()
+        }
 
         ComposableFullScreenshotScreen(
+            imageSelectViewModel = imageSelectViewModel,
             urlImageShareViewModel = urlImageShareViewModel,
             onBack = onBack::invoke,
             title = param.title,

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/ComposableFullScreenshotScreen.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/ComposableFullScreenshotScreen.kt
@@ -13,6 +13,7 @@ import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.faphub.screenshotspreview.impl.composable.content.ComposableFullScreenshotAppBar
 import com.flipperdevices.faphub.screenshotspreview.impl.composable.content.ComposableScreenshotsList
 import com.flipperdevices.faphub.screenshotspreview.impl.composable.content.ComposableScreenshotsPager
+import com.flipperdevices.faphub.screenshotspreview.impl.viewmodel.ImageSelectViewModel
 import com.flipperdevices.faphub.screenshotspreview.impl.viewmodel.UrlImageShareViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
@@ -24,7 +25,8 @@ internal fun ComposableFullScreenshotScreen(
     title: String,
     selected: Int,
     screenshots: ImmutableList<String>,
-    urlImageShareViewModel: UrlImageShareViewModel
+    urlImageShareViewModel: UrlImageShareViewModel,
+    imageSelectViewModel: ImageSelectViewModel
 ) {
     val pagerState = rememberPagerState(selected) {
         screenshots.size
@@ -41,13 +43,15 @@ internal fun ComposableFullScreenshotScreen(
             pagerState = pagerState,
             modifier = Modifier
                 .fillMaxSize()
-                .align(Alignment.Center)
+                .align(Alignment.Center),
+            imageSelectViewModel = imageSelectViewModel
         )
 
         ComposableScreenshotsList(
             screenshots = screenshots,
-            pagerState = pagerState,
-            modifier = Modifier.align(Alignment.BottomCenter)
+            currentPage = pagerState.currentPage,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            onImageSelected = imageSelectViewModel::onImageSelected
         )
 
         ComposableFullScreenshotAppBar(
@@ -77,7 +81,8 @@ private fun FullScreenshotScreenPreview() {
             selected = 3,
             urlImageShareViewModel = UrlImageShareViewModel(
                 applicationContext = LocalContext.current.applicationContext
-            )
+            ),
+            imageSelectViewModel = ImageSelectViewModel()
         )
     }
 }

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/content/ComposableScreenshotsList.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/content/ComposableScreenshotsList.kt
@@ -9,18 +9,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.ktx.clickableRipple
 import com.flipperdevices.faphub.appcard.composable.components.ComposableAppScreenshot
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.launch
 
 private const val MAX_SCALE = 1.35f
 private const val MIN_SCALE = 1f
@@ -56,19 +53,19 @@ private fun IndicatorItem(
 @Composable
 internal fun ComposableScreenshotsList(
     screenshots: ImmutableList<String>,
-    pagerState: PagerState,
-    modifier: Modifier = Modifier
+    currentPage: Int,
+    modifier: Modifier = Modifier,
+    onImageSelected: (Int) -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
     val lazyRowState = rememberLazyListState()
-    LaunchedEffect(pagerState.currentPage) {
+    LaunchedEffect(currentPage) {
         val firstVisibleItemIndex = lazyRowState.firstVisibleItemIndex
         val lastVisibleItemIndex = lazyRowState.layoutInfo.visibleItemsInfo
             .lastOrNull()?.index ?: return@LaunchedEffect
-        if (pagerState.currentPage >= lastVisibleItemIndex) {
-            lazyRowState.animateScrollToItem(pagerState.currentPage)
-        } else if (pagerState.currentPage <= firstVisibleItemIndex) {
-            lazyRowState.animateScrollToItem(pagerState.currentPage)
+        if (currentPage >= lastVisibleItemIndex) {
+            lazyRowState.animateScrollToItem(currentPage)
+        } else if (currentPage <= firstVisibleItemIndex) {
+            lazyRowState.animateScrollToItem(currentPage)
         }
     }
     LazyRow(
@@ -80,11 +77,13 @@ internal fun ComposableScreenshotsList(
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         itemsIndexed(screenshots) { index, item ->
+            val isSelected = index == currentPage
             IndicatorItem(
                 screenshotUrl = item,
-                isSelected = index == pagerState.currentPage,
-                onClicked = {
-                    coroutineScope.launch { pagerState.animateScrollToPage(index) }
+                isSelected = isSelected,
+                onClicked = onClicked@{
+                    if (isSelected) return@onClicked
+                    onImageSelected.invoke(index)
                 }
             )
         }

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/content/ComposableScreenshotsPager.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/composable/content/ComposableScreenshotsPager.kt
@@ -6,11 +6,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.faphub.appcard.composable.components.ComposableAppScreenshot
+import com.flipperdevices.faphub.screenshotspreview.impl.viewmodel.ImageSelectViewModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import net.engawapg.lib.zoomable.ScrollGesturePropagation
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
@@ -21,15 +29,31 @@ private const val SIXTEEN_NINE_RATIO = 16f / 9f
 internal fun ComposableScreenshotsPager(
     screenshots: ImmutableList<String>,
     pagerState: PagerState,
-    modifier: Modifier = Modifier
+    imageSelectViewModel: ImageSelectViewModel,
+    modifier: Modifier = Modifier,
 ) {
+    var isScaleEnabled by remember { mutableStateOf(false) }
+
     HorizontalPager(
         state = pagerState,
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        userScrollEnabled = !isScaleEnabled
     ) { index ->
         val screenshotUrl = screenshots[index]
         val zoomState = rememberZoomState()
+        isScaleEnabled = zoomState.scale != 1f
+        LaunchedEffect(imageSelectViewModel) {
+            imageSelectViewModel.eventFlow
+                .onEach { event ->
+                    when (event) {
+                        is ImageSelectViewModel.Event.ImageSelected -> {
+                            zoomState.reset().join()
+                            pagerState.scrollToPage(event.index)
+                        }
+                    }
+                }.launchIn(this)
+        }
         ComposableAppScreenshot(
             modifier = Modifier
                 .fillMaxWidth()
@@ -39,7 +63,7 @@ internal fun ComposableScreenshotsPager(
                 .zoomable(
                     zoomState = zoomState,
                     enableOneFingerZoom = false,
-                    scrollGesturePropagation = ScrollGesturePropagation.NotZoomed
+                    scrollGesturePropagation = ScrollGesturePropagation.ContentEdge
                 ),
             url = screenshotUrl
         )

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/ImageSelectViewModel.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/ImageSelectViewModel.kt
@@ -1,0 +1,24 @@
+package com.flipperdevices.faphub.screenshotspreview.impl.viewmodel
+
+import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class ImageSelectViewModel @Inject constructor() : DecomposeViewModel() {
+    private val eventChannel = Channel<Event>()
+    val eventFlow: Flow<Event> = eventChannel.receiveAsFlow()
+
+    fun onImageSelected(index: Int) {
+        viewModelScope.launch {
+            val event = Event.ImageSelected(index)
+            eventChannel.send(event)
+        }
+    }
+
+    sealed interface Event {
+        class ImageSelected(val index: Int) : Event
+    }
+}


### PR DESCRIPTION
**Background**

When extremely fast scrolling zoomed image just after zoom, the image will be displayed above other image. It also can be reproduced by clicking on bottom image.

**Changes**

- Disable `HorizontalPager` zoom when image is zoomed
- Add ViewModel with events, which will be handled inside ViewPager. It will reset scale and only then swipe pages 

**Test plan**

- Open any screenshot preview screen
- Try zoom and extrmely fast scroll
- See it's now imposible
- Try zoom image and select any other image on bottom list
- See other image displayed without previous image overlay
