### PR TITLE
Fix check permission for foreground service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # 1.7.2 - In Progress
 
 - [FIX] Distinct fap items by id in paging sources
+- [FIX] Paddings for update button
+- [FIX] Crash on app startup with WearOS app
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules
 - [CI] Bump target SDK to 34

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
@@ -2,8 +2,10 @@ package com.flipperdevices.bridge.service.impl
 
 import android.content.Intent
 import android.os.Binder
+import android.os.Build
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
+import com.flipperdevices.bridge.api.utils.PermissionHelper
 import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.bridge.service.impl.di.FlipperBleServiceComponent
 import com.flipperdevices.bridge.service.impl.di.FlipperServiceComponent
@@ -17,6 +19,7 @@ import com.flipperdevices.core.di.provideDelegate
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.runBlockingWithLog
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -55,6 +58,15 @@ class FlipperService : LifecycleService(), LogTagProvider {
                 applicationParams = component.applicationParams
             )
             flipperNotification = flipperNotificationLocal
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+                && PermissionHelper.getUngrantedPermission(
+                    this,
+                    PermissionHelper.getRequiredPermissions()
+                ).isNotEmpty()
+            ) {
+                error { "Can't launch foreground service on Android API 34 and upper without bluetooth permission" }
+                return
+            }
             startForeground(FLIPPER_NOTIFICATION_ID, flipperNotificationLocal.show())
             flipperNotificationLocal.showStopButton()
         }

--- a/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
+++ b/components/bridge/service/impl/src/main/java/com/flipperdevices/bridge/service/impl/FlipperService.kt
@@ -58,8 +58,8 @@ class FlipperService : LifecycleService(), LogTagProvider {
                 applicationParams = component.applicationParams
             )
             flipperNotification = flipperNotificationLocal
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-                && PermissionHelper.getUngrantedPermission(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+                PermissionHelper.getUngrantedPermission(
                     this,
                     PermissionHelper.getRequiredPermissions()
                 ).isNotEmpty()

--- a/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/composable/type/ComposableInAppNotificationSelfUpdateReady.kt
+++ b/components/inappnotification/impl/src/main/java/com/flipperdevices/inappnotification/impl/composable/type/ComposableInAppNotificationSelfUpdateReady.kt
@@ -28,7 +28,7 @@ internal fun ComposableInAppNotificationSelfUpdateReady(
             ComposableFlipperButton(
                 modifier = Modifier
                     .padding(start = 8.dp),
-                textPadding = PaddingValues(vertical = 12.dp, horizontal = 4.dp),
+                textPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
                 text = stringResource(R.string.ready_update_button),
                 textStyle = TextStyle(
                     fontSize = 12.sp

--- a/components/selfupdater/thirdparty/api/src/main/kotlin/com/flipperdevices/selfupdater/thirdparty/api/SelfUpdaterThirdParty.kt
+++ b/components/selfupdater/thirdparty/api/src/main/kotlin/com/flipperdevices/selfupdater/thirdparty/api/SelfUpdaterThirdParty.kt
@@ -13,6 +13,7 @@ import com.flipperdevices.core.activityholder.CurrentActivityHolder
 import com.flipperdevices.core.data.SemVer
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.di.ApplicationParams
+import com.flipperdevices.core.ktx.android.toFullString
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
@@ -95,7 +96,7 @@ class SelfUpdaterThirdParty @Inject constructor(
     private fun registerDownloadReceiver(activity: Activity) {
         val intentFilter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            activity.registerReceiver(downloadReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
+            activity.registerReceiver(downloadReceiver, intentFilter, Context.RECEIVER_EXPORTED)
         } else {
             @Suppress("UnspecifiedRegisterReceiverFlag")
             activity.registerReceiver(downloadReceiver, intentFilter)
@@ -128,6 +129,7 @@ class SelfUpdaterThirdParty @Inject constructor(
 
     private val downloadReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intents: Intent) {
+            info { "#onReceive ${intents.toFullString()}" }
             try {
                 val currentDownloadId = intents.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
                 if (downloadId != currentDownloadId) {

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.flipperdevices.bridge.api.utils.PermissionHelper
@@ -30,8 +29,8 @@ class WearRequestForegroundService : LifecycleService(), WearRequestChannelBinde
     override fun onCreate() {
         super.onCreate()
         info { "#onCreate" }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-            && PermissionHelper.getUngrantedPermission(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            PermissionHelper.getUngrantedPermission(
                 this,
                 PermissionHelper.getRequiredPermissions()
             ).isNotEmpty()

--- a/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
+++ b/components/wearable/emulate/handheld/impl/src/main/java/com/flipperdevices/wearable/emulate/handheld/impl/service/WearRequestForegroundService.kt
@@ -2,12 +2,16 @@ package com.flipperdevices.wearable.emulate.handheld.impl.service
 
 import android.content.Intent
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
+import com.flipperdevices.bridge.api.utils.PermissionHelper
 import com.flipperdevices.core.di.ComponentHolder
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.wearable.emulate.handheld.impl.di.WearServiceComponent
 import com.google.android.gms.wearable.ChannelClient.Channel
@@ -26,6 +30,15 @@ class WearRequestForegroundService : LifecycleService(), WearRequestChannelBinde
     override fun onCreate() {
         super.onCreate()
         info { "#onCreate" }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            && PermissionHelper.getUngrantedPermission(
+                this,
+                PermissionHelper.getRequiredPermissions()
+            ).isNotEmpty()
+        ) {
+            error { "Can't launch foreground service on Android API 34 and upper without bluetooth permission" }
+            return
+        }
         startForeground(
             NOTIFICATION_ID,
             HandheldWearOSNotificationHelper.buildNotification(applicationContext)


### PR DESCRIPTION
**Background**

With the new update and the target sdk update we started crashing when start foreground service without permissions

**Changes**

- Added check for permishen when starting services
- Fixed self updater 3-rd party. Fixed paddings

**Test plan**

Try opening the wearos app before the onboarding pass. It would have crashed before
