### PR TITLE
Fix/markdown code block color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [FIX] Scrolling of zoomed screenshots in app image preview
 - [FIX] Display MfKey32 loading progress when no keys available
 - [FIX] Return baseline profiles
+- [FIX] Markdown code blocks background color
 - [Feature] Add not connected, empty and syncing states to emulation button on key screen
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator

--- a/components/core/markdown/src/main/java/com/flipperdevices/core/markdown/ComposableMarkdown.kt
+++ b/components/core/markdown/src/main/java/com/flipperdevices/core/markdown/ComposableMarkdown.kt
@@ -37,7 +37,7 @@ fun ComposableMarkdown(
 
 @Composable
 fun markdownColors(
-    backgroundCode: Color = LocalPallet.current.text20,
+    backgroundCode: Color = LocalPallet.current.text8,
     text: Color = LocalPallet.current.text100,
     link: Color = LocalPallet.current.accentSecond,
     dividerColor: Color = LocalPallet.current.divider12
@@ -48,7 +48,7 @@ fun markdownColors(
     codeBackground = backgroundCode,
     inlineCodeBackground = backgroundCode,
     dividerColor = dividerColor,
-    inlineCodeText = backgroundCode
+    inlineCodeText = text
 )
 
 @Composable


### PR DESCRIPTION
**Background**

Makrdown code blocks on flipper update screen has wrong colors

**Changes**

- Fixed markdown theme colors

**Test plan**

- Find somewhere in app markdown with code block(for example in flipper update to rc version)
- See that markdown code block now have readeable colors
- Also here's screenshot below
<img width="759" alt="image" src="https://github.com/flipperdevices/Flipper-Android-App/assets/57789105/70b46033-a501-472c-a9c4-429c06206f63">

