### PR TITLE
Fix for a vulnerability causing write access to internal application files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.7.1 - In Progress
 
-
+- Fix for a vulnerability causing write access to internal application files
 
 # 1.7.0
 

--- a/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/UriKtx.kt
+++ b/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/UriKtx.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.core.ktx.android
 import android.content.ContentResolver
 import android.net.Uri
 import android.provider.OpenableColumns
+import java.io.File
 import java.io.FileNotFoundException
 
 private const val FILE_DESCRIPTOR_FAILED_SIZE = -1L
@@ -60,10 +61,10 @@ fun Uri.filename(contentResolver: ContentResolver): String? {
     } else {
         null
     }
+    val fileName = nameFromResolver ?: path?.substringAfterLast(File.separatorChar)
 
-    if (nameFromResolver != null) {
-        return nameFromResolver
+    if (fileName != null) {
+        return File(fileName).name // Bypass for path traversal
     }
-
-    return path?.substringAfterLast("/")
+    return null
 }


### PR DESCRIPTION
**Background**

Now we can get write access to the internal files. Now this doesn't give direct access to the user's files, but it serves as a very dangerous step towards potential other vulnerabilities
More info: https://github.com/flipperdevices/Flipper-Android-App/issues/877

**Changes**

- Now the file name is obtained using `File(filename).name`, which eliminates the use of the path traversal vulnerability

**Test plan**

Try run apk from attached issue

Co-authored-by: LiveOverflow <liveoverflow@gmail.com>