### PR TITLE
Ignore manifests with dot in start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Feature] Infrared controls
 - [Feature] Remove bond on retry pair
 - [Feature] Add onetap widget
+- [FIX] Ignore faps manifest with point in start
 
 # 1.7.1
 

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestCacheLoader.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestCacheLoader.kt
@@ -34,6 +34,7 @@ class FapManifestCacheLoader @Inject constructor(
         val namesWithHash = flipperStorageApi
             .listingDirectoryWithMd5(FapManifestConstants.FAP_MANIFESTS_FOLDER_ON_FLIPPER)
             .filter { File(it.name).extension == FapManifestConstants.FAP_MANIFEST_EXTENSION }
+            .filterNot { it.name.startsWith(".") }
         val filesWithHash = getLocalFilesWithHash().associate { (file, md5) -> md5 to file }
         info { "Find ${filesWithHash.size} files in cache" }
         val cached = mutableListOf<Pair<File, String>>()

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
@@ -129,10 +129,9 @@ class FapManifestsLoader @AssistedInject constructor(
         val cacheResult = cacheLoader.loadCache()
         info { "Cache load result is toLoad: ${cacheResult.toLoadNames}, cached: ${cacheResult.cachedNames}" }
         val fapItemsList = mutableListOf<FapManifestItem>()
-        cacheResult.cachedNames.map { (file, name) ->
+        cacheResult.cachedNames.mapNotNull { (file, name) ->
             parser.parse(file.readBytes(), name)
-        }.filterNotNull()
-            .filter { fapExistChecker.checkExist(it.path) }
+        }.filter { fapExistChecker.checkExist(it.path) }
             .filter { it.isDevCatalog == isUseDevCatalog }
             .forEach {
                 fapItemsList.add(it)
@@ -144,15 +143,12 @@ class FapManifestsLoader @AssistedInject constructor(
                 )
             }
         info { "Parsed ${fapItemsList.size} manifests from cache" }
-        cacheResult.toLoadNames
-            .map { name ->
-                loadManifestFile(
-                    requestApi = serviceApi.requestApi,
-                    filePath = File(FAP_MANIFESTS_FOLDER_ON_FLIPPER, name).absolutePath
-                )?.let { parser.parse(it, name) }
-            }
-            .filterNotNull()
-            .filter { fapExistChecker.checkExist(it.path) }
+        cacheResult.toLoadNames.mapNotNull { name ->
+            loadManifestFile(
+                requestApi = serviceApi.requestApi,
+                filePath = File(FAP_MANIFESTS_FOLDER_ON_FLIPPER, name).absolutePath
+            )?.let { parser.parse(it, name) }
+        }.filter { fapExistChecker.checkExist(it.path) }
             .filter { it.isDevCatalog == isUseDevCatalog }
             .forEach { content ->
                 fapItemsList.add(content)


### PR DESCRIPTION
**Background**

Right now we're trying to load even those manifest files that are created with a dot at the beginning - that's usually how they mark those files that are deleted

**Changes**

- Add filter for start with point

**Test plan**

Try sync app
