### PR TITLE
fix avd linux baseline

### DIFF
--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -61,29 +61,26 @@ jobs:
           baseline_file_path="./instances/android/app/src/${build_variant}/generated/baselineProfiles/baseline-prof.txt"
           echo "BASELINE_FILE_PATH=${baseline_file_path}" >> $GITHUB_OUTPUT
 
+
+      # On Flipper self-hosted we don't have it so install locally in current container
       - name: Setup libx11
         run: |
           export DEBIAN_FRONTEND=noninteractive;
           sudo apt update;
           sudo apt install -y libx11-6;
 
+      # We need to install specific platforms for this job which is not present inside self-hosted VM
       - name: Setup Platform-android-34
         run: |
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-34"
 
+      # Remember current user ANDROID_HOME location to use it via sudo
       # steps.share_android_home.ANDROID_HOME
       - name: Share ANDROID_HOME location
         id: share_android_home
         run: |
           android_home="$ANDROID_HOME"
-          echo $ANDROID_HOME
-          echo $android_home
           echo "ANDROID_HOME=$android_home" >> $GITHUB_OUTPUT
-
-      - name: Print android home
-        run: |
-          sudo echo ${{ steps.share_android_home.outputs.ANDROID_HOME }}
-          sudo ls ${{ steps.share_android_home.outputs.ANDROID_HOME }}
 
       # steps.create_baseline_task.outputs.BASELINE_TASK
       - id: create_baseline_task
@@ -93,17 +90,9 @@ jobs:
           task_name="generate${{ steps.create_uppercase_variant.outputs.BUILD_VARIANT_NAME_UPPERCASE }}BaselineProfile"
           path=":instances:android:app"          
           gradlew_full_task="$path:$task_name $no_test_param  --stacktrace"
-          echo "BASELINE_TASK=$gradlew_full_task" >> $GITHUB_OUTPUT
+          echo "BASELINE_TASK=$gradlew_full_task" >> $GITHUB_OUTPUT    
 
-      # print all outputs
-      - name: Print outputs of current baseline task
-        run: |
-          echo "BUILD_VARIANT_NAME ${{ steps.create_uppercase_variant.outputs.BUILD_VARIANT_NAME }}"
-          echo "BUILD_VARIANT_NAME_UPPERCASE ${{ steps.create_uppercase_variant.outputs.BUILD_VARIANT_NAME_UPPERCASE }}"  
-          echo "BASELINE_FILE_ID ${{ steps.create_baseline_file_id.outputs.BASELINE_FILE_ID }}"           
-          echo "BASELINE_FILE_PATH ${{ steps.create_baseline_file_path.outputs.BASELINE_FILE_PATH }}"
-          echo "BASELINE_TASK ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}"          
-
+      # Here also specified ANDROID environment variables for sudo command
       - name: Run baseline profiles
         run: |
           sudo ANDROID_SDK_ROOT=${{ steps.share_android_home.outputs.ANDROID_HOME }} ANDROID_HOME=${{ steps.share_android_home.outputs.ANDROID_HOME }} ANDROID_AVD_HOME=${{ steps.share_android_home.outputs.ANDROID_HOME }}/avd ./gradlew ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}

--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   baseline_file:
     name: Upload baseline profile file
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     outputs:
       BUILD_VARIANT_NAME: ${{ steps.create_uppercase_variant.outputs.BUILD_VARIANT_NAME }}
       BASELINE_FILE_ID: ${{ steps.create_baseline_file_id.outputs.BASELINE_FILE_ID }}
@@ -61,6 +61,30 @@ jobs:
           baseline_file_path="./instances/android/app/src/${build_variant}/generated/baselineProfiles/baseline-prof.txt"
           echo "BASELINE_FILE_PATH=${baseline_file_path}" >> $GITHUB_OUTPUT
 
+      - name: Setup libx11
+        run: |
+          export DEBIAN_FRONTEND=noninteractive;
+          sudo apt update;
+          sudo apt install -y libx11-6;
+
+      - name: Setup Platform-android-34
+        run: |
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-34"
+
+      # steps.share_android_home.ANDROID_HOME
+      - name: Share ANDROID_HOME location
+        id: share_android_home
+        run: |
+          android_home="$ANDROID_HOME"
+          echo $ANDROID_HOME
+          echo $android_home
+          echo "ANDROID_HOME=$android_home" >> $GITHUB_OUTPUT
+
+      - name: Print android home
+        run: |
+          sudo echo ${{ steps.share_android_home.outputs.ANDROID_HOME }}
+          sudo ls ${{ steps.share_android_home.outputs.ANDROID_HOME }}
+
       # steps.create_baseline_task.outputs.BASELINE_TASK
       - id: create_baseline_task
         run: |
