### PR TITLE
Remove bond on retry pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [CI] Enabling detekt module for android and kmp modules
 - [CI] Bump target SDK to 34
 - [Feature] Infrared controls
+- [Feature] Remove bond on retry pair
 
 # 1.7.1
 

--- a/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/RemoveBondHelper.kt
+++ b/components/core/ktx/src/androidMain/kotlin/com/flipperdevices/core/ktx/android/RemoveBondHelper.kt
@@ -1,0 +1,41 @@
+package com.flipperdevices.core.ktx.android
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.flipperdevices.core.log.info
+
+object RemoveBondHelper : LogTagProvider {
+    override val TAG = "RemoveBondHelper"
+
+    @SuppressLint("MissingPermission")
+    fun removeBond(adapter: BluetoothAdapter, id: String): Boolean {
+        info { "Request remove bond for $id" }
+        val pairedDevices = adapter.bondedDevices.filter { it.address == id }
+        if (pairedDevices.isEmpty()) {
+            info { "Return false because no any paired device with id $id" }
+            return false // Not found any paired devices
+        }
+        info { "Found ${pairedDevices.size} paired devices with id $id" }
+
+        var isSuccess = false
+        for (device in pairedDevices) {
+            val result = removeBond(device).onFailure {
+                error(it) { "Failed remove bond for device with id $id and device is $device" }
+            }
+            if (result.getOrNull() == true) {
+                info { "Remove bond successful for $device" }
+                isSuccess = true
+            }
+        }
+        return isSuccess // At lease one bond was deleted
+    }
+
+    fun removeBond(device: BluetoothDevice): Result<Boolean> = runCatching {
+        info { "Request remove bond for $device" }
+        val removeBond = device.javaClass.getMethod("removeBond")
+        return@runCatching removeBond.invoke(device) as Boolean
+    }
+}

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearching.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearching.kt
@@ -24,7 +24,7 @@ fun ComposableSearchingScreen(
     onBack: () -> Unit,
     onHelpClicking: () -> Unit,
     onSkipConnection: () -> Unit,
-    onDeviceClick: (DiscoveredBluetoothDevice) -> Unit,
+    onDeviceClick: (DiscoveredBluetoothDevice, resetPair: Boolean) -> Unit,
     onRefreshSearching: () -> Unit,
     onResetTimeoutState: () -> Unit,
     modifier: Modifier = Modifier
@@ -51,7 +51,7 @@ fun ComposableSearchingScreen(
 @Composable
 fun ComposableSearchingContent(
     content: SearchingContent,
-    onDeviceClick: (DiscoveredBluetoothDevice) -> Unit,
+    onDeviceClick: (DiscoveredBluetoothDevice, resetPair: Boolean) -> Unit,
     onRefreshSearching: () -> Unit,
     onResetTimeoutState: () -> Unit,
     modifier: Modifier = Modifier
@@ -96,7 +96,7 @@ private fun ComposableSearchingScreenPreview() {
         onHelpClicking = {},
         onSkipConnection = {},
         onRefreshSearching = {},
-        onDeviceClick = {},
+        onDeviceClick = { _, _ -> },
         onResetTimeoutState = {}
     )
 }

--- a/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearchingDevices.kt
+++ b/components/firstpair/impl/src/main/java/com/flipperdevices/firstpair/impl/composable/searching/ComposableSearchingDevices.kt
@@ -21,7 +21,7 @@ import com.flipperdevices.firstpair.impl.model.SearchingContent
 @Composable
 fun ComposableSearchingDevices(
     state: SearchingContent.FoundedDevices,
-    onDeviceClick: (DiscoveredBluetoothDevice) -> Unit,
+    onDeviceClick: (DiscoveredBluetoothDevice, resetPair: Boolean) -> Unit,
     onRefreshSearching: () -> Unit,
     onResetTimeoutState: () -> Unit,
     modifier: Modifier = Modifier
@@ -41,7 +41,7 @@ fun ComposableSearchingDevices(
             ComposableConnectingTimeoutDialog(
                 titleId = R.string.firstpair_retry_dialog_pairing_title,
                 descId = R.string.firstpair_retry_dialog_pairing_desc,
-                onRetry = { onDeviceClick(pairDevice) },
+                onRetry = { onDeviceClick(pairDevice, true) },
                 onResetTimeoutState = onResetTimeoutState
             )
         }
@@ -51,7 +51,7 @@ fun ComposableSearchingDevices(
             ComposableConnectingTimeoutDialog(
                 titleId = R.string.firstpair_retry_dialog_connecting_title,
                 descId = R.string.firstpair_retry_dialog_connecting_desc,
-                onRetry = { onDeviceClick(pairDevice) },
+                onRetry = { onDeviceClick(pairDevice, false) },
                 onResetTimeoutState = onResetTimeoutState
             )
         }
@@ -78,9 +78,11 @@ fun ComposableSearchingDevices(
                 val isConnecting = remember(device.address, currentDeviceConnecting) {
                     device.address == currentDeviceConnecting
                 }
-                ComposableSearchItem(text = name, isConnecting = isConnecting) {
-                    onDeviceClick(device)
-                }
+                ComposableSearchItem(
+                    text = name,
+                    isConnecting = isConnecting,
+                    onConnectionClick = { onDeviceClick(device, false) }
+                )
             }
         }
     }

--- a/components/firstpair/impl/src/test/kotlin/com/flipperdevices/firstpair/impl/viewmodels/connecting/PairDeviceViewModelTest.kt
+++ b/components/firstpair/impl/src/test/kotlin/com/flipperdevices/firstpair/impl/viewmodels/connecting/PairDeviceViewModelTest.kt
@@ -80,7 +80,7 @@ class PairDeviceViewModelTest {
             bleManager.bluetoothDevice
         } returns testDevice.device
 
-        underTest.startConnectToDevice(testDevice)
+        underTest.startConnectToDevice(testDevice, resetPair = false)
         advanceUntilIdle()
         Assert.assertEquals(
             listOf(
@@ -121,7 +121,7 @@ class PairDeviceViewModelTest {
             bleManager.bluetoothDevice
         } returns testDevice.device
 
-        underTest.startConnectToDevice(testDevice)
+        underTest.startConnectToDevice(testDevice, resetPair = false)
         advanceUntilIdle()
         stateFlow.emit(ConnectionState.Ready(FlipperSupportedState.READY))
         advanceUntilIdle()
@@ -169,7 +169,7 @@ class PairDeviceViewModelTest {
         } returns testDevice.device
 
         advanceUntilIdle()
-        underTest.startConnectToDevice(testDevice)
+        underTest.startConnectToDevice(testDevice, resetPair = false)
         advanceUntilIdle()
         stateFlow.emit(ConnectionState.Initializing)
         advanceUntilIdle()
@@ -218,7 +218,7 @@ class PairDeviceViewModelTest {
             bleManager.bluetoothDevice
         } returns testDevice.device
 
-        underTest.startConnectToDevice(testDevice)
+        underTest.startConnectToDevice(testDevice, resetPair = false)
         advanceUntilIdle()
         Assert.assertEquals(
             listOf(
@@ -252,7 +252,7 @@ class PairDeviceViewModelTest {
             bleManager.bluetoothDevice
         } returns testDevice.device
 
-        underTest.startConnectToDevice(testDevice)
+        underTest.startConnectToDevice(testDevice, resetPair = false)
         advanceUntilIdle()
         stateFlow.emit(ConnectionState.Disconnected(ConnectionState.Disconnected.Reason.UNKNOWN))
         advanceUntilIdle()


### PR DESCRIPTION
**Background**

Right now the Retry button on a failed peering error does nothing and just reconnects it

**Changes**

- Deletion of Bond on repeat request

**Test plan**

Try reconnect to/from flipper with changed mac address
https://github.com/flipperdevices/flipperzero-firmware/pull/3723