### PR TITLE
Enabling Detekt Type Resolution in a project

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
       - name: detekt
         uses: gradle/gradle-build-action@4c39dd82cd5e1ec7c6fa0173bb41b4b6bb3b86ff # v3
         with:
-          arguments: detekt
+          arguments: detektMain
   android_lint:
     name: "Check project by android`s lint"
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # 1.7.2 - In Progress
 
 - [FIX] Distinct fap items by id in paging sources
+- [CI] Add https://github.com/LionZXY/detekt-decompose-rule
+- [CI] Enabling detekt module for android and kmp modules
 
 # 1.7.1
 

--- a/build-logic/plugins/convention/src/main/kotlin/commonAndroid.kt
+++ b/build-logic/plugins/convention/src/main/kotlin/commonAndroid.kt
@@ -105,17 +105,17 @@ private fun Project.suppressOptIn() {
                 jvmTarget = "11"
 
                 freeCompilerArgs = freeCompilerArgs + listOf(
-                    "-Xopt-in=com.google.accompanist.pager.ExperimentalPagerApi",
-                    "-Xopt-in=androidx.compose.ui.ExperimentalComposeUiApi",
-                    "-Xopt-in=androidx.compose.foundation.ExperimentalFoundationApi",
-                    "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi",
-                    "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                    "-Xopt-in=com.squareup.anvil.annotations.ExperimentalAnvilApi",
-                    "-Xopt-in=kotlin.time.ExperimentalTime",
-                    "-Xopt-in=kotlin.RequiresOptIn",
-                    "-Xopt-in=androidx.compose.animation.ExperimentalAnimationApi",
-                    "-Xopt-in=com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi", // ktlint-disable max-line-length
-                    "-Xopt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi"
+                    "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi",
+                    "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",
+                    "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                    "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                    "-opt-in=com.squareup.anvil.annotations.ExperimentalAnvilApi",
+                    "-opt-in=kotlin.time.ExperimentalTime",
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-opt-in=androidx.compose.animation.ExperimentalAnimationApi",
+                    "-opt-in=com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi", // ktlint-disable max-line-length
+                    "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi"
                 )
             }
         }

--- a/build-logic/plugins/convention/src/main/kotlin/flipper.android-app.gradle.kts
+++ b/build-logic/plugins/convention/src/main/kotlin/flipper.android-app.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("io.sentry.android.gradle")
+    id("flipper.lint")
 }
 
 @Suppress("UnstableApiUsage")

--- a/build-logic/plugins/convention/src/main/kotlin/flipper.android-lib.gradle.kts
+++ b/build-logic/plugins/convention/src/main/kotlin/flipper.android-lib.gradle.kts
@@ -3,6 +3,7 @@ import com.android.build.gradle.BaseExtension
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("flipper.lint")
 }
 
 configure<BaseExtension> {

--- a/build-logic/plugins/convention/src/main/kotlin/flipper.lint.gradle.kts
+++ b/build-logic/plugins/convention/src/main/kotlin/flipper.lint.gradle.kts
@@ -41,4 +41,5 @@ dependencies {
     detektPlugins(libs.detekt.ruleset.compiler)
     detektPlugins(libs.detekt.ruleset.ktlint)
     detektPlugins(libs.detekt.ruleset.compose)
+    detektPlugins(libs.detekt.ruleset.decompose)
 }

--- a/build-logic/plugins/convention/src/main/kotlin/flipper.multiplatform-compose.gradle.kts
+++ b/build-logic/plugins/convention/src/main/kotlin/flipper.multiplatform-compose.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("org.jetbrains.compose")
     id("com.android.library")
+    id("flipper.lint")
 }
 
 configure<BaseExtension> {

--- a/build-logic/plugins/convention/src/main/kotlin/flipper.multiplatform.gradle.kts
+++ b/build-logic/plugins/convention/src/main/kotlin/flipper.multiplatform.gradle.kts
@@ -3,6 +3,7 @@ import com.android.build.gradle.BaseExtension
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.library")
+    id("flipper.lint")
 }
 
 configure<BaseExtension> {

--- a/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/components/ComposableCheckBox.kt
+++ b/components/analytics/shake2report/impl/src/main/java/com/flipperdevices/analytics/shake2report/impl/composable/components/ComposableCheckBox.kt
@@ -7,7 +7,7 @@ import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxColors
 import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.LocalMinimumTouchTargetEnforcement
+import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
@@ -28,7 +28,7 @@ internal fun ComposableCheckBox(
     Disable padding for checkbox
     https://stackoverflow.com/a/71609165
      */
-    CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
+    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
         Checkbox(
             checked = checked,
             onCheckedChange = onCheckedChange,

--- a/components/analytics/shake2report/noop/src/main/java/com/flipperdevices/shake2report/noop/Shake2ReportDecomposeComponentStub.kt
+++ b/components/analytics/shake2report/noop/src/main/java/com/flipperdevices/shake2report/noop/Shake2ReportDecomposeComponentStub.kt
@@ -13,6 +13,7 @@ import me.gulya.anvil.assisted.ContributesAssistedFactory
 @Suppress("UnusedPrivateProperty")
 class Shake2ReportDecomposeComponentStub @AssistedInject constructor(
     @Assisted componentContext: ComponentContext,
+    @Suppress("UNUSED_PARAMETER")
     @Assisted onBack: DecomposeOnBackParameter
 ) : Shake2ReportDecomposeComponent(componentContext) {
     @Composable

--- a/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/DeleteViewModel.kt
+++ b/components/archive/category/src/main/java/com/flipperdevices/archive/category/viewmodels/DeleteViewModel.kt
@@ -3,7 +3,6 @@ package com.flipperdevices.archive.category.viewmodels
 import com.flipperdevices.bridge.dao.api.delegates.key.DeleteKeyApi
 import com.flipperdevices.core.ktx.jre.forEachIterable
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -12,7 +11,7 @@ class DeleteViewModel @Inject constructor(
     private val deleteKeyApi: DeleteKeyApi
 ) : DecomposeViewModel() {
     fun onDeleteAll() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             val deletedKeys = deleteKeyApi.getDeletedKeyAsFlow().first()
             deletedKeys.forEachIterable {
                 deleteKeyApi.deleteMarkedDeleted(it.path)
@@ -21,7 +20,7 @@ class DeleteViewModel @Inject constructor(
     }
 
     fun onRestoreAll() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             val deletedKeys = deleteKeyApi.getDeletedKeyAsFlow().first()
             deletedKeys.forEachIterable {
                 deleteKeyApi.restore(it.path)

--- a/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
+++ b/components/archive/search/src/main/java/com/flipperdevices/archive/search/viewmodel/SearchViewModel.kt
@@ -7,6 +7,7 @@ import com.flipperdevices.bridge.synchronization.api.SynchronizationState
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.keyparser.api.KeyParser
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModel @Inject constructor(
     private val utilsKeyApi: UtilsKeyApi,
     private val keyParser: KeyParser,
@@ -23,6 +25,7 @@ class SearchViewModel @Inject constructor(
 ) : DecomposeViewModel() {
     private val queryFlow = MutableStateFlow("")
     private val searchState = MutableStateFlow<SearchState>(SearchState.Loading)
+
     init {
         queryFlow.mapLatest { query ->
             searchState.emit(SearchState.Loading)

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperRequestApi.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperRequestApi.kt
@@ -41,5 +41,5 @@ interface FlipperRequestApi {
     /**
      * Method for connection break debug - put random bytes into session
      */
-    suspend fun sendTrashBytesAndBrokeSession()
+    fun sendTrashBytesAndBrokeSession()
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperRequestApi.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/FlipperRequestApi.kt
@@ -36,7 +36,7 @@ interface FlipperRequestApi {
     /**
      * Contains state about average serial speed
      */
-    suspend fun getSpeed(): StateFlow<FlipperSerialSpeed>
+    fun getSpeed(): StateFlow<FlipperSerialSpeed>
 
     /**
      * Method for connection break debug - put random bytes into session

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/FlipperSerialApi.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/manager/service/FlipperSerialApi.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.StateFlow
 interface FlipperSerialApi {
     fun receiveBytesFlow(): Flow<ByteArray>
     fun sendBytes(data: ByteArray)
-    suspend fun getSpeed(): StateFlow<FlipperSerialSpeed>
+    fun getSpeed(): StateFlow<FlipperSerialSpeed>
 }

--- a/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/scanner/DiscoveredBluetoothDevice.kt
+++ b/components/bridge/api/src/main/java/com/flipperdevices/bridge/api/scanner/DiscoveredBluetoothDevice.kt
@@ -24,7 +24,7 @@ data class DiscoveredBluetoothDevice(
     val name: String? get() = nameInternal
     val rssi: Int get() = rssiInternal
     val highestRssi: Int get() = highestRssiInternal
-    val services: List<UUID> get() = servicesResult?.map { it.uuid } ?: emptyList()
+    val services: List<UUID> get() = servicesResult?.map { it.uuid }.orEmpty()
 
     constructor(scanResult: ScanResult) : this(
         device = scanResult.device,

--- a/components/bridge/connection/config/impl/src/main/kotlin/com/flipperdevices/bridge/connection/config/impl/FDevicePersistedStorageImpl.kt
+++ b/components/bridge/connection/config/impl/src/main/kotlin/com/flipperdevices/bridge/connection/config/impl/FDevicePersistedStorageImpl.kt
@@ -42,7 +42,7 @@ class FDevicePersistedStorageImpl @Inject constructor(
             if (id == null) {
                 builder = builder
                     .clearCurrentSelectedDeviceId()
-            } else if (settings.devicesList.find { it.id == id } == null) {
+            } else if (settings.devicesList.none { it.id == id }) {
                 error("Can't find device with id $id")
             } else {
                 builder = builder
@@ -93,7 +93,8 @@ class FDevicePersistedStorageImpl @Inject constructor(
                 )
             }
 
-            DataCase.DATA_NOT_SET -> null
+            DataCase.DATA_NOT_SET,
+            null -> null
         }
     }
 

--- a/components/bridge/connection/feature/lagsdetector/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/seriallagsdetector/impl/FLagsDetectorFeatureImpl.kt
+++ b/components/bridge/connection/feature/lagsdetector/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/seriallagsdetector/impl/FLagsDetectorFeatureImpl.kt
@@ -33,7 +33,7 @@ class FLagsDetectorFeatureImpl @AssistedInject constructor(
 
     init {
         scope.launch(FlipperDispatchers.workStealingDispatcher) {
-            flipperActionNotifier.getActionFlow().collectLatest { connectionState ->
+            flipperActionNotifier.getActionFlow().collectLatest { _ ->
                 delay(PendingResponseCounter.LAGS_FLIPPER_DETECT_TIMEOUT_MS)
                 if (pendingResponseCounter.hasPendingRequests()) {
                     error {

--- a/components/bridge/connection/feature/lagsdetector/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/seriallagsdetector/impl/PendingResponseCounter.kt
+++ b/components/bridge/connection/feature/lagsdetector/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/seriallagsdetector/impl/PendingResponseCounter.kt
@@ -25,17 +25,17 @@ internal class PendingResponseCounter(
         }
     }
 
-    suspend fun rememberAction(request: FlipperRequest?) {
+    fun rememberAction(request: FlipperRequest?) {
         if (BuildConfig.INTERNAL && request != null) {
             pendingCommands[request] = Unit
         }
-        val tag = request?.javaClass?.simpleName ?: ""
+        val tag = request?.javaClass?.simpleName.orEmpty()
         onAction.invoke()
         val pendingCount = counter.getAndIncrement()
         verbose { "Increase pending response command $tag, current size is ${pendingCount + 1}" }
     }
 
-    suspend fun forgetAction(request: FlipperRequest?) {
+    fun forgetAction(request: FlipperRequest?) {
         if (BuildConfig.INTERNAL && request != null) {
             pendingCommands.remove(request)
         }

--- a/components/bridge/connection/feature/rpc/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/rpc/reader/PeripheralResponseReader.kt
+++ b/components/bridge/connection/feature/rpc/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/rpc/reader/PeripheralResponseReader.kt
@@ -62,8 +62,6 @@ class PeripheralResponseReader @AssistedInject constructor(
                 }
             } catch (ignored: CancellationException) {
                 // ignore
-            } catch (ignored: java.util.concurrent.CancellationException) {
-                // ignore
             } catch (invalidProtocol: InvalidProtocolBufferException) {
                 error(invalidProtocol) { "Broke protocol" }
                 restartRPCApi.restartRpc()

--- a/components/bridge/connection/feature/rpc/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorage.kt
+++ b/components/bridge/connection/feature/rpc/impl/src/main/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorage.kt
@@ -48,7 +48,7 @@ class FRequestStorage @Inject constructor() : LogTagProvider {
         }
     }
 
-    suspend fun getNextRequest(timeout: Long = REQUEST_POOL_TIMEOUT_MS): FlipperRequest? {
+    fun getNextRequest(timeout: Long = REQUEST_POOL_TIMEOUT_MS): FlipperRequest? {
         val request = runCatching {
             queue.poll(timeout, TimeUnit.MILLISECONDS)
         }.getOrNull()

--- a/components/bridge/connection/orchestrator/impl/src/main/kotlin/com/flipperdevices/bridge/connection/ble/impl/FTransportListenerImpl.kt
+++ b/components/bridge/connection/orchestrator/impl/src/main/kotlin/com/flipperdevices/bridge/connection/ble/impl/FTransportListenerImpl.kt
@@ -24,6 +24,7 @@ class FTransportListenerImpl : LogTagProvider {
     fun getState() = state.asStateFlow()
 
     fun onErrorDuringConnect(device: FDeviceBaseModel, throwable: Throwable) {
+        @Suppress("UNUSED_EXPRESSION")
         when (throwable) {
             else -> {
                 error(throwable) { "Unknown error from transport layer" }

--- a/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/ConnectionRootDecomposeComponent.kt
+++ b/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/ConnectionRootDecomposeComponent.kt
@@ -8,6 +8,7 @@ import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.push
+import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.decompose.value.Value
 import com.flipperdevices.bridge.connection.screens.device.ConnectionDeviceScreenDecomposeComponent
 import com.flipperdevices.bridge.connection.screens.models.ConnectionRootConfig
@@ -51,7 +52,7 @@ class ConnectionRootDecomposeComponent @AssistedInject constructor(
         is ConnectionRootConfig.Device ->
             connectionDeviceScreenDecomposeComponentFactory(
                 componentContext = componentContext,
-                onOpenSearch = { navigation.push(ConnectionRootConfig.Search) }
+                onOpenSearch = { navigation.pushToFront(ConnectionRootConfig.Search) }
             )
     }
 

--- a/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/ConnectionRootDecomposeComponent.kt
+++ b/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/ConnectionRootDecomposeComponent.kt
@@ -7,7 +7,6 @@ import androidx.core.content.ContextCompat
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.childStack
-import com.arkivanov.decompose.router.stack.push
 import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.decompose.value.Value
 import com.flipperdevices.bridge.connection.screens.device.ConnectionDeviceScreenDecomposeComponent

--- a/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/device/viewmodel/PingViewModel.kt
+++ b/components/bridge/connection/sample/src/main/kotlin/com/flipperdevices/bridge/connection/screens/device/viewmodel/PingViewModel.kt
@@ -14,6 +14,7 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.system.pingRequest
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -24,9 +25,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class PingViewModel @Inject constructor(
     private val featureProvider: FFeatureProvider,
-    private val orchestrator: FDeviceOrchestrator
+    orchestrator: FDeviceOrchestrator
 ) : DecomposeViewModel() {
     private val logLines = MutableStateFlow(persistentListOf("Init PingViewModel"))
 

--- a/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/api/FBleApiImpl.kt
+++ b/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/api/FBleApiImpl.kt
@@ -23,7 +23,7 @@ open class FBleApiImpl(
         info { "Init ble api listener" }
         client.connectionStateWithStatus
             .filterNotNull()
-            .onEach { (state, status) ->
+            .onEach { (state, _) ->
                 info { "Receive state $state" }
                 statusListener.onStatusUpdate(
                     when (state) {

--- a/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/serial/FSerialOverflowThrottler.kt
+++ b/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/serial/FSerialOverflowThrottler.kt
@@ -44,7 +44,7 @@ class FSerialOverflowThrottler @AssistedInject constructor(
     /**
      * Bytes waiting to be sent to the device
      */
-    private var bufferSizeState = MutableSharedFlow<Int>(replay = 1)
+    private val bufferSizeState = MutableSharedFlow<Int>(replay = 1)
 
     init {
         scope.launch {

--- a/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/serial/SpeedMeter.kt
+++ b/components/bridge/connection/transport/ble/impl/src/main/kotlin/com/flipperdevices/bridge/connection/transport/ble/impl/serial/SpeedMeter.kt
@@ -15,7 +15,7 @@ private const val DELAY_MS = 1000L
 
 class SpeedMeter(scope: CoroutineScope) {
     private val bytesPerSecond = MutableStateFlow(0L)
-    private var bytesCollected = AtomicLong(0)
+    private val bytesCollected = AtomicLong(0)
 
     init {
         scope.launch(FlipperDispatchers.workStealingDispatcher) {

--- a/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/delegates/FavoriteApi.kt
+++ b/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/delegates/FavoriteApi.kt
@@ -11,7 +11,7 @@ interface FavoriteApi {
 
     suspend fun setFavorite(keyPath: FlipperKeyPath, isFavorite: Boolean)
 
-    suspend fun getFavoritesFlow(): Flow<List<FlipperKey>>
+    fun getFavoritesFlow(): Flow<List<FlipperKey>>
 
     suspend fun getFavorites(): List<FlipperKey>
 }

--- a/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperFilePath.kt
+++ b/components/bridge/dao/api/src/main/java/com/flipperdevices/bridge/dao/api/model/FlipperFilePath.kt
@@ -51,7 +51,7 @@ data class FlipperFilePath(
         nameWithExtension.substringAfterLast('/').substringBeforeLast(".")
     }
 
-    fun getPathOnFlipper() = File(FLIPPER_STORAGE_NAME, pathToKey).path
+    fun getPathOnFlipper(): String = File(FLIPPER_STORAGE_NAME, pathToKey).path
 
     override fun toString() = pathToKey
 

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/WidgetDataApiImpl.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/WidgetDataApiImpl.kt
@@ -12,9 +12,9 @@ import com.flipperdevices.bridge.dao.impl.repository.WidgetDataDao
 import com.flipperdevices.bridge.dao.impl.repository.key.SimpleKeyDao
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
@@ -31,7 +31,7 @@ class WidgetDataApiImpl @Inject constructor(
     private val simpleKeyDao by simpleKeyDaoProvider
     private val appDatabase by appDatabaseProvider
 
-    override suspend fun getAll(): List<WidgetData> = withContext(Dispatchers.IO) {
+    override suspend fun getAll(): List<WidgetData> = withContext(FlipperDispatchers.workStealingDispatcher) {
         return@withContext widgetDataDao.getAll().map { element ->
             val keyPath = if (element.keyId != null) {
                 simpleKeyDao.getById(element.keyId)?.getFlipperKeyPath()
@@ -44,7 +44,7 @@ class WidgetDataApiImpl @Inject constructor(
 
     override suspend fun getWidgetDataByWidgetId(
         widgetId: Int
-    ): WidgetData? = withContext(Dispatchers.IO) {
+    ): WidgetData? = withContext(FlipperDispatchers.workStealingDispatcher) {
         val widgetDataElement = widgetDataDao.getWidgetDataById(widgetId)
             ?: return@withContext null
         val keyPath = if (widgetDataElement.keyId != null) {
@@ -58,7 +58,7 @@ class WidgetDataApiImpl @Inject constructor(
     override suspend fun updateTypeForWidget(
         widgetId: Int,
         type: WidgetType
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         appDatabase.withTransaction {
             val widgetData = widgetDataDao.getWidgetDataById(widgetId)
 
@@ -77,7 +77,7 @@ class WidgetDataApiImpl @Inject constructor(
     override suspend fun updateKeyForWidget(
         widgetId: Int,
         flipperKeyPath: FlipperKeyPath
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         appDatabase.withTransaction {
             val key = simpleKeyDao.getByPath(
                 flipperKeyPath.path.pathToKey,

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/SimpleKeyApiImpl.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/SimpleKeyApiImpl.kt
@@ -12,9 +12,9 @@ import com.flipperdevices.bridge.dao.impl.repository.AdditionalFileDao
 import com.flipperdevices.bridge.dao.impl.repository.key.SimpleKeyDao
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -33,7 +33,7 @@ class SimpleKeyApiImpl @Inject constructor(
 
     override suspend fun getAllKeys(
         includeDeleted: Boolean
-    ): List<FlipperKey> = withContext(Dispatchers.IO) {
+    ): List<FlipperKey> = withContext(FlipperDispatchers.workStealingDispatcher) {
         return@withContext if (includeDeleted) {
             simpleKeyDao.getAllIncludeDeleted()
         } else {
@@ -43,7 +43,7 @@ class SimpleKeyApiImpl @Inject constructor(
 
     override suspend fun getExistKeys(
         fileType: FlipperKeyType?
-    ): List<FlipperKey> = withContext(Dispatchers.IO) {
+    ): List<FlipperKey> = withContext(FlipperDispatchers.workStealingDispatcher) {
         return@withContext if (fileType == null) {
             simpleKeyDao.getAll()
         } else {
@@ -70,7 +70,7 @@ class SimpleKeyApiImpl @Inject constructor(
         }
     }
 
-    override suspend fun insertKey(key: FlipperKey) = withContext(Dispatchers.IO) {
+    override suspend fun insertKey(key: FlipperKey) = withContext(FlipperDispatchers.workStealingDispatcher) {
         simpleKeyDao.insert(key.toDatabaseKey())
     }
 
@@ -82,7 +82,7 @@ class SimpleKeyApiImpl @Inject constructor(
 
     override suspend fun getKey(
         keyPath: FlipperKeyPath
-    ): FlipperKey? = withContext(Dispatchers.IO) {
+    ): FlipperKey? = withContext(FlipperDispatchers.workStealingDispatcher) {
         return@withContext simpleKeyDao.getByPath(keyPath.path.pathToKey, keyPath.deleted)
             ?.toFlipperKey(additionalFileDao)
     }

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/UpdateKeyApiImpl.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/UpdateKeyApiImpl.kt
@@ -12,10 +12,10 @@ import com.flipperdevices.bridge.dao.impl.model.SynchronizedStatus
 import com.flipperdevices.bridge.dao.impl.repository.key.SimpleKeyDao
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.withFirstElement
 import com.flipperdevices.core.log.LogTagProvider
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
@@ -53,7 +53,7 @@ class UpdateKeyApiImpl @Inject constructor(
     override suspend fun updateKey(
         oldKey: FlipperKey,
         newKey: FlipperKey
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (oldKey == newKey) return@withContext
 
         val isShouldSynchronize = isShouldSynchronize(oldKey, newKey)

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/UtilsKeyApiImpl.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/api/key/UtilsKeyApiImpl.kt
@@ -11,10 +11,10 @@ import com.flipperdevices.bridge.dao.impl.repository.AdditionalFileDao
 import com.flipperdevices.bridge.dao.impl.repository.key.UtilsKeyDao
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.provideDelegate
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -35,7 +35,7 @@ class UtilsKeyApiImpl @Inject constructor(
 
     override suspend fun markAsSynchronized(
         keyPath: FlipperKeyPath
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         utilsKeyDao.markSynchronized(
             keyPath.path.pathToKey,
             keyPath.deleted,
@@ -46,7 +46,7 @@ class UtilsKeyApiImpl @Inject constructor(
     override suspend fun updateNote(
         keyPath: FlipperKeyPath,
         note: String
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         utilsKeyDao.updateNote(keyPath.path.pathToKey, keyPath.deleted, note)
     }
 

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/comparator/DefaultFileComparator.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/comparator/DefaultFileComparator.kt
@@ -1,8 +1,8 @@
 package com.flipperdevices.bridge.dao.impl.comparator
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import javax.inject.Inject
@@ -12,7 +12,7 @@ class DefaultFileComparator @Inject constructor() : FileComparator {
     override suspend fun isSameContent(
         istream1: InputStream,
         istream2: InputStream
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Boolean = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (istream1.available() == 0 && istream2.available() == 0) return@withContext true
         if (istream1.available() == 0 || istream2.available() == 0) return@withContext false
         if (istream1.available() != istream2.available()) {

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/comparator/FileComparatorExt.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/comparator/FileComparatorExt.kt
@@ -1,6 +1,6 @@
 package com.flipperdevices.bridge.dao.impl.comparator
 
-import kotlinx.coroutines.Dispatchers
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.nio.file.Files
@@ -14,7 +14,7 @@ object FileComparatorExt {
     suspend fun FileComparator.isSameContent(
         file1: File,
         file2: File
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Boolean = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (!file1.exists() && !file2.exists()) return@withContext true
         if (!file1.exists() || !file2.exists()) return@withContext false
         if (Files.size(file1.toPath()) != Files.size(file2.toPath())) {

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/model/FlipperAdditionalFile.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/model/FlipperAdditionalFile.kt
@@ -34,6 +34,6 @@ data class FlipperAdditionalFile(
     val filePath: FlipperFilePath
         get() {
             val file = File(path)
-            return FlipperFilePath(file.parent ?: "", file.name)
+            return FlipperFilePath(file.parent.orEmpty(), file.name)
         }
 }

--- a/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/model/Key.kt
+++ b/components/bridge/dao/impl/src/main/java/com/flipperdevices/bridge/dao/impl/model/Key.kt
@@ -35,6 +35,6 @@ data class Key(
         get() {
             val pathNotNull = path
             val file = File(pathNotNull)
-            return FlipperFilePath(file.parent ?: "", file.name)
+            return FlipperFilePath(file.parent.orEmpty(), file.name)
         }
 }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/FlipperBleManagerImpl.kt
@@ -171,11 +171,11 @@ class FlipperBleManagerImpl @Inject constructor(
             error(it) { "Error while initialize RTC" }
         }
 
-        flipperReadyListeners.forEach {
+        flipperReadyListeners.forEach { listener ->
             runCatching {
-                it.onFlipperReady(scope)
-            }.onFailure {
-                error(it) { "Failed notify flipper ready listener" }
+                listener.onFlipperReady(scope)
+            }.onFailure { error ->
+                error(error) { "Failed notify flipper ready listener" }
             }
         }
 

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/PeripheralResponseReader.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/PeripheralResponseReader.kt
@@ -70,8 +70,6 @@ class PeripheralResponseReader(
                 }
             } catch (ignored: CancellationException) {
                 // ignore
-            } catch (ignored: java.util.concurrent.CancellationException) {
-                // ignore
             } catch (invalidProtocol: InvalidProtocolBufferException) {
                 error(invalidProtocol) { "Broke protocol" }
                 restartRPCApi.restartRpc()

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/overflow/FlipperSerialOverflowThrottler.kt
@@ -43,7 +43,7 @@ class FlipperSerialOverflowThrottler(
     /**
      * Bytes waiting to be sent to the device
      */
-    private var bufferSizeState = MutableSharedFlow<Int>(replay = 1)
+    private val bufferSizeState = MutableSharedFlow<Int>(replay = 1)
 
     override fun onServiceReceived(gatt: BluetoothGatt): Boolean {
         val service = getServiceOrLog(gatt, Constants.BLESerialService.SERVICE_UUID) ?: return false
@@ -124,7 +124,7 @@ class FlipperSerialOverflowThrottler(
     }
 
     @Suppress("MagicNumber")
-    suspend fun sendTrashBytesAndBrokeSession() {
+    fun sendTrashBytesAndBrokeSession() {
         val randomBytes = byteArrayOf(-61, 91, 69, 107, -128, -69, -42, 107, 53, -102)
         serialApi.sendBytes(randomBytes)
     }

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/FlipperInformationApiImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/FlipperInformationApiImpl.kt
@@ -39,7 +39,7 @@ class FlipperInformationApiImpl @Inject constructor(
 ) : BluetoothGattServiceWrapper, FlipperInformationApi, LogTagProvider {
     override val TAG = "FlipperInformationApi"
     private val informationState = MutableStateFlow(FlipperGATTInformation())
-    private var infoCharacteristics = mutableMapOf<UUID, BluetoothGattCharacteristic>()
+    private val infoCharacteristics = mutableMapOf<UUID, BluetoothGattCharacteristic>()
 
     private val scope by scopeProvider
     private val metricApi by metricApiProvider

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
@@ -72,7 +72,7 @@ class FlipperRequestApiImpl @Inject constructor(
     private val sentryApi by sentryApiProvider
 
     // Start from 1 because 0 is default in protobuf
-    private var idCounter = AtomicInteger(1)
+    private val idCounter = AtomicInteger(1)
     private val requestListeners = ConcurrentHashMap<Int, OnReceiveResponse>()
     private val notificationMutableFlow = MutableSharedFlow<Flipper.Main>()
 
@@ -208,7 +208,9 @@ class FlipperRequestApiImpl @Inject constructor(
         }
 
         cont.invokeOnCancellation {
-            requestStorage.removeIf { it.data.commandId == uniqueId }
+            requestStorage.removeIf { request ->
+                request.data.commandId == uniqueId
+            }
             requestListeners.remove(uniqueId)
         }
     }
@@ -254,7 +256,7 @@ class FlipperRequestApiImpl @Inject constructor(
         info { "Complete reset and finish $counter tasks" }
     }
 
-    override suspend fun sendTrashBytesAndBrokeSession() {
+    override fun sendTrashBytesAndBrokeSession() {
         serialApi.sendTrashBytesAndBrokeSession()
     }
 

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperRequestApiImpl.kt
@@ -29,6 +29,7 @@ import com.flipperdevices.protobuf.copy
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.shake2report.api.Shake2ReportApi
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
@@ -173,7 +174,7 @@ class FlipperRequestApiImpl @Inject constructor(
         requestStorage.sendRequest(*commands)
     }
 
-    override suspend fun getSpeed(): StateFlow<FlipperSerialSpeed> {
+    override fun getSpeed(): StateFlow<FlipperSerialSpeed> {
         return serialApiUnsafe.getSpeed()
     }
 
@@ -195,6 +196,7 @@ class FlipperRequestApiImpl @Inject constructor(
         return counter
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun awaitCommandAnswer(
         uniqueId: Int
     ): Flipper.Main = suspendCancellableCoroutine { cont ->

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperSerialApiUnsafeImpl.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/manager/service/request/FlipperSerialApiUnsafeImpl.kt
@@ -94,7 +94,7 @@ class FlipperSerialApiUnsafeImpl(
     }
 
     override fun receiveBytesFlow() = receiveBytesFlow
-    override suspend fun getSpeed() = speedFlowState.asStateFlow()
+    override fun getSpeed() = speedFlowState.asStateFlow()
 
     override fun sendBytes(data: ByteArray) {
         if (data.isEmpty()) {

--- a/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/SpeedMeter.kt
+++ b/components/bridge/impl/src/main/java/com/flipperdevices/bridge/impl/utils/SpeedMeter.kt
@@ -15,7 +15,7 @@ private const val MS_IN_SEC = 1000L
 
 class SpeedMeter(scope: CoroutineScope) {
     private val bytesPerSecond = MutableStateFlow(0L)
-    private var bytesCollected = AtomicLong(0)
+    private val bytesCollected = AtomicLong(0)
 
     init {
         scope.launch(FlipperDispatchers.workStealingDispatcher) {

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/delegate/FlipperLagsDetectorImpl.kt
@@ -87,7 +87,7 @@ class FlipperLagsDetectorImpl @Inject constructor(
         if (BuildConfig.INTERNAL && request != null) {
             pendingCommands[request] = Unit
         }
-        incrementPendingCounter(request?.javaClass?.simpleName ?: "")
+        incrementPendingCounter(request?.javaClass?.simpleName.orEmpty())
         val result = try {
             block()
         } finally {
@@ -105,7 +105,7 @@ class FlipperLagsDetectorImpl @Inject constructor(
             if (BuildConfig.INTERNAL && request != null) {
                 pendingCommands[request] = Unit
             }
-            incrementPendingCounter(request?.javaClass?.simpleName ?: "")
+            incrementPendingCounter(request?.javaClass?.simpleName.orEmpty())
         }.onEach {
             flipperActionNotifier.notifyAboutAction()
         }.onCompletion {
@@ -117,7 +117,7 @@ class FlipperLagsDetectorImpl @Inject constructor(
         }
     }
 
-    private suspend fun incrementPendingCounter(tag: String) {
+    private fun incrementPendingCounter(tag: String) {
         flipperActionNotifier.notifyAboutAction()
         val pendingCount = pendingResponseCounter.getAndIncrement()
         verbose { "Increase pending response command $tag, current size is ${pendingCount + 1}" }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/provider/FlipperServiceProviderImpl.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/provider/FlipperServiceProviderImpl.kt
@@ -20,6 +20,7 @@ import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.preference.pb.Settings
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -83,6 +84,7 @@ class FlipperServiceProviderImpl @Inject constructor(
             lateinit var consumer: FlipperBleServiceConsumer
             consumer = object : FlipperBleServiceConsumer {
                 override fun onServiceApiReady(serviceApi: FlipperServiceApi) {
+                    @OptIn(ExperimentalCoroutinesApi::class)
                     continuation.resume(serviceApi, onCancellation = {
                         disconnectInternal(consumer)
                     })

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/executor/DiffKeyExecutor.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/executor/DiffKeyExecutor.kt
@@ -63,7 +63,11 @@ class DiffKeyExecutorImpl @Inject constructor() : DiffKeyExecutor, LogTagProvide
     ) {
         val path = diff.newHash.keyPath
         val folder = when (path.fileType) {
-            FlipperFileType.KEY -> path.keyType!!.flipperDir
+            FlipperFileType.KEY -> {
+                @Suppress("UnsafeCallOnNullableType")
+                path.keyType!!.flipperDir
+            }
+
             FlipperFileType.SHADOW_NFC -> FlipperKeyType.NFC.flipperDir
             FlipperFileType.OTHER -> error("Don't support file with this type")
         }
@@ -77,10 +81,12 @@ class DiffKeyExecutorImpl @Inject constructor() : DiffKeyExecutor, LogTagProvide
                 val content = source.loadFile(path)
                 target.saveFile(targetPath, content)
             }
+
             KeyAction.MODIFIED -> {
                 val content = source.loadFile(path)
                 target.modify(targetPath, content)
             }
+
             KeyAction.DELETED -> target.deleteFile(targetPath)
         }
     }

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/model/KeyWithHash.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/model/KeyWithHash.kt
@@ -1,10 +1,12 @@
 package com.flipperdevices.bridge.synchronization.impl.model
 
 import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class KeyWithHash(
     @JsonNames("keyPath")

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/flipper/FlipperFavoritesRepository.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/flipper/FlipperFavoritesRepository.kt
@@ -7,11 +7,10 @@ import com.flipperdevices.bridge.synchronization.impl.di.TaskGraph
 import com.flipperdevices.bridge.synchronization.impl.executor.FlipperKeyStorage
 import com.flipperdevices.bridge.synchronization.impl.model.KeyAction
 import com.flipperdevices.bridge.synchronization.impl.model.KeyDiff
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.ExperimentalSerializationApi
 import java.nio.charset.Charset
 import javax.inject.Inject
 
@@ -49,7 +48,7 @@ class FlipperFavoritesRepositoryImpl @Inject constructor() :
 
     private suspend fun getFavoritesFromFlipper(
         flipperKeyStorage: FlipperKeyStorage
-    ): List<String> = withContext(Dispatchers.IO) {
+    ): List<String> = withContext(FlipperDispatchers.workStealingDispatcher) {
         val favoritesFile = flipperKeyStorage.loadFile(
             FAVORITES_PATH
         ).openStream().use {

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/flipper/FlipperFavoritesRepository.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/flipper/FlipperFavoritesRepository.kt
@@ -11,6 +11,7 @@ import com.flipperdevices.core.log.LogTagProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
 import java.nio.charset.Charset
 import javax.inject.Inject
 

--- a/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/manifest/ManifestStorage.kt
+++ b/components/bridge/synchronization/impl/src/main/java/com/flipperdevices/bridge/synchronization/impl/repository/manifest/ManifestStorage.kt
@@ -13,6 +13,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
@@ -47,6 +48,7 @@ class ManifestStorageImpl @Inject constructor(
         return@withLockResult loadInternal()
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     private suspend fun saveInternal(manifestFile: ManifestFile) = withContext(Dispatchers.IO) {
         file.delete()
         var os: FileOutputStream? = null

--- a/components/changelog/impl/src/main/kotlin/com/flipperdevices/changelog/impl/api/ChangelogScreenDecomposeComponentImpl.kt
+++ b/components/changelog/impl/src/main/kotlin/com/flipperdevices/changelog/impl/api/ChangelogScreenDecomposeComponentImpl.kt
@@ -46,7 +46,8 @@ class ChangelogScreenDecomposeComponentImpl @AssistedInject constructor(
         val settings = runBlocking { dataStore.data.first() }
         return when (settings.selectedTheme) {
             SelectedTheme.SYSTEM,
-            SelectedTheme.UNRECOGNIZED -> systemIsDark
+            SelectedTheme.UNRECOGNIZED,
+            null -> systemIsDark
 
             SelectedTheme.DARK -> true
             SelectedTheme.LIGHT -> false

--- a/components/core/ktx/src/jvmSharedMain/kotlin/com/flipperdevices/core/ktx/jre/MD5Ktx.kt
+++ b/components/core/ktx/src/jvmSharedMain/kotlin/com/flipperdevices/core/ktx/jre/MD5Ktx.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.core.ktx.jre
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.math.BigInteger
@@ -14,7 +13,7 @@ private const val BIG_INTEGER_POSITIVE_NUMBER = 1
 /**
  * Calculate md5 and _close_ stream
  */
-suspend fun InputStream.md5(): String = withContext(Dispatchers.IO) {
+suspend fun InputStream.md5(): String = withContext(FlipperDispatchers.workStealingDispatcher) {
     use { stream ->
         val encoder = MessageDigest.getInstance(MD5_NAME)
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)

--- a/components/core/ktx/src/jvmSharedMain/kotlin/com/flipperdevices/core/ktx/jre/StreamKtx.kt
+++ b/components/core/ktx/src/jvmSharedMain/kotlin/com/flipperdevices/core/ktx/jre/StreamKtx.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.core.ktx.jre
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.io.OutputStream
@@ -14,7 +13,7 @@ suspend fun InputStream.copyTo(
     out: OutputStream,
     bufferSize: Int = DEFAULT_BUFFER_SIZE,
     onProcessed: suspend (Long) -> Unit
-): Long = withContext(Dispatchers.IO) {
+): Long = withContext(FlipperDispatchers.workStealingDispatcher) {
     var bytesCopied: Long = 0
     val buffer = ByteArray(bufferSize)
     var bytes = read(buffer)

--- a/components/core/ui/hexkeyboard/src/main/kotlin/com/flipperdevices/core/ui/hexkeyboard/ComposableHexKeyboard.kt
+++ b/components/core/ui/hexkeyboard/src/main/kotlin/com/flipperdevices/core/ui/hexkeyboard/ComposableHexKeyboard.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -88,7 +89,7 @@ internal fun ComposableKey(
         val text = key.title.toString()
         when (key) {
             HexKey.Clear -> Icon(
-                imageVector = Icons.Filled.ArrowBack,
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = text
             )
             HexKey.Ok -> Text(text = "OK")

--- a/components/core/ui/ktx/src/main/java/com/flipperdevices/core/ui/ktx/PlaceholderKtx.kt
+++ b/components/core/ui/ktx/src/main/java/com/flipperdevices/core/ui/ktx/PlaceholderKtx.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.theme.LocalPallet
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.placeholder
-import com.google.accompanist.placeholder.shimmer
+import io.github.fornewid.placeholder.foundation.PlaceholderHighlight
+import io.github.fornewid.placeholder.foundation.placeholder
+import io.github.fornewid.placeholder.foundation.shimmer
 
 @Suppress("ModifierComposed") // MOB-1039
 fun Modifier.placeholderConnecting(shape: Int = 4) = composed {

--- a/components/core/ui/ktx/src/main/java/com/flipperdevices/core/ui/ktx/sweep/RotatableSweepShader.kt
+++ b/components/core/ui/ktx/src/main/java/com/flipperdevices/core/ui/ktx/sweep/RotatableSweepShader.kt
@@ -13,7 +13,7 @@ class RotatableSweepShader(
     colorsSteps: FloatArray?,
     angel: Float
 ) : SweepGradient(centerX, centerY, colorsInt, colorsSteps) {
-    private var gradientMatrix = Matrix()
+    private val gradientMatrix = Matrix()
 
     init {
         gradientMatrix.postRotate(angel, centerX, centerY)

--- a/components/debug/stresstest/src/main/java/com/flipperdevices/debug/stresstest/viewmodel/StressTestViewModel.kt
+++ b/components/debug/stresstest/src/main/java/com/flipperdevices/debug/stresstest/viewmodel/StressTestViewModel.kt
@@ -23,7 +23,6 @@ import com.google.protobuf.ByteString
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -105,7 +104,7 @@ class StressTestViewModel @Inject constructor(
 
     private suspend fun removeTemporaryFile(
         requestApi: FlipperRequestApi
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         requestApi.request(
             main {
                 storageDeleteRequest = deleteRequest {
@@ -116,7 +115,7 @@ class StressTestViewModel @Inject constructor(
         writeToLog("Remove $TEST_FILE")
     }
 
-    private suspend fun fillBuffer() = withContext(Dispatchers.IO) {
+    private suspend fun fillBuffer() = withContext(FlipperDispatchers.workStealingDispatcher) {
         byteBuffer = Random.nextBytes(byteBuffer)
     }
 
@@ -154,7 +153,7 @@ class StressTestViewModel @Inject constructor(
 
     private suspend fun receiveBufferFromFileAndCheck(
         requestApi: FlipperRequestApi
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         val receiveBytes = ByteBuffer.allocate(byteBuffer.size)
         var bytesCount = 0L
         requestApi.request(

--- a/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFileUriCopy.kt
+++ b/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFileUriCopy.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.android.filename
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.deeplink.api.DeepLinkParserDelegate
@@ -13,7 +14,6 @@ import com.flipperdevices.deeplink.model.DeepLinkParserDelegatePriority
 import com.flipperdevices.deeplink.model.Deeplink
 import com.flipperdevices.deeplink.model.DeeplinkContent
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
@@ -51,7 +51,7 @@ class DeepLinkFileUriCopy @Inject constructor() : DeepLinkParserDelegate, LogTag
         contentResolver: ContentResolver,
         cacheDir: File,
         uri: Uri
-    ): DeeplinkContent? = withContext(Dispatchers.IO) {
+    ): DeeplinkContent? = withContext(FlipperDispatchers.workStealingDispatcher) {
         val filename = uri.filename(contentResolver) ?: System.currentTimeMillis().toString()
         val temporaryFile = File(cacheDir, filename)
         if (temporaryFile.exists()) {

--- a/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFileUriGrantPermission.kt
+++ b/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFileUriGrantPermission.kt
@@ -7,12 +7,12 @@ import android.net.Uri
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.android.filename
 import com.flipperdevices.core.ktx.android.length
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.deeplink.api.DeepLinkParserDelegate
 import com.flipperdevices.deeplink.model.DeepLinkParserDelegatePriority
 import com.flipperdevices.deeplink.model.Deeplink
 import com.flipperdevices.deeplink.model.DeeplinkContent
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -48,7 +48,7 @@ class DeepLinkFileUriGrantPermission @Inject constructor() : DeepLinkParserDeleg
     private suspend fun buildExternalUri(
         contentResolver: ContentResolver,
         uri: Uri
-    ): DeeplinkContent = withContext(Dispatchers.IO) {
+    ): DeeplinkContent = withContext(FlipperDispatchers.workStealingDispatcher) {
         return@withContext DeeplinkContent.ExternalUri(
             filename = uri.filename(contentResolver),
             size = uri.length(contentResolver),

--- a/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFlipperFormatSharing.kt
+++ b/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkFlipperFormatSharing.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.deeplink.api.DeepLinkParserDelegate
 import com.flipperdevices.deeplink.impl.utils.Constants
@@ -13,7 +14,6 @@ import com.flipperdevices.deeplink.model.Deeplink
 import com.flipperdevices.deeplink.model.DeeplinkContent
 import com.flipperdevices.keyparser.api.KeyParser
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URLDecoder
 import javax.inject.Inject
@@ -47,7 +47,7 @@ class DeepLinkFlipperFormatSharing @Inject constructor(
 
         if (pureUri.scheme == SCHEME_FLIPPERKEY) {
             val query = pureUri.query
-            val decodedQuery = withContext(Dispatchers.IO) {
+            val decodedQuery = withContext(FlipperDispatchers.workStealingDispatcher) {
                 URLDecoder.decode(query, "UTF-8")
             }
             pureUri = Uri.parse(decodedQuery)

--- a/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkWebUpdater.kt
+++ b/components/deeplink/impl/src/main/java/com/flipperdevices/deeplink/impl/parser/delegates/DeepLinkWebUpdater.kt
@@ -35,8 +35,8 @@ class DeepLinkWebUpdater @Inject constructor() : DeepLinkParserDelegate, LogTagP
     override suspend fun fromIntent(context: Context, intent: Intent): Deeplink? {
         val uri = intent.data ?: return null
         val link = uri.getQueryParameter(QUERY_URL) ?: return null
-        val version = uri.getQueryParameter(QUERY_VERSION) ?: ""
-        val channel = uri.getQueryParameter(QUERY_CHANNEL) ?: ""
+        val version = uri.getQueryParameter(QUERY_VERSION).orEmpty()
+        val channel = uri.getQueryParameter(QUERY_CHANNEL).orEmpty()
         return Deeplink.BottomBar.DeviceTab.WebUpdate(link, "$channel $version")
     }
 }

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableCategoryCard.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/composable/categories/ComposableCategoryCard.kt
@@ -61,7 +61,7 @@ fun ComposableCategoryCard(
             }
             Text(
                 modifier = Modifier.padding(bottom = 8.dp, start = 8.dp, end = 8.dp),
-                text = fapCategory?.name ?: "",
+                text = fapCategory?.name.orEmpty(),
                 style = LocalTypography.current.subtitleM12,
                 color = LocalPallet.current.text100,
                 maxLines = 1,

--- a/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
+++ b/components/faphub/catalogtab/impl/src/main/java/com/flipperdevices/faphub/catalogtab/impl/viewmodel/FapsListViewModel.kt
@@ -16,6 +16,7 @@ import com.flipperdevices.faphub.dao.api.model.SortType
 import com.flipperdevices.faphub.dao.api.model.SortType.Companion.toSortType
 import com.flipperdevices.faphub.installation.manifest.api.FapManifestApi
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,6 +46,7 @@ class FapsListViewModel @Inject constructor(
 
     fun getSortTypeFlow() = sortStateFlow.asStateFlow()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val faps = combine(
         sortStateFlow,
         targetProviderApi.getFlipperTarget(),

--- a/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
+++ b/components/faphub/category/impl/src/main/java/com/flipperdevices/faphub/category/impl/viewmodel/FapHubCategoryViewModel.kt
@@ -17,6 +17,7 @@ import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -42,6 +43,7 @@ class FapHubCategoryViewModel @AssistedInject constructor(
 
     fun getSortTypeFlow() = sortStateFlow.asStateFlow()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val faps = combine(
         sortStateFlow,
         targetProviderApi.getFlipperTarget(),

--- a/components/faphub/dao/network/src/main/java/com/flipperdevices/faphub/dao/network/api/FapNetworkApiImpl.kt
+++ b/components/faphub/dao/network/src/main/java/com/flipperdevices/faphub/dao/network/api/FapNetworkApiImpl.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.faphub.dao.network.api
 
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.debug
 import com.flipperdevices.core.log.warn
@@ -157,5 +158,5 @@ class FapNetworkApiImpl @Inject constructor(
 private suspend fun <T> catchWithDispatcher(
     block: suspend () -> T
 ): Result<T> = runCatching {
-    return@runCatching withContext(Dispatchers.IO) { block() }
+    return@runCatching withContext(FlipperDispatchers.workStealingDispatcher) { block() }
 }

--- a/components/faphub/dao/network/src/main/java/com/flipperdevices/faphub/dao/network/api/FapNetworkApiImpl.kt
+++ b/components/faphub/dao/network/src/main/java/com/flipperdevices/faphub/dao/network/api/FapNetworkApiImpl.kt
@@ -16,7 +16,6 @@ import com.flipperdevices.faphub.dao.network.ktorfit.utils.HostUrlBuilder
 import com.flipperdevices.faphub.errors.api.throwable.FirmwareNotSupported
 import com.flipperdevices.faphub.target.model.FlipperTarget
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 

--- a/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
+++ b/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
@@ -18,7 +18,6 @@ import com.flipperdevices.protobuf.app.startRequest
 import com.flipperdevices.protobuf.main
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
+++ b/components/faphub/installation/button/impl/src/main/java/com/flipperdevices/faphub/installation/button/impl/helper/OpenFapHelper.kt
@@ -47,7 +47,7 @@ class OpenFapHelperImpl @Inject constructor(
     private val currentOpenAppFlow = MutableStateFlow<FapButtonConfig?>(null)
     private val rpcVersionFlow = MutableStateFlow<SemVer?>(null)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
 
     override fun getOpenFapState(fapButtonConfig: FapButtonConfig?): Flow<OpenFapState> {
         return combine(

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestCacheLoader.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestCacheLoader.kt
@@ -2,13 +2,13 @@ package com.flipperdevices.faphub.installation.manifest.impl.utils
 
 import android.content.Context
 import com.flipperdevices.bridge.rpc.api.FlipperStorageApi
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.md5
 import com.flipperdevices.core.ktx.jre.withLock
 import com.flipperdevices.core.ktx.jre.withLockResult
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
 import com.flipperdevices.faphub.installation.manifest.model.FapManifestItem
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -57,7 +57,7 @@ class FapManifestCacheLoader @Inject constructor(
     suspend fun invalidate(
         manifestItems: List<FapManifestItem>
     ) = withLock(mutex, "invalidate") {
-        withContext(Dispatchers.IO) {
+        withContext(FlipperDispatchers.workStealingDispatcher) {
             if (!cacheDir.exists()) {
                 cacheDir.mkdirs()
             }
@@ -87,9 +87,9 @@ class FapManifestCacheLoader @Inject constructor(
     }
 
     private suspend fun getLocalFilesWithHash(): List<Pair<File, String>> =
-        withContext(Dispatchers.IO) {
+        withContext(FlipperDispatchers.workStealingDispatcher) {
             return@withContext cacheDir.listFiles()?.map {
                 it to it.name
-            } ?: emptyList()
+            }.orEmpty()
         }
 }

--- a/components/faphub/installation/stateprovider/impl/src/main/java/com/flipperdevices/faphub/installation/stateprovider/impl/api/FapInstallationStateManagerImpl.kt
+++ b/components/faphub/installation/stateprovider/impl/src/main/java/com/flipperdevices/faphub/installation/stateprovider/impl/api/FapInstallationStateManagerImpl.kt
@@ -39,7 +39,7 @@ class FapInstallationStateManagerImpl @Inject constructor(
     }
 
     @Suppress("UnusedPrivateMember")
-    private suspend fun getState(
+    private fun getState(
         manifest: FapManifestState,
         applicationUid: String,
         queueState: FapQueueState,

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/composable/ComposableInstalledTabScreen.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/composable/ComposableInstalledTabScreen.kt
@@ -108,14 +108,14 @@ private fun LazyListScope.ComposableInstalledTabScreenState(
         is FapInstalledScreenState.Error -> {}
         is FapInstalledScreenState.Loaded -> if (screenState.faps.isEmpty()) {
             if (screenState.inProgress) {
-                items(DEFAULT_FAP_COUNT) {
+                items(DEFAULT_FAP_COUNT) { _ ->
                     ComposableOnlineFapApp(
                         modifier = Modifier.padding(vertical = 12.dp),
                         fapItem = null,
                         installationButton = { modifier ->
                             installationButton(null, modifier)
                         },
-                        uninstallButton = { Box(it.placeholderConnecting()) }
+                        uninstallButton = { modifier -> Box(modifier.placeholderConnecting()) }
                     )
                 }
             } else {

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/composable/button/ComposableErrorButton.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/composable/button/ComposableErrorButton.kt
@@ -27,7 +27,7 @@ import com.flipperdevices.faphub.installedtab.impl.model.InstalledNetworkErrorEn
 
 @Composable
 fun ComposableErrorButton(
-    @Suppress("UnusedParameter")
+    @Suppress("UNUSED_PARAMETER")
     installedNetworkErrorEnum: InstalledNetworkErrorEnum,
     modifier: Modifier = Modifier
 ) = Column(

--- a/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsFromNetworkProducer.kt
+++ b/components/faphub/installedtab/impl/src/main/java/com/flipperdevices/faphub/installedtab/impl/viewmodel/InstalledFapsFromNetworkProducer.kt
@@ -20,6 +20,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -160,6 +161,7 @@ class InstalledFapsFromNetworkProducer @Inject constructor(
         )
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun getLoadedFapsFlow(): Flow<FapInstalledInternalLoadingState> {
         return applicationFromNetworkStateFlow.flatMapLatest { state ->
             return@flatMapLatest when (state) {

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
@@ -20,6 +20,7 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import com.flipperdevices.core.ui.res.R as DesignSystem
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 
 private const val SCREENSHOT_FILE_PREFIX = "flpr"
 private const val TIMEFORMAT = "yyyy-MM-dd-HH-mm-ss"
@@ -68,7 +69,7 @@ class UrlImageShareViewModel @Inject constructor(
         return newBitmap
     }
 
-    fun shareUrlImage(url: URL) = viewModelScope.launch(Dispatchers.IO) {
+    fun shareUrlImage(url: URL) = viewModelScope.launch(FlipperDispatchers.workStealingDispatcher) {
         url.decodeBitmap()
             .map { bitmap -> bitmap.fillBackground() }
             .map { bitmap -> bitmap.rescale(EXPORT_RESCALE_MULTIPLIER) }

--- a/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
+++ b/components/faphub/screenshotspreview/impl/src/main/kotlin/com/flipperdevices/faphub/screenshotspreview/impl/viewmodel/UrlImageShareViewModel.kt
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Paint
 import com.flipperdevices.core.ktx.android.BitmapKtx.rescale
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.createClearNewFileWithMkDirs
 import com.flipperdevices.core.share.SharableFile
 import com.flipperdevices.core.share.ShareHelper
@@ -20,7 +21,6 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import com.flipperdevices.core.ui.res.R as DesignSystem
-import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 
 private const val SCREENSHOT_FILE_PREFIX = "flpr"
 private const val TIMEFORMAT = "yyyy-MM-dd-HH-mm-ss"

--- a/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
+++ b/components/faphub/search/impl/src/main/java/com/flipperdevices/faphub/search/impl/viewmodel/FapHubSearchViewModel.kt
@@ -9,6 +9,7 @@ import com.flipperdevices.core.pager.loadingPagingDataFlow
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.faphub.dao.api.FapNetworkApi
 import com.flipperdevices.faphub.target.api.FlipperTargetProviderApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -23,6 +24,7 @@ class FapHubSearchViewModel @Inject constructor(
 ) : DecomposeViewModel() {
     private val searchRequestFlow = MutableStateFlow("")
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val faps = combine(
         searchRequestFlow,
         targetProviderApi.getFlipperTarget(),

--- a/components/faphub/target/impl/src/main/java/com/flipperdevices/faphub/target/impl/api/FlipperTargetProviderApiImpl.kt
+++ b/components/faphub/target/impl/src/main/java/com/flipperdevices/faphub/target/impl/api/FlipperTargetProviderApiImpl.kt
@@ -12,7 +12,6 @@ import com.flipperdevices.faphub.target.impl.utils.FlipperSdkFetcher
 import com.flipperdevices.faphub.target.model.FlipperTarget
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,7 +29,7 @@ class FlipperTargetProviderApiImpl @Inject constructor(
 ) : FlipperTargetProviderApi, LogTagProvider {
     override val TAG = "FlipperTargetProviderApi"
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + FlipperDispatchers.workStealingDispatcher)
     private val targetFlow = MutableStateFlow<FlipperTarget?>(null)
 
     init {

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/FileManagerViewModel.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/FileManagerViewModel.kt
@@ -40,7 +40,7 @@ class FileManagerViewModel @AssistedInject constructor(
     override val TAG = "FileManagerViewModel"
 
     private val mutex = Mutex()
-    private var fileManagerStateFlow =
+    private val fileManagerStateFlow =
         MutableStateFlow(FileManagerState(currentPath = directory))
 
     init {

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ReceiveViewModel.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ReceiveViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -15,7 +16,6 @@ import com.flipperdevices.filemanager.impl.viewmodels.helpers.UploadFileHelper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -73,7 +73,9 @@ class ReceiveViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun startUpload(serviceApi: FlipperServiceApi) = withContext(Dispatchers.IO) {
+    private suspend fun startUpload(
+        serviceApi: FlipperServiceApi
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (!uploadStarted.compareAndSet(false, true)) {
             info { "Upload file $deeplinkContent in $path already started" }
             return@withContext

--- a/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ShareViewModel.kt
+++ b/components/filemanager/impl/src/main/java/com/flipperdevices/filemanager/impl/viewmodels/ShareViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
 import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.createClearNewFileWithMkDirs
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -74,7 +75,9 @@ class ShareViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun startDownload(serviceApi: FlipperServiceApi) = withContext(Dispatchers.IO) {
+    private suspend fun startDownload(
+        serviceApi: FlipperServiceApi
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         if (!downloadStarted.compareAndSet(false, true)) {
             info { "Download file $shareFile already started" }
             return@withContext

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/searching/PermissionStateBuilder.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/viewmodels/searching/PermissionStateBuilder.kt
@@ -35,14 +35,14 @@ class PermissionStateBuilder(
     LocationEnableHelper.Listener,
     PermissionEnableHelper.Listener {
     override val TAG = "PermissionStateBuilder"
-    private var bluetoothEnableHelper: BluetoothEnableHelper = BluetoothEnableHelper(
+    private val bluetoothEnableHelper: BluetoothEnableHelper = BluetoothEnableHelper(
         listener = this
     )
-    private var locationEnableHelper: LocationEnableHelper = LocationEnableHelper(
+    private val locationEnableHelper: LocationEnableHelper = LocationEnableHelper(
         context = context,
         listener = this
     )
-    private var permissionEnableHelper: PermissionEnableHelper = PermissionEnableHelper(
+    private val permissionEnableHelper: PermissionEnableHelper = PermissionEnableHelper(
         context = context,
         listener = this,
         permissions = PermissionHelper.getRequiredPermissions()
@@ -64,7 +64,7 @@ class PermissionStateBuilder(
     fun processLocationSettings() = locationEnableHelper.processLocationAccept()
 
     // If a user has refused one permissive more than three times, we offer him to open the settings
-    private var permissionDeniedByUserCount = mutableMapOf<String, Int>()
+    private val permissionDeniedByUserCount = mutableMapOf<String, Int>()
 
     private val state = MutableStateFlow(NOT_REQUESTED_YET)
 

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/BasicInfoViewModel.kt
@@ -29,7 +29,7 @@ class BasicInfoViewModel @Inject constructor(
 ) : DecomposeViewModel(), FlipperBleServiceConsumer, LogTagProvider {
     override val TAG = "DeviceInfoViewModel"
     private val flipperBasicInfoState = MutableStateFlow(FlipperBasicInfo())
-    private var jobs = mutableListOf<Job>()
+    private val jobs = mutableListOf<Job>()
 
     init {
         serviceProvider.provideServiceApi(this, this)

--- a/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
+++ b/components/info/impl/src/main/java/com/flipperdevices/info/impl/viewmodel/deviceinfo/FullInfoViewModel.kt
@@ -30,7 +30,7 @@ class FullInfoViewModel @Inject constructor(
     FlipperBleServiceConsumer,
     LogTagProvider {
     override val TAG = "FullInfoViewModel"
-    private var jobs = mutableListOf<Job>()
+    private val jobs = mutableListOf<Job>()
     private val flipperRpcInformationState =
         MutableStateFlow<FlipperInformationStatus<FlipperRpcInformation>>(
             FlipperInformationStatus.NotStarted()

--- a/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/compose/screen/ComposableInfraredEditorScreenReady.kt
+++ b/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/compose/screen/ComposableInfraredEditorScreenReady.kt
@@ -79,7 +79,7 @@ internal fun ComposableInfraredEditorScreenReady(
                     defaultDraggingModifier = Modifier,
                     key = remote,
                     index = index,
-                ) {
+                ) { _ ->
                     ComposableInfraredEditorItem(
                         remoteName = remote.name,
                         onChangeName = { onChangeName(index, it) },

--- a/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredEditorViewModel.kt
+++ b/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredEditorViewModel.kt
@@ -43,7 +43,7 @@ class InfraredEditorViewModel @AssistedInject constructor(
 ) : DecomposeViewModel(), LogTagProvider {
     override val TAG: String = "InfraredEditorViewModel"
 
-    private var vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
+    private val vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
 
     private val flipperKeyFlow = MutableStateFlow<FlipperKey?>(null)
     private val flipperParsedKeyFlow = MutableStateFlow<ImmutableList<InfraredRemote>?>(null)

--- a/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredKeyParser.kt
+++ b/components/infrared/editor/src/main/kotlin/com/flipperdevices/infrared/editor/viewmodel/InfraredKeyParser.kt
@@ -76,20 +76,20 @@ object InfraredKeyParser {
     }
 
     private fun parseRemoteRaw(block: Map<String, String>): InfraredRemote.Raw {
-        val name = block[KEY_NAME] ?: ""
-        val type = block[KEY_TYPE] ?: ""
-        val frequency = block[KEY_FREQUENCY] ?: ""
-        val dutyCycle = block[KEY_DUTY_CYCLE] ?: ""
-        val data = block[KEY_DATA] ?: ""
+        val name = block[KEY_NAME].orEmpty()
+        val type = block[KEY_TYPE].orEmpty()
+        val frequency = block[KEY_FREQUENCY].orEmpty()
+        val dutyCycle = block[KEY_DUTY_CYCLE].orEmpty()
+        val data = block[KEY_DATA].orEmpty()
         return InfraredRemote.Raw(name, type, frequency, dutyCycle, data)
     }
 
     private fun parseRemoteParsed(block: Map<String, String>): InfraredRemote.Parsed {
-        val name = block[KEY_NAME] ?: ""
-        val type = block[KEY_TYPE] ?: ""
-        val protocol = block[KEY_PROTOCOL] ?: ""
-        val address = block[KEY_ADDRESS] ?: ""
-        val command = block[KEY_COMMAND] ?: ""
+        val name = block[KEY_NAME].orEmpty()
+        val type = block[KEY_TYPE].orEmpty()
+        val protocol = block[KEY_PROTOCOL].orEmpty()
+        val address = block[KEY_ADDRESS].orEmpty()
+        val command = block[KEY_COMMAND].orEmpty()
         return InfraredRemote.Parsed(name, type, protocol, address, command)
     }
 }

--- a/components/keyedit/api/build.gradle.kts
+++ b/components/keyedit/api/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(projects.components.bridge.dao.api)
     implementation(projects.components.core.preference)
     implementation(projects.components.core.ui.decompose)
+    implementation(projects.components.core.ktx)
 
     implementation(libs.kotlin.serialization.json)
     implementation(libs.decompose)

--- a/components/keyedit/api/src/main/java/com/flipperdevices/keyedit/api/NotSavedFlipperKey.kt
+++ b/components/keyedit/api/src/main/java/com/flipperdevices/keyedit/api/NotSavedFlipperKey.kt
@@ -5,8 +5,8 @@ import android.os.Parcelable
 import com.flipperdevices.bridge.dao.api.model.FlipperFile
 import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyContent
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.preference.FlipperStorageProvider
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
@@ -28,7 +28,7 @@ data class NotSavedFlipperFile(
 
 suspend fun FlipperFile.toNotSavedFlipperFile(
     context: Context
-): NotSavedFlipperFile = withContext(Dispatchers.IO) {
+): NotSavedFlipperFile = withContext(FlipperDispatchers.workStealingDispatcher) {
     val localContent = content
     if (localContent is FlipperKeyContent.InternalFile) {
         return@withContext NotSavedFlipperFile(path, localContent)
@@ -39,5 +39,8 @@ suspend fun FlipperFile.toNotSavedFlipperFile(
             contentStream.copyTo(fileStream)
         }
     }
-    return@withContext NotSavedFlipperFile(path, FlipperKeyContent.InternalFile(internalFile.absolutePath))
+    return@withContext NotSavedFlipperFile(
+        path,
+        FlipperKeyContent.InternalFile(internalFile.absolutePath)
+    )
 }

--- a/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/composable/ComposableEditCard.kt
+++ b/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/composable/ComposableEditCard.kt
@@ -61,7 +61,7 @@ private fun ColumnScope.ComposableCardContent(
         modifier = Modifier.padding(horizontal = 12.dp),
         title = stringResource(R.string.keyedit_name_title),
         label = stringResource(R.string.keyedit_name_hint),
-        text = name ?: "",
+        text = name.orEmpty(),
         onTextChange = onNameChange,
         keyboardType = KeyboardType.Ascii,
         enabled = enabled
@@ -70,7 +70,7 @@ private fun ColumnScope.ComposableCardContent(
         modifier = Modifier.padding(horizontal = 12.dp),
         title = stringResource(R.string.keyedit_notes_title),
         label = stringResource(R.string.keyedit_notes_hint),
-        text = notes ?: "",
+        text = notes.orEmpty(),
         onTextChange = onNoteChange,
         keyboardType = KeyboardType.Text,
         enabled = enabled

--- a/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/viewmodel/KeyEditViewModel.kt
+++ b/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/viewmodel/KeyEditViewModel.kt
@@ -31,7 +31,7 @@ class KeyEditViewModel @AssistedInject constructor(
 ) : DecomposeViewModel(), LogTagProvider {
     override val TAG = "KeyEditViewModel"
 
-    private var vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
+    private val vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
     private val lengthFilter = LengthFilter(context)
 
     private val keyEditState = MutableStateFlow<KeyEditState>(KeyEditState.Loading)

--- a/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/viewmodel/LengthFilter.kt
+++ b/components/keyedit/impl/src/main/java/com/flipperdevices/keyedit/impl/viewmodel/LengthFilter.kt
@@ -10,7 +10,7 @@ private const val MAX_NOTE_LENGTH = 1024
 private const val VIBRATOR_TIME_MS = 500L
 
 class LengthFilter(context: Context) {
-    private var vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
+    private val vibrator = ContextCompat.getSystemService(context, Vibrator::class.java)
 
     fun nameLengthFilter(name: String, result: (String) -> Unit) {
         maxLengthFilter(name, MAX_NAME_LENGTH, result)

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/composable/common/ComposableActionLoading.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/composable/common/ComposableActionLoading.kt
@@ -10,9 +10,9 @@ import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.keyemulate.impl.R
 import com.flipperdevices.keyemulate.model.LoadingState
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.placeholder
-import com.google.accompanist.placeholder.shimmer
+import io.github.fornewid.placeholder.foundation.PlaceholderHighlight
+import io.github.fornewid.placeholder.foundation.placeholder
+import io.github.fornewid.placeholder.foundation.shimmer
 
 @Composable
 fun ComposableActionLoading(

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/composable/common/ComposableEmulateButtonWithText.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/composable/common/ComposableEmulateButtonWithText.kt
@@ -54,7 +54,7 @@ internal fun InternalComposableEmulateButtonWithText(
                         .padding(horizontal = 4.dp)
                         .size(14.dp),
                     painter = painterResource(iconId),
-                    contentDescription = textId?.let { stringResource(it) } ?: "",
+                    contentDescription = textId?.let { stringResource(it) }.orEmpty(),
                     tint = LocalPallet.current.warningColor
                 )
             }

--- a/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/helpers/EmulateHelperImpl.kt
+++ b/components/keyemulate/impl/src/main/java/com/flipperdevices/keyemulate/helpers/EmulateHelperImpl.kt
@@ -38,7 +38,7 @@ class EmulateHelperImpl @Inject constructor(
 ) : EmulateHelper, LogTagProvider {
     override val TAG = "EmulateHelper"
 
-    private var currentKeyEmulating = MutableStateFlow<EmulateConfig?>(null)
+    private val currentKeyEmulating = MutableStateFlow<EmulateConfig?>(null)
 
     @Volatile
     private var stopEmulateTimeAllowedMs: Long = 0
@@ -58,9 +58,8 @@ class EmulateHelperImpl @Inject constructor(
             stopEmulateInternal(requestApi)
         }
         currentKeyEmulating.emit(config)
-        var isEmulateStarted = false
-        try {
-            isEmulateStarted = startEmulateHelper.onStart(
+        val isEmulateStarted = try {
+            startEmulateHelper.onStart(
                 scope,
                 serviceApi,
                 config,

--- a/components/keyparser/impl/build.gradle.kts
+++ b/components/keyparser/impl/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(projects.components.core.di)
     implementation(projects.components.core.log)
     implementation(projects.components.core.data)
+    implementation(projects.components.core.ktx)
 
     implementation(libs.kotlin.immutable.collections)
     implementation(libs.kotlin.coroutines)

--- a/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/api/KeyParserImpl.kt
+++ b/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/api/KeyParserImpl.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.bridge.dao.api.model.FlipperKeyCrypto
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyType
 import com.flipperdevices.core.data.PredefinedEnumMap
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.warn
 import com.flipperdevices.keyparser.api.KeyParser
@@ -27,7 +28,6 @@ import com.flipperdevices.keyparser.impl.parsers.url.QUERY_ID
 import com.flipperdevices.keyparser.impl.parsers.url.QUERY_KEY
 import com.flipperdevices.keyparser.impl.parsers.url.QUERY_KEY_PATH
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.net.URL
@@ -54,7 +54,7 @@ class KeyParserImpl @Inject constructor() : KeyParser, LogTagProvider {
 
     override suspend fun parseKey(
         flipperKey: FlipperKey
-    ): FlipperKeyParsed = withContext(Dispatchers.IO) {
+    ): FlipperKeyParsed = withContext(FlipperDispatchers.workStealingDispatcher) {
         val fileContent = flipperKey.keyContent.openStream().use {
             it.readBytes().toString(Charset.defaultCharset())
         }
@@ -75,7 +75,7 @@ class KeyParserImpl @Inject constructor() : KeyParser, LogTagProvider {
         val fileType = FlipperKeyType.getByExtension(extension)
         val keyPath = if (fileType == null) {
             warn { "Can't find file type with extension $fileType" }
-            FlipperFilePath(pathAsFile.parent ?: "", pathAsFile.name)
+            FlipperFilePath(pathAsFile.parent.orEmpty(), pathAsFile.name)
         } else {
             FlipperFilePath(fileType.flipperDir, pathAsFile.name)
         }

--- a/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/parsers/impl/NFCParser.kt
+++ b/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/parsers/impl/NFCParser.kt
@@ -36,7 +36,13 @@ class NFCParser : KeyParserDelegate {
 
         val lines = keyContentAsMap.filter { it.key.startsWith(KEY_BLOCK) }.map {
             it.key.replace(KEY_BLOCK, "").trim().toIntOrNull() to it.value
-        }.filterNot { it.first == null }.map { it.first!! to it.second }
+        }.mapNotNull { (key, value) ->
+            if (key == null) {
+                null
+            } else {
+                key to value
+            }
+        }
 
         return FlipperKeyParsed.NFC(
             keyName = flipperKey.path.nameWithoutExtension,

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
@@ -99,7 +99,8 @@ class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
         val settings = runBlocking { dataStore.data.first() }
         return when (settings.selectedTheme) {
             SelectedTheme.SYSTEM,
-            SelectedTheme.UNRECOGNIZED -> systemIsDark
+            SelectedTheme.UNRECOGNIZED,
+            null -> systemIsDark
 
             SelectedTheme.DARK -> true
             SelectedTheme.LIGHT -> false

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyStateHelperImpl.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyStateHelperImpl.kt
@@ -26,6 +26,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -143,6 +144,7 @@ class KeyStateHelperImpl @AssistedInject constructor(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun loadFileAsFlow(keyPathNotNull: FlipperKeyPath) {
         updaterKeyApi.subscribeOnUpdatePath(keyPathNotNull).flatMapLatest {
             combine(

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/composable/actions/common/ComposableActionContent.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/composable/actions/common/ComposableActionContent.kt
@@ -100,14 +100,14 @@ private fun ComposableActionContent(
 ) {
     val descriptionText = stringResource(descriptionId)
 
-    if (isProgress) {
+    if (isProgress || iconId == null) {
         CircularProgressIndicator(
             modifier = Modifier.size(size = 24.dp)
         )
     } else {
         Icon(
             modifier = Modifier.size(size = 24.dp),
-            painter = painterResourceByKey(iconId!!),
+            painter = painterResourceByKey(iconId),
             contentDescription = descriptionText,
             tint = if (isActive) {
                 tint

--- a/components/keyscreen/shared/src/main/java/com/flipperdevices/keyscreen/shared/content/ComposableKeyContent.kt
+++ b/components/keyscreen/shared/src/main/java/com/flipperdevices/keyscreen/shared/content/ComposableKeyContent.kt
@@ -51,8 +51,14 @@ internal fun ComposableKeyContent(
             modifier = Modifier.padding(vertical = 18.dp),
             verticalArrangement = Arrangement.spacedBy(18.dp)
         ) {
-            lines.filter { it.second != null }.map { it.first to it.second!! }.forEach {
-                ComposableKeyItem(it.first, it.second)
+            lines.mapNotNull { (name, value) ->
+                if (value == null) {
+                    null
+                } else {
+                    name to value
+                }
+            }.forEach { (name, value) ->
+                ComposableKeyItem(name, value)
             }
         }
     }

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/api/NfcEditorApiImpl.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/api/NfcEditorApiImpl.kt
@@ -10,7 +10,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 @Suppress("MagicNumber")
-private val SUPPORTED_NFC_FORMATS = arrayOf(2, 3, 4)
+private val SUPPORTED_NFC_FORMATS = intArrayOf(2, 3, 4)
 private const val SUPPORTED_NFC_TYPE = "Mifare Classic"
 
 @ContributesBinding(AppGraph::class)

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/ComposableNfcEditor.kt
@@ -52,8 +52,9 @@ fun ComposableNfcEditor(
             )
         ) {
             val maxIndexSymbolCount = remember(constraints, nfcEditorState) {
-                nfcEditorState.sectors.maxOfOrNull { it.lines.maxOf { it.index } }
-                    ?.length() ?: 0
+                nfcEditorState.sectors.maxOfOrNull { sector ->
+                    sector.lines.maxOf { line -> line.index }
+                }?.length() ?: 0
             }
 
             val scaleFactor = key(

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableNfcCard.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/composable/card/ComposableNfcCard.kt
@@ -120,9 +120,9 @@ private fun ComposableNfcCardPreview() {
         ComposableNfcCard(
             nfcEditorCardInfo = NfcEditorCardInfo(
                 cardType = NfcEditorCardType.MF_4K,
-                PredefinedEnumMap(CardFieldInfo::class.java) {
+                PredefinedEnumMap(CardFieldInfo::class.java) { _ ->
                     "B6 69 03 36 8A 98 02".split(" ")
-                        .map { NfcEditorCell(it, NfcCellType.SIMPLE) }
+                        .map { content -> NfcEditorCell(content, NfcCellType.SIMPLE) }
                         .toImmutableList()
                 }
             ),

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/model/NfcEditorState.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/model/NfcEditorState.kt
@@ -46,7 +46,7 @@ data class NfcEditorState(
 
     operator fun get(location: NfcEditorCellLocation): NfcEditorCell {
         val selectableSector = when (location.field) {
-            EditorField.CARD -> nfcEditorCardInfo?.fieldsAsSectors ?: emptyList()
+            EditorField.CARD -> nfcEditorCardInfo?.fieldsAsSectors.orEmpty()
             EditorField.DATA -> sectors
         }
         val currentSector = selectableSector[location.sectorIndex]

--- a/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/TextUpdaterHelper.kt
+++ b/components/nfceditor/impl/src/main/java/com/flipperdevices/nfceditor/impl/viewmodel/TextUpdaterHelper.kt
@@ -19,13 +19,13 @@ const val DELETE_CELL = "$DELETE_SYMBOL$DELETE_SYMBOL"
 const val BYTES_SYMBOL_COUNT = 2
 
 class TextUpdaterHelper {
-    private var nfcEditorStateFlow = MutableStateFlow<NfcEditorState?>(
+    private val nfcEditorStateFlow = MutableStateFlow<NfcEditorState?>(
         NfcEditorState(
             sectors = persistentListOf()
         )
     )
 
-    private var currentActiveCellState = mutableStateOf<NfcEditorCellLocation?>(null)
+    private val currentActiveCellState = mutableStateOf<NfcEditorCellLocation?>(null)
     private var currentActiveCell by currentActiveCellState
 
     private var backupTextCurrentCell: String? = null

--- a/components/rootscreen/impl/src/main/kotlin/com/flipperdevices/rootscreen/impl/api/RootDecomposeComponentImpl.kt
+++ b/components/rootscreen/impl/src/main/kotlin/com/flipperdevices/rootscreen/impl/api/RootDecomposeComponentImpl.kt
@@ -171,8 +171,6 @@ class RootDecomposeComponentImpl @AssistedInject constructor(
             stack = childStack,
         ) {
             it.instance.Render()
-
-            Dispatchers.IO.limitedParallelism(2)
         }
     }
 }

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/ScreenStreamingViewModel.kt
@@ -28,7 +28,7 @@ class ScreenStreamingViewModel @AssistedInject constructor(
     private val flipperButtonRepository: FlipperButtonRepository,
     private val buttonStackRepository: ButtonStackRepository,
 ) : DecomposeViewModel() {
-    private var vibrator = ContextCompat.getSystemService(application, Vibrator::class.java)
+    private val vibrator = ContextCompat.getSystemService(application, Vibrator::class.java)
 
     private val lockRepository = LockRepository(
         scope = viewModelScope,

--- a/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/repository/StreamingRepository.kt
+++ b/components/screenstreaming/impl/src/main/java/com/flipperdevices/screenstreaming/impl/viewmodel/repository/StreamingRepository.kt
@@ -6,6 +6,7 @@ import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
 import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.protobuf.main
 import com.flipperdevices.protobuf.screen.Gui
 import com.flipperdevices.protobuf.screen.startScreenStreamRequest
@@ -13,7 +14,6 @@ import com.flipperdevices.protobuf.screen.stopScreenStreamRequest
 import com.flipperdevices.screenstreaming.impl.model.FlipperScreenState
 import com.flipperdevices.screenstreaming.impl.model.StreamingState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -68,7 +68,7 @@ class StreamingRepository(
 
     private suspend fun onStreamFrameReceived(
         streamFrame: Gui.ScreenFrame
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         val screen = ScreenStreamFrameDecoder.decode(streamFrame) ?: return@withContext
         scope.launch {
             flipperScreen.emit(screen)

--- a/components/screenstreaming/noop/src/main/kotlin/com/flipperdevices/screenstreaming/noop/ScreenStreamingDecomposeComponentNoop.kt
+++ b/components/screenstreaming/noop/src/main/kotlin/com/flipperdevices/screenstreaming/noop/ScreenStreamingDecomposeComponentNoop.kt
@@ -15,7 +15,7 @@ private data object MainScreen
 class ScreenStreamingDecomposeComponentNoop @AssistedInject constructor(
     @Assisted componentContext: ComponentContext,
     @Assisted
-    @Suppress("UnusedPrivateProperty")
+    @Suppress("UnusedPrivateProperty", "UNUSED_PARAMETER")
     onBack: DecomposeOnBackParameter
 ) : ScreenStreamingDecomposeComponent(componentContext) {
 

--- a/components/selfupdater/debug/src/main/kotlin/com/flipperdevices/selfupdater/debug/api/SelfUpdaterDebug.kt
+++ b/components/selfupdater/debug/src/main/kotlin/com/flipperdevices/selfupdater/debug/api/SelfUpdaterDebug.kt
@@ -32,11 +32,11 @@ class SelfUpdaterDebug @Inject constructor(
         }
 
         delay(NOTIFICATION_DEBUG_DELAY_MS)
-        return debugNoUpdates(manual)
+        return debugNoUpdates()
     }
 
     @Suppress("UnusedPrivateMember")
-    private fun debugSuccessUpdate(manual: Boolean): SelfUpdateResult {
+    private fun debugSuccessUpdate(): SelfUpdateResult {
         val startUpdateNotification = InAppNotification.SelfUpdateStarted()
         val readyUpdateNotification = InAppNotification.SelfUpdateReady(
             action = { inAppNotificationStorage.addNotification(startUpdateNotification) },
@@ -45,8 +45,7 @@ class SelfUpdaterDebug @Inject constructor(
         return SelfUpdateResult.COMPLETE
     }
 
-    @Suppress("UnusedPrivateMember")
-    private fun debugNoUpdates(manual: Boolean): SelfUpdateResult {
+    private fun debugNoUpdates(): SelfUpdateResult {
         return SelfUpdateResult.NO_UPDATES
     }
 

--- a/components/selfupdater/googleplay/src/main/kotlin/com/flipperdevices/selfupdater/googleplay/api/SelfUpdaterGooglePlay.kt
+++ b/components/selfupdater/googleplay/src/main/kotlin/com/flipperdevices/selfupdater/googleplay/api/SelfUpdaterGooglePlay.kt
@@ -12,6 +12,7 @@ import com.flipperdevices.selfupdater.api.SelfUpdaterSourceApi
 import com.flipperdevices.selfupdater.models.SelfUpdateResult
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.InstallState
 import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
@@ -35,7 +36,7 @@ class SelfUpdaterGooglePlay @Inject constructor(
 
     private val appUpdateManager by lazy { AppUpdateManagerFactory.create(context) }
     private val appUpdateInfoTask by lazy { appUpdateManager.appUpdateInfo }
-    private var updateListener = InstallStateUpdatedListener(::processUpdateListener)
+    private val updateListener = InstallStateUpdatedListener(::processUpdateListener)
 
     private fun processUpdateListener(state: InstallState) {
         info { "Current update state $state" }
@@ -49,10 +50,12 @@ class SelfUpdaterGooglePlay @Inject constructor(
                 )
                 inAppNotificationStorage.addNotification(notification)
             }
+
             InstallStatus.FAILED, InstallStatus.CANCELED -> {
                 val notification = InAppNotification.SelfUpdateError()
                 inAppNotificationStorage.addNotification(notification)
             }
+
             else -> {}
         }
     }
@@ -71,8 +74,8 @@ class SelfUpdaterGooglePlay @Inject constructor(
             info { "New update available, suggest to update" }
             appUpdateManager.startUpdateFlowForResult(
                 appUpdateInfo,
-                AppUpdateType.FLEXIBLE,
                 activity,
+                AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
                 UPDATE_CODE
             )
             SelfUpdateResult.COMPLETE
@@ -86,6 +89,6 @@ class SelfUpdaterGooglePlay @Inject constructor(
 
     private fun isUpdateAvailable(appUpdateInfo: AppUpdateInfo): Boolean {
         return appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+                appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
     }
 }

--- a/components/selfupdater/googleplay/src/main/kotlin/com/flipperdevices/selfupdater/googleplay/api/SelfUpdaterGooglePlay.kt
+++ b/components/selfupdater/googleplay/src/main/kotlin/com/flipperdevices/selfupdater/googleplay/api/SelfUpdaterGooglePlay.kt
@@ -89,6 +89,6 @@ class SelfUpdaterGooglePlay @Inject constructor(
 
     private fun isUpdateAvailable(appUpdateInfo: AppUpdateInfo): Boolean {
         return appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
     }
 }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/ExportKeysHelper.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/ExportKeysHelper.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import com.flipperdevices.bridge.dao.api.delegates.key.SimpleKeyApi
 import com.flipperdevices.bridge.dao.api.model.FlipperFile
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.createClearNewFileWithMkDirs
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.share.SharableFile
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -27,7 +27,7 @@ class ExportKeysHelperImpl @Inject constructor(
 ) : ExportKeysHelper, LogTagProvider {
     override val TAG = "ExportKeysHelper"
 
-    override suspend fun createBackupArchive() = withContext(Dispatchers.IO) {
+    override suspend fun createBackupArchive() = withContext(FlipperDispatchers.workStealingDispatcher) {
         val keysZip = SharableFile(context, KEYS_ARCHIVE_NAME).apply {
             createClearNewFileWithMkDirs()
         }
@@ -52,7 +52,7 @@ class ExportKeysHelperImpl @Inject constructor(
     private suspend fun insert(
         flipperFile: FlipperFile,
         outputStream: ZipOutputStream
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         val entry = ZipEntry(flipperFile.path.pathToKey)
         outputStream.putNextEntry(entry)
         flipperFile.content.openStream().use {

--- a/components/share/cryptostorage/src/main/kotlin/com/flipperdevices/share/cryptostorage/helper/DecryptHelper.kt
+++ b/components/share/cryptostorage/src/main/kotlin/com/flipperdevices/share/cryptostorage/helper/DecryptHelper.kt
@@ -1,13 +1,13 @@
 package com.flipperdevices.share.cryptostorage.helper
 
 import android.security.keystore.KeyProperties
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.share.cryptostorage.ALGORITHM_HELPER
 import com.flipperdevices.share.cryptostorage.BIT_SIZE
 import com.flipperdevices.share.cryptostorage.IV_LENGTH
 import com.flipperdevices.share.cryptostorage.TAG_LENGTH
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.core.readBytes
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
@@ -34,7 +34,7 @@ class DecryptHelper {
         inputStream: ByteReadChannel,
         secretKey: SecretKeySpec,
         outputStream: FileOutputStream
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(FlipperDispatchers.workStealingDispatcher) {
         var cipher: Cipher? = null
 
         while (!inputStream.isClosedForRead) {

--- a/components/share/cryptostorage/src/test/kotlin/com/flipperdevices/share/cryptostorage/CryptoTest.kt
+++ b/components/share/cryptostorage/src/test/kotlin/com/flipperdevices/share/cryptostorage/CryptoTest.kt
@@ -1,13 +1,13 @@
 package com.flipperdevices.share.cryptostorage
 
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyContent
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.share.cryptostorage.helper.DecryptHelper
 import com.flipperdevices.share.cryptostorage.helper.EncryptHelper
 import io.ktor.util.toByteArray
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.close
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Assert
@@ -32,7 +32,7 @@ class CryptoTest {
 
         // Decrypt
         val decryptHelper = DecryptHelper()
-        val tempFile = withContext(Dispatchers.IO) {
+        val tempFile = withContext(FlipperDispatchers.workStealingDispatcher) {
             File.createTempFile("temp", null)
         }
         decryptHelper.writeDecrypt(encryptedReadChannel, tempFile, encryptHelper.getKeyString())

--- a/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/compose/content/ComposableSheetPending.kt
+++ b/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/compose/content/ComposableSheetPending.kt
@@ -84,7 +84,7 @@ private fun ComposableSheetAction(
         )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
-            text = descId?.let { stringResource(id = it) } ?: "",
+            text = descId?.let { stringResource(id = it) }.orEmpty(),
             style = LocalTypography.current.subtitleR10.copy(
                 color = LocalPallet.current.text30
             )

--- a/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
+++ b/components/singleactivity/impl/src/main/java/com/flipperdevices/singleactivity/impl/SingleActivity.kt
@@ -103,6 +103,7 @@ class SingleActivity : AppCompatActivity(), LogTagProvider {
         }
     }
 
+    @Suppress("UNNECESSARY_SAFE_CALL", "UnnecessarySafeCall", "SENSELESS_COMPARISON")
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         info { "Receive new intent: ${intent?.toFullString()}" }

--- a/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/viewmodel/ToolsNotificationViewModel.kt
+++ b/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/viewmodel/ToolsNotificationViewModel.kt
@@ -2,10 +2,8 @@ package com.flipperdevices.toolstab.impl.viewmodel
 
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.toolstab.api.ToolsApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
@@ -14,6 +12,5 @@ class ToolsNotificationViewModel @Inject constructor(
 ) : DecomposeViewModel() {
     val hasNotificationStateFlow: StateFlow<Boolean> = toolsApi
         .hasNotification(viewModelScope)
-        .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 }

--- a/components/unhandledexception/impl/src/main/kotlin/com/flipperdevices/unhandledexception/impl/composable/ComposableUnhandledExceptionDialogText.kt
+++ b/components/unhandledexception/impl/src/main/kotlin/com/flipperdevices/unhandledexception/impl/composable/ComposableUnhandledExceptionDialogText.kt
@@ -58,7 +58,7 @@ fun ComposableUnhandledExceptionDialogText(modifier: Modifier = Modifier) {
                     modifier = Modifier.layout { measurable, constraints ->
                         val placeable = measurable.measure(constraints)
 
-                        val existingWidth = columnWidth ?: 0
+                        val existingWidth = columnWidth
                         val maxWidth = maxOf(existingWidth, placeable.width)
 
                         if (maxWidth > existingWidth) {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
@@ -4,6 +4,7 @@ import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferDelegate
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
@@ -18,13 +19,15 @@ class UpdateOfferProvider @Inject constructor(
     private val delegates: MutableSet<UpdateOfferDelegate>
 ) : UpdateOfferProviderApi {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun isUpdateRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
-        return serviceApi.connectionInformationApi.getConnectionStateFlow().flatMapLatest {
-            combine(
-                delegates.map { it.isRequire(serviceApi) }
-            ) { delegate ->
-                return@combine delegate.any { it }
+        return serviceApi.connectionInformationApi.getConnectionStateFlow()
+            .flatMapLatest { _ ->
+                combine(
+                    delegates.map { it.isRequire(serviceApi) }
+                ) { delegate ->
+                    return@combine delegate.any { it }
+                }
             }
-        }
     }
 }

--- a/components/updater/downloader/build.gradle.kts
+++ b/components/updater/downloader/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     implementation(projects.components.core.di)
     implementation(projects.components.core.log)
+    implementation(projects.components.core.ktx)
     implementation(projects.components.core.preference)
 
     implementation(libs.kotlin.serialization.json)

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.flipperdevices.bridge.api.manager.FlipperRequestApi
 import com.flipperdevices.bridge.api.model.FlipperRequestPriority
 import com.flipperdevices.bridge.api.model.wrapToRequest
+import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -12,7 +13,6 @@ import com.flipperdevices.protobuf.screen.screenFrame
 import com.flipperdevices.protobuf.screen.startVirtualDisplayRequest
 import com.flipperdevices.protobuf.screen.stopVirtualDisplayRequest
 import com.google.protobuf.ByteString
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -56,10 +56,11 @@ class FlipperUpdateImageHelper(
         error(e) { "Error while stop streaming" }
     }
 
-    private suspend fun loadImageFromResource(): ByteArray = withContext(Dispatchers.IO) {
-        val pictureStream = context.resources.openRawResource(DesignSystem.raw.update_pic)
-        return@withContext pictureStream.use { inputStream ->
-            inputStream.readBytes()
+    private suspend fun loadImageFromResource(): ByteArray =
+        withContext(FlipperDispatchers.workStealingDispatcher) {
+            val pictureStream = context.resources.openRawResource(DesignSystem.raw.update_pic)
+            return@withContext pictureStream.use { inputStream ->
+                inputStream.readBytes()
+            }
         }
-    }
 }

--- a/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandInputStream.kt
+++ b/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandInputStream.kt
@@ -79,8 +79,6 @@ class WearableCommandInputStream<T : GeneratedMessageLite<*, *>>(
                 requests.emit(main)
             } catch (ignored: CancellationException) {
                 // ignore
-            } catch (ignored: java.util.concurrent.CancellationException) {
-                // ignore
             } catch (invalidProtocol: InvalidProtocolBufferException) {
                 error(invalidProtocol) { "Broke protocol" }
             } catch (e: Exception) {

--- a/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandOutputStream.kt
+++ b/components/wearable/emulate/common/src/main/java/com/flipperdevices/wearable/emulate/common/WearableCommandOutputStream.kt
@@ -73,8 +73,6 @@ class WearableCommandOutputStream<T : GeneratedMessageLite<*, *>>(
                 }
             } catch (ignored: CancellationException) {
                 // ignore
-            } catch (ignored: java.util.concurrent.CancellationException) {
-                // ignore
             } catch (invalidProtocol: InvalidProtocolBufferException) {
                 error(invalidProtocol) { "Broke protocol" }
             } catch (e: Exception) {

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableSendProcessor.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableSendProcessor.kt
@@ -60,7 +60,7 @@ class WearableSendProcessor @Inject constructor(
 
         val keyPath = path.replaceFirstChar { if (it == '/') "" else it.toString() }
         val keyFile = File(keyPath)
-        val filePath = FlipperFilePath(keyFile.parent ?: "", keyFile.name)
+        val filePath = FlipperFilePath(keyFile.parent.orEmpty(), keyFile.name)
         val timeout = calculateTimeout(filePath)
         try {
             val emulateConfig = EmulateConfig(

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableStartEmulateProcessor.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/request/WearableStartEmulateProcessor.kt
@@ -55,7 +55,7 @@ class WearableStartEmulateProcessor @Inject constructor(
         try {
             val emulateConfig = EmulateConfig(
                 keyType = keyType,
-                keyPath = FlipperFilePath(keyFile.parent ?: "", keyFile.name)
+                keyPath = FlipperFilePath(keyFile.parent.orEmpty(), keyFile.name)
             )
             commandOutputStream.send(
                 mainResponse {

--- a/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/composable/ComposableActionLoading.kt
+++ b/components/wearable/emulate/wear/impl/src/main/java/com/flipperdevices/wearable/emulate/impl/composable/ComposableActionLoading.kt
@@ -9,9 +9,9 @@ import com.flipperdevices.core.ui.theme.LocalPallet
 import com.flipperdevices.keyemulate.api.KeyEmulateUiApi
 import com.flipperdevices.wearable.emulate.impl.R
 import com.flipperdevices.wearable.emulate.impl.viewmodel.WearLoadingState
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.placeholder
-import com.google.accompanist.placeholder.shimmer
+import io.github.fornewid.placeholder.foundation.PlaceholderHighlight
+import io.github.fornewid.placeholder.foundation.placeholder
+import io.github.fornewid.placeholder.foundation.shimmer
 
 @Composable
 fun ComposableActionLoading(

--- a/components/wearable/sync/wear/impl/build.gradle.kts
+++ b/components/wearable/sync/wear/impl/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.compose.tooling)
     implementation(libs.compose.wear.foundation)
     implementation(libs.compose.wear.material)
+    implementation(libs.compose.wear.preview)
     implementation(libs.bundles.decompose)
     implementation(libs.horologist.layout)
     implementation(libs.lifecycle.compose)

--- a/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/composable/ComposableKeysList.kt
+++ b/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/composable/ComposableKeysList.kt
@@ -13,12 +13,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
+import androidx.wear.tooling.preview.devices.WearDevices
 import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.wearable.core.ui.components.ComposableWearOsScalingLazyColumn
 import com.flipperdevices.wearable.core.ui.components.ComposableWearOsScrollableColumn
@@ -28,7 +28,6 @@ import com.flipperdevices.wearable.sync.wear.impl.model.KeysListState
 import com.flipperdevices.wearable.sync.wear.impl.viewmodel.KeysListViewModel
 import kotlinx.collections.immutable.ImmutableList
 import com.flipperdevices.core.ui.res.R as DesignSystem
-import androidx.wear.tooling.preview.devices.WearDevices
 
 @Composable
 fun ComposableKeysList(

--- a/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/composable/ComposableKeysList.kt
+++ b/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/composable/ComposableKeysList.kt
@@ -28,6 +28,7 @@ import com.flipperdevices.wearable.sync.wear.impl.model.KeysListState
 import com.flipperdevices.wearable.sync.wear.impl.viewmodel.KeysListViewModel
 import kotlinx.collections.immutable.ImmutableList
 import com.flipperdevices.core.ui.res.R as DesignSystem
+import androidx.wear.tooling.preview.devices.WearDevices
 
 @Composable
 fun ComposableKeysList(
@@ -61,7 +62,7 @@ private fun ComposableKeysListLoading() {
 @Preview(
     showSystemUi = true,
     showBackground = true,
-    device = Devices.WEAR_OS_LARGE_ROUND
+    device = WearDevices.LARGE_ROUND
 )
 private fun ComposableKeysListEmpty() {
     ComposableWearOsScrollableColumn {

--- a/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/model/FlipperWearKey.kt
+++ b/components/wearable/sync/wear/impl/src/main/java/com/flipperdevices/wearable/sync/wear/impl/model/FlipperWearKey.kt
@@ -16,7 +16,7 @@ data class FlipperWearKey(
         path = File(syncItem.path).absoluteFile.let {
             FlipperKeyPath(
                 path = FlipperFilePath(
-                    folder = it.parent ?: "",
+                    folder = it.parent.orEmpty(),
                     nameWithExtension = it.name
                 ),
                 deleted = false

--- a/components/widget/impl/src/main/java/com/flipperdevices/widget/impl/tasks/StartEmulateWorker.kt
+++ b/components/widget/impl/src/main/java/com/flipperdevices/widget/impl/tasks/StartEmulateWorker.kt
@@ -115,7 +115,7 @@ class StartEmulateWorker(
 
         val filePath = File(filePathString)
         val folder =
-            filePath.parent ?: FlipperKeyType.getByExtension(filePath.extension)?.flipperDir ?: ""
+            filePath.parent ?: FlipperKeyType.getByExtension(filePath.extension)?.flipperDir.orEmpty()
         return FlipperFilePath(
             folder,
             filePath.name

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -193,7 +193,7 @@ coroutines:
   SuspendFunWithCoroutineScopeReceiver:
     active: false
   SuspendFunWithFlowReturnType:
-    active: true
+    active: false
 
 empty-blocks:
   active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -779,3 +779,6 @@ Compose:
     active: false
   ModifierNotUsedAtRoot:
     active: true
+  DecomposeRule:
+    PushForbiddenRule:
+      active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -779,6 +779,9 @@ Compose:
     active: false
   ModifierNotUsedAtRoot:
     active: true
-  DecomposeRule:
-    PushForbiddenRule:
-      active: true
+
+DecomposeRule:
+  PushForbiddenRule:
+    active: true
+    checkImport: true
+    replaceTo: 'pushToFront()'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ detekt = "1.23.6" # https://detekt.dev/docs/gettingstarted/gradle/
 detekt-ruleset-compiler = "0.0.4" # https://github.com/BraisGabin/detekt-compiler-rules/releases
 detekt-ruleset-ktlint = "0.50.0" # https://github.com/pinterest/ktlint/releases
 detekt-ruleset-compose = "0.4.1" # https://github.com/mrmans0n/compose-rules/releases
+detekt-ruleset-decompose = "0.3" # https://github.com/LionZXY/detekt-decompose-rule/releases
 
 # Firebase
 google-gms-gradle = "4.4.1" # https://developers.google.com/android/guides/google-services-plugin
@@ -125,6 +126,7 @@ detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 detekt-ruleset-compiler = { module = "com.braisgabin.detekt:kotlin-compiler-wrapper", version.ref = "detekt-ruleset-compiler" }
 detekt-ruleset-ktlint = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-ruleset-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detekt-ruleset-compose" }
+detekt-ruleset-decompose = { module = "uk.kulikov.detekt.decompose:decompose-detekt-rules", version.ref = "detekt-ruleset-decompose" }
 
 # UI
 splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashscreen" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ detekt = "1.23.6" # https://detekt.dev/docs/gettingstarted/gradle/
 detekt-ruleset-compiler = "0.0.4" # https://github.com/BraisGabin/detekt-compiler-rules/releases
 detekt-ruleset-ktlint = "0.50.0" # https://github.com/pinterest/ktlint/releases
 detekt-ruleset-compose = "0.4.1" # https://github.com/mrmans0n/compose-rules/releases
-detekt-ruleset-decompose = "0.3" # https://github.com/LionZXY/detekt-decompose-rule/releases
+detekt-ruleset-decompose = "1.0.1" # https://github.com/LionZXY/detekt-decompose-rule/releases
 
 # Firebase
 google-gms-gradle = "4.4.1" # https://developers.google.com/android/guides/google-services-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ compose-material = "1.6.7" # https://developer.android.com/jetpack/androidx/rele
 compose-foundation = "1.6.7" # https://developer.android.com/jetpack/androidx/releases/compose#versions
 compose-ui = "1.6.7" # https://developer.android.com/jetpack/androidx/releases/compose#versions
 compose-wear = "1.3.1" # https://developer.android.com/jetpack/androidx/releases/wear-compose
+compose-wear-preview = "1.0.0" # https://mvnrepository.com/artifact/androidx.wear/wear-tooling-preview
 compose-compiler = "1.5.14" # https://developer.android.com/jetpack/androidx/releases/compose#versions
 compose-accompanist = "0.34.0" # https://github.com/google/accompanist/releases
 compose-placeholder = "1.1.3" # https://github.com/fornewid/placeholder/releases
@@ -141,6 +142,7 @@ compose-material = { module = "androidx.compose.material:material", version.ref 
 # UI - Wear
 compose-wear-material = { module = "androidx.wear.compose:compose-material", version.ref = "compose-wear" }
 compose-wear-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "compose-wear" }
+compose-wear-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "compose-wear-preview" }
 horologist-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
 
 # UI - Compose Extension

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ compose-ui = "1.6.7" # https://developer.android.com/jetpack/androidx/releases/c
 compose-wear = "1.3.1" # https://developer.android.com/jetpack/androidx/releases/wear-compose
 compose-compiler = "1.5.14" # https://developer.android.com/jetpack/androidx/releases/compose#versions
 compose-accompanist = "0.34.0" # https://github.com/google/accompanist/releases
+compose-placeholder = "1.1.3" # https://github.com/fornewid/placeholder/releases
 compose-constraint = "1.0.1" # https://developer.android.com/jetpack/compose/layouts/constraintlayout
 compose-paging = "3.3.0" # https://developer.android.com/jetpack/androidx/releases/paging
 compose-drag-drop = "0.9.6" # https://github.com/aclassen/ComposeReorderable/releases
@@ -145,7 +146,7 @@ horologist-layout = { module = "com.google.android.horologist:horologist-compose
 # UI - Compose Extension
 compose-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "compose-accompanist" }
 compose-pager-indicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "compose-accompanist" }
-compose-placeholder = { module = "com.google.accompanist:accompanist-placeholder", version.ref = "compose-accompanist" }
+compose-placeholder = { module = "io.github.fornewid:placeholder-foundation", version.ref = "compose-placeholder" }
 compose-swipetorefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "compose-accompanist" }
 compose-constraint = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose-constraint" }
 compose-paging = { module = "androidx.paging:paging-compose", version.ref = "compose-paging" }


### PR DESCRIPTION
**Background**

Right now in the project we only use static analysis without access to classpath and types. This leads to avoiding many Detekt rules

**Changes**

- Add https://github.com/LionZXY/detekt-decompose-rule
- Enabling detekt module for android and kmp modules

**Test plan**

Try launch `./gradlew detektMain` command and check for errors