@@ -71,7 +95,6 @@ jobs:
           gradlew_full_task="$path:$task_name $no_test_param  --stacktrace"
           echo "BASELINE_TASK=$gradlew_full_task" >> $GITHUB_OUTPUT
 
-
       # print all outputs
       - name: Print outputs of current baseline task
         run: |
@@ -79,11 +102,11 @@ jobs:
           echo "BUILD_VARIANT_NAME_UPPERCASE ${{ steps.create_uppercase_variant.outputs.BUILD_VARIANT_NAME_UPPERCASE }}"  
           echo "BASELINE_FILE_ID ${{ steps.create_baseline_file_id.outputs.BASELINE_FILE_ID }}"           
           echo "BASELINE_FILE_PATH ${{ steps.create_baseline_file_path.outputs.BASELINE_FILE_PATH }}"
-          echo "BASELINE_TASK ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}"
+          echo "BASELINE_TASK ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}"          
 
       - name: Run baseline profiles
         run: |
-          ./gradlew ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}
+          sudo ANDROID_SDK_ROOT=${{ steps.share_android_home.outputs.ANDROID_HOME }} ANDROID_HOME=${{ steps.share_android_home.outputs.ANDROID_HOME }} ANDROID_AVD_HOME=${{ steps.share_android_home.outputs.ANDROID_HOME }}/avd ./gradlew ${{ steps.create_baseline_task.outputs.BASELINE_TASK }}
 
       - uses: actions/upload-artifact@master
         name: "Upload baseline file"

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   invalidate_gradle_cache:
     name: Update gradle cache
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
         with:
@@ -28,7 +28,7 @@ jobs:
           arguments: testDebugUnitTest desktopTest detekt lint
   build_number:
     name: Generate build number
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     outputs:
       number: ${{ steps.build_out.outputs.number }}
       number_wearos: ${{ steps.wearos_out.outputs.number_wearos }}
@@ -59,7 +59,7 @@ jobs:
       BUILD_VARIANT_NAME: "internal"
   build_internal_release:
     name: Build Internal AAB and APK
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     needs: [ create_internal_baseline, build_number ]
     strategy:
       matrix:
@@ -131,7 +131,7 @@ jobs:
           path: ${{ steps.artifacts_copy.outputs.path }}
   build_internal_release_gms_wearos:
     name: Build Internal AAB and APK WearOS
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     needs: build_number
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
@@ -193,7 +193,7 @@ jobs:
           path: ${{ steps.artifacts_copy.outputs.path }}
   upload_to_github:
     name: Upload to Github Releases
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     needs: [ build_internal_release, build_internal_release_gms_wearos, build_number ]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
@@ -256,7 +256,7 @@ jobs:
       - name: Artefact build beautifier
         id: beautifier
         run: |
-          mv ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gh_gms.apk ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk  
+          mv ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gh_gms.apk ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
           mv ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-gh_nogms.apk ${{ steps.artifacts_copy.outputs.path }}/flipper-zero-nogms-${{ steps.vars.outputs.major_version }}.${{ steps.vars.outputs.minor_version }}.apk
       - name: Create internal Release
         id: create_internal_release
@@ -275,7 +275,7 @@ jobs:
           prerelease: true
   upload_to_playstore:
     name: Upload to Play Store
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     needs: [ build_internal_release ]
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
@@ -292,7 +292,7 @@ jobs:
           mappingFile: ${{steps.download-googleplay.outputs.download-path}}/mapping-googleplay.txt
   upload_to_playstore_wearos:
     name: Upload Wear OS to Play Store
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     needs: [ build_internal_release_gms_wearos ]
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4


### PR DESCRIPTION
**Background**

After relocating on self-hosted runners baseline generator is broken. This PR adding missing linux packaged with sudo ./gradlew as it requires permissions

**Changes**

- Add libx11
- add platform-android-sdk34

**Test plan**

- See [this action](https://github.com/flipperdevices/Flipper-Android-App/actions/runs/9989676210/job/27608801873)
