### PR TITLE
Fix expandable signal verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [FIX] Button arrow tint
 - [FIX] Paddings for update button
 - [FIX] Crash on app startup with WearOS app
+- [FIX] Expand verify signal bottom sheet only after signal is dispatched
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules
 - [CI] Bump target SDK to 34

--- a/components/remote-controls/setup/api/src/main/kotlin/com/flipperdevices/remotecontrols/api/DispatchSignalApi.kt
+++ b/components/remote-controls/setup/api/src/main/kotlin/com/flipperdevices/remotecontrols/api/DispatchSignalApi.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface DispatchSignalApi : InstanceKeeper.Instance {
     val state: StateFlow<State>
+    val isEmulated: StateFlow<Boolean>
 
     fun dismissBusyDialog()
 
@@ -16,6 +17,8 @@ interface DispatchSignalApi : InstanceKeeper.Instance {
      * Dispatch key from temporal file which contains only one key
      */
     fun dispatch(config: EmulateConfig)
+
+    fun reset()
 
     /**
      * Dispatch specific key from custom located remote

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
@@ -83,7 +83,6 @@ fun SetupScreen(
                     }
                     LoadedContent(
                         model = model,
-                        isEmulating = model.isEmulating,
                         modifier = Modifier.padding(scaffoldPaddings),
                         onPositiveClicked = setupComponent::onSuccessClicked,
                         onNegativeClicked = setupComponent::onFailedClicked,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
@@ -1,11 +1,14 @@
 package com.flipperdevices.remotecontrols.impl.setup.composable.components
 
 import android.content.res.Configuration
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,7 +21,6 @@ import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
 @Composable
 fun LoadedContent(
     model: SetupComponent.Model.Loaded,
-    isEmulating: Boolean,
     onPositiveClicked: () -> Unit,
     onNegativeClicked: () -> Unit,
     onDispatchSignalClicked: () -> Unit,
@@ -26,28 +28,33 @@ fun LoadedContent(
 ) {
     val ifrFileModel = model.response.ifrFileModel
     val signalResponse = model.response.signalResponse
-    Column(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.SpaceBetween
-    ) {
+    Box(modifier = modifier.fillMaxSize()) {
         when {
             ifrFileModel != null -> Unit
 
             signalResponse != null -> {
-                Box(modifier = Modifier)
                 ButtonContent(
                     onClicked = onDispatchSignalClicked,
-                    modifier = Modifier,
+                    modifier = Modifier.align(Alignment.Center),
                     data = signalResponse.data,
                     categoryName = signalResponse.categoryName,
-                    isEmulating = isEmulating
+                    isEmulating = model.isEmulating,
                 )
-                ConfirmContent(
-                    text = signalResponse.message,
-                    onNegativeClicked = onNegativeClicked,
-                    onPositiveClicked = onPositiveClicked,
+                AnimatedVisibility(
+                    visible = model.isEmulated,
+                    enter = slideInVertically(initialOffsetY = { it / 2 }),
+                    exit = slideOutVertically(),
                     modifier = Modifier
-                )
+                        .fillMaxWidth()
+                        .align(Alignment.BottomCenter),
+                ) {
+                    ConfirmContent(
+                        text = signalResponse.message,
+                        onNegativeClicked = onNegativeClicked,
+                        onPositiveClicked = onPositiveClicked,
+                        modifier = Modifier.align(Alignment.BottomCenter)
+                    )
+                }
             }
 
             else -> {
@@ -70,8 +77,8 @@ private fun LoadedContentPreview() {
         LoadedContent(
             model = SetupComponent.Model.Loaded(
                 response = SignalResponseModel(),
+                isEmulated = true
             ),
-            isEmulating = true,
             onPositiveClicked = {},
             onNegativeClicked = {},
             onDispatchSignalClicked = {}

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
@@ -31,7 +31,8 @@ interface SetupComponent {
         data class Loaded(
             val response: SignalResponseModel,
             val isFlipperBusy: Boolean = false,
-            val isEmulating: Boolean = false
+            val isEmulating: Boolean = false,
+            val isEmulated: Boolean
         ) : Model
 
         data object Error : Model

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
@@ -74,7 +74,8 @@ class SetupComponentImpl @AssistedInject constructor(
         createCurrentSignalViewModel.state,
         saveSignalApi.state,
         dispatchSignalApi.state,
-        transform = { signalState, saveState, dispatchState ->
+        dispatchSignalApi.isEmulated,
+        transform = { signalState, saveState, dispatchState, isEmulated ->
             when (signalState) {
                 CurrentSignalViewModel.State.Error -> SetupComponent.Model.Error
                 is CurrentSignalViewModel.State.Loaded -> {
@@ -83,13 +84,15 @@ class SetupComponentImpl @AssistedInject constructor(
                         SaveTempSignalApi.State.Pending -> SetupComponent.Model.Loaded(
                             response = signalState.response,
                             isFlipperBusy = dispatchState is DispatchSignalApi.State.FlipperIsBusy,
-                            isEmulating = dispatchState is DispatchSignalApi.State.Emulating
+                            isEmulating = dispatchState is DispatchSignalApi.State.Emulating,
+                            isEmulated = isEmulated
                         )
 
                         SaveTempSignalApi.State.Uploaded -> SetupComponent.Model.Loaded(
                             response = signalState.response,
                             isFlipperBusy = dispatchState is DispatchSignalApi.State.FlipperIsBusy,
-                            isEmulating = dispatchState is DispatchSignalApi.State.Emulating
+                            isEmulating = dispatchState is DispatchSignalApi.State.Emulating,
+                            isEmulated = isEmulated
                         )
 
                         is SaveTempSignalApi.State.Uploading -> SetupComponent.Model.Loading(
@@ -115,6 +118,8 @@ class SetupComponentImpl @AssistedInject constructor(
     }
 
     override fun tryLoad() {
+        if (dispatchSignalApi.state.value is DispatchSignalApi.State.Emulating) return
+        dispatchSignalApi.reset()
         createCurrentSignalViewModel.load(
             successResults = historyViewModel.state.value.successfulSignals,
             failedResults = historyViewModel.state.value.failedSignals


### PR DESCRIPTION
**Background**

When selecting signal inside Infrared remote setup - the "bottom sheet" displayed from the beginning. It should be displayed only when  signal is dispatched.

**Changes**

- Add state to display "bottom sheet" only after signal is dispatched

**Test plan**

- Open signal select screen
- Press signal
- See the confirm menu animated and shown only after signal is dispatched
- Press yes/no
- See "bottom sheet" is hidden again
