### PR TITLE
add github ci PR concurrency cancellation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,30 @@ on:
       - 'dev'
   merge_group:
 
+# Concurrency strategy:
+#   github.workflow: distinguish this workflow from others
+#   github.event_name: distinguish `push` event from `pull_request` event
+#   github.ref_name: distinguish branch
+#   github.repository: distinguish owner+repository
+#
+# Reference:
+#   https://docs.github.com/en/actions/using-jobs/using-concurrency
+#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{github.ref_name}}-${{github.repository}}
+  cancel-in-progress: true
+
+
 jobs:
+  info:
+    name: "Display concurrency info"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "github.workflow=${{ github.workflow }}"
+          echo "github.event_name=${{ github.event_name }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.repository=${{ github.repository }}"
   test:
     name: "Run unit tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -5,6 +5,19 @@ on:
     branches:
       - 'dev'
 
+# Concurrency strategy:
+#   github.workflow: distinguish this workflow from others
+#   github.event_name: distinguish `push` event from `pull_request` event
+#   github.ref_name: distinguish branch
+#   github.repository: distinguish owner+repository
+#
+# Reference:
+#   https://docs.github.com/en/actions/using-jobs/using-concurrency
+#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{github.ref_name}}-${{github.repository}}
+  cancel-in-progress: true
+
 jobs:
   changelog_changes:
     name: "Checking that changelog has changed"

--- a/.github/workflows/pr_gradle.yml
+++ b/.github/workflows/pr_gradle.yml
@@ -9,6 +9,19 @@ on:
       - 'gradle.properties'
   merge_group:
 
+# Concurrency strategy:
+#   github.workflow: distinguish this workflow from others
+#   github.event_name: distinguish `push` event from `pull_request` event
+#   github.ref_name: distinguish branch
+#   github.repository: distinguish owner+repository
+#
+# Reference:
+#   https://docs.github.com/en/actions/using-jobs/using-concurrency
+#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{github.ref_name}}-${{github.repository}}
+  cancel-in-progress: true
+
 jobs:
   release_build:
     name: "Build release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [Feature] Check app exist on apps catalog manifest loading
 - [Feature] First version of device orchestrator
 - [Feature] Add sample for flipper reconnecting
+- [Feature] Cancel previous pipelines on Github CI after push new commits to PR 
 - [Refactor] Use https://github.com/IlyaGulya/anvil-utils to automatically generate and contribute assisted factories.
 - [Refactor] Add test for Progress Tracker logic
 

--- a/test_file
+++ b/test_file
@@ -1,0 +1,1 @@
+test_content

--- a/test_file
+++ b/test_file
@@ -1,1 +1,0 @@
-test_content


### PR DESCRIPTION
**Background**

When creating pull requests and pushing multiple commits one after another, previous pipelines are not cancelld and continue to run, even if they are now useless

**Changes**

- Here added concurrency for pull requests commits
- When new pull request is pushed, the old pipelines of this PR will be cancelled 

**Test plan**

- See this PR
- See after few pushes previous jobs is cancelled
