### PR TITLE
Merge CI actions

### DIFF
--- a/.github/workflows/call-check-changelog.yml
+++ b/.github/workflows/call-check-changelog.yml
@@ -1,27 +1,11 @@
 name: Pull Request CI - Changelog
-
 on:
-  pull_request:
-    branches:
-      - 'dev'
-
-# Concurrency strategy:
-#   github.workflow: distinguish this workflow from others
-#   github.event_name: distinguish `push` event from `pull_request` event
-#   github.ref_name: distinguish branch
-#   github.repository: distinguish owner+repository
-#
-# Reference:
-#   https://docs.github.com/en/actions/using-jobs/using-concurrency
-#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{github.ref_name}}-${{github.repository}}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   changelog_changes:
     name: "Checking that changelog has changed"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/.github/workflows/call-check-changelog.yml
+++ b/.github/workflows/call-check-changelog.yml
@@ -1,4 +1,4 @@
-name: Pull Request CI - Changelog
+name: Check changelog changed
 on:
   workflow_call:
 

--- a/.github/workflows/call-create-baseline.yml
+++ b/.github/workflows/call-create-baseline.yml
@@ -1,4 +1,4 @@
-name: "Create baseline call"
+name: Create BaselineProfile files
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/call-gradle-cache.yml
+++ b/.github/workflows/call-gradle-cache.yml
@@ -18,11 +18,14 @@ jobs:
             build-logic/**
             gradle/**
             gradle.properties
-  release_build:
-    name: "Build release"
+  matrx_update_gradle:
+    name: "Build ${{ matrix.target }}"
     runs-on: [ self-hosted, AndroidShell ]
     needs: check_gradle_files_change
     if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
+    strategy:
+      matrix:
+        target: [ "Release", "Debug", "Internal" ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -35,40 +38,4 @@ jobs:
       - name: Build release
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
         with:
-          arguments: assembleRelease bundleRelease
-  debug_build:
-    name: "Build debug"
-    runs-on: [ self-hosted, AndroidShell ]
-    needs: check_gradle_files_change
-    if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          submodules: 'recursive'
-      - name: Set up JDK 1.17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Build debug
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
-        with:
-          arguments: assembleDebug bundleDebug
-  internal_build:
-    name: "Build internal"
-    runs-on: [ self-hosted, AndroidShell ]
-    needs: check_gradle_files_change
-    if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          submodules: 'recursive'
-      - name: Set up JDK 1.17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Build internal
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
-        with:
-          arguments: assembleInternal bundleInternal
+          arguments: assemble${{ matrix.target }} bundle${{ matrix.target }}

--- a/.github/workflows/call-gradle-cache.yml
+++ b/.github/workflows/call-gradle-cache.yml
@@ -1,31 +1,28 @@
 name: Check configuration change
-
 on:
-  pull_request:
-    paths:
-      - '**.gradle.kts'
-      - 'build-logic/**'
-      - 'gradle/**'
-      - 'gradle.properties'
-  merge_group:
-
-# Concurrency strategy:
-#   github.workflow: distinguish this workflow from others
-#   github.event_name: distinguish `push` event from `pull_request` event
-#   github.ref_name: distinguish branch
-#   github.repository: distinguish owner+repository
-#
-# Reference:
-#   https://docs.github.com/en/actions/using-jobs/using-concurrency
-#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{github.ref_name}}-${{github.repository}}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
+  check_gradle_files_change:
+    name: "Check that gradle files changed"
+    runs-on: ubuntu-latest
+    outputs:
+      GRADLE_FILES_CHANGED: ${{ steps.changed-changelog.outputs.any_changed }}
+    steps:
+      - name: Check that gradle files changed
+        id: changed-changelog
+        uses: tj-actions/changed-files@58ae566dc69a926834e4798bcfe0436ff97c0599 # v26.1
+        with:
+          files: |
+            **.gradle.kts
+            build-logic/**
+            gradle/**
+            gradle.properties
   release_build:
     name: "Build release"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
+    needs: check_gradle_files_change
+    if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -41,7 +38,9 @@ jobs:
           arguments: assembleRelease bundleRelease
   debug_build:
     name: "Build debug"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
+    needs: check_gradle_files_change
+    if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -57,7 +56,9 @@ jobs:
           arguments: assembleDebug bundleDebug
   internal_build:
     name: "Build internal"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
+    needs: check_gradle_files_change
+    if: needs.check_gradle_files_change.outputs.GRADLE_FILES_CHANGED == 'true'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/.github/workflows/call-validate-gradle-wrapper.yml
+++ b/.github/workflows/call-validate-gradle-wrapper.yml
@@ -1,10 +1,11 @@
-name: "Validate Gradle Wrapper"
-on: [ push, pull_request ]
+name: "Validate gradle wrapper"
+on:
+  workflow_call:
 
 jobs:
   validation:
-    name: "Validation"
-    runs-on: [self-hosted, AndroidShell]
+    name: "Validate gradle wrapper"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -9,9 +9,13 @@ concurrency:
   group: "deploy"
 
 jobs:
+  validate_gradle_wrapper:
+    name: "Validate gradle wrapper"
+    uses: ./.github/workflows/call-validate-gradle-wrapper.yml
   invalidate_gradle_cache:
     name: Update gradle cache
     runs-on: [ self-hosted, AndroidShell ]
+    needs: [ validate_gradle_wrapper ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -28,7 +32,7 @@ jobs:
           arguments: testDebugUnitTest desktopTest detekt lint
   build_number:
     name: Generate build number
-    runs-on: [ self-hosted, AndroidShell ]
+    runs-on: ubuntu-latest
     outputs:
       number: ${{ steps.build_out.outputs.number }}
       number_wearos: ${{ steps.wearos_out.outputs.number_wearos }}

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -33,6 +33,7 @@ jobs:
   build_number:
     name: Generate build number
     runs-on: ubuntu-latest
+    needs: [ validate_gradle_wrapper ]
     outputs:
       number: ${{ steps.build_out.outputs.number }}
       number_wearos: ${{ steps.wearos_out.outputs.number_wearos }}
@@ -197,7 +198,7 @@ jobs:
           path: ${{ steps.artifacts_copy.outputs.path }}
   upload_to_github:
     name: Upload to Github Releases
-    runs-on: [ self-hosted, AndroidShell ]
+    runs-on: ubuntu-latest
     needs: [ build_internal_release, build_internal_release_gms_wearos, build_number ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -279,7 +280,7 @@ jobs:
           prerelease: true
   upload_to_playstore:
     name: Upload to Play Store
-    runs-on: [ self-hosted, AndroidShell ]
+    runs-on: ubuntu-latest
     needs: [ build_internal_release ]
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
@@ -297,7 +298,7 @@ jobs:
           changesNotSentForReview: true
   upload_to_playstore_wearos:
     name: Upload Wear OS to Play Store
-    runs-on: [ self-hosted, AndroidShell ]
+    runs-on: ubuntu-latest
     needs: [ build_internal_release_gms_wearos ]
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
 
 # Concurrency strategy:
 #   github.workflow: distinguish this workflow from others
-#   github.event_name: distinguish `push` event from `pull_request` event
+#   github.event_name: distinguish `push` event from `pull_request` and 'merge_group' event
 #   github.ref_name: distinguish branch
 #   github.repository: distinguish owner+repository
 #
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/call-check-changelog.yml
   update_gradle_cache:
     name: "Gradle cache update"
+    needs: [ validate_gradle_wrapper ]
     if: github.event_name == 'merge_group'
     uses: ./.github/workflows/call-gradle-cache.yml
   info:
@@ -44,6 +45,7 @@ jobs:
   test:
     name: "Run unit tests"
     runs-on: [ self-hosted, AndroidShell ]
+    needs: [ validate_gradle_wrapper ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -58,8 +60,9 @@ jobs:
         with:
           arguments: testDebugUnitTest desktopTest
   detekt:
-    name: "Check project by detekt"
+    name: "Check project by detekt and android`s lint"
     runs-on: [ self-hosted, AndroidShell ]
+    needs: [ validate_gradle_wrapper ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -72,20 +75,4 @@ jobs:
       - name: detekt
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
         with:
-          arguments: detektMain
-  android_lint:
-    name: "Check project by android`s lint"
-    runs-on: [ self-hosted, AndroidShell ]
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          submodules: 'recursive'
-      - name: Set up JDK 1.17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Android lint
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
-        with:
-          arguments: lint
+          arguments: detektMain lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,9 +21,20 @@ concurrency:
 
 
 jobs:
+  validate_gradle_wrapper:
+    name: "Validate gradle wrapper"
+    uses: ./.github/workflows/call-validate-gradle-wrapper.yml
+  check_changelog_changed:
+    name: "Validate CHANGELOG changed"
+    uses: ./.github/workflows/call-check-changelog.yml
+  update_gradle_cache:
+    name: "Gradle cache update"
+    if: github.event_name == 'merge_group'
+    uses: ./.github/workflows/call-gradle-cache.yml
   info:
     name: "Display concurrency info"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
+    needs: [ validate_gradle_wrapper ]
     steps:
       - run: |
           echo "github.workflow=${{ github.workflow }}"
@@ -32,7 +43,7 @@ jobs:
           echo "github.repository=${{ github.repository }}"
   test:
     name: "Run unit tests"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -48,7 +59,7 @@ jobs:
           arguments: testDebugUnitTest desktopTest
   detekt:
     name: "Check project by detekt"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -64,7 +75,7 @@ jobs:
           arguments: detektMain
   android_lint:
     name: "Check project by android`s lint"
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: [ self-hosted, AndroidShell ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,13 @@ on:
       - 'rc'
 
 jobs:
+  validate_gradle_wrapper:
+    name: "Validate gradle wrapper"
+    uses: ./.github/workflows/call-validate-gradle-wrapper.yml
   build_number:
     name: Generate build number
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
+    needs: [ validate_gradle_wrapper ]
     outputs:
       number: ${{ steps.build_out.outputs.number }}
       number_wearos: ${{ steps.wearos_out.outputs.number_wearos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           path: ${{ steps.artifacts_copy.outputs.path }}
   upload_to_github:
     name: Upload to Github Releases
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [ build_release, build_release_gms_wearos, build_number ]
     steps:
@@ -262,7 +262,7 @@ jobs:
           prerelease: false
   upload_to_playstore:
     name: Upload to Play Store
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
     needs: [ build_release ]
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
@@ -285,7 +285,7 @@ jobs:
           mappingFile: ${{steps.download-googleplay.outputs.download-path}}/mapping-googleplay.txt
   upload_to_playstore_wearos:
     name: Upload WearOS to Play Store
-    runs-on: [self-hosted, AndroidShell]
+    runs-on: ubuntu-latest
     needs: [ build_release_gms_wearos ]
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [CI] Enabling detekt module for android and kmp modules
 - [CI] Bump target SDK to 34
 - [CI] Update deps
+- [CI] Merge CI workflows in one
 
 # 1.7.1
 


### PR DESCRIPTION
**Background**

Right now, CI  creating different actions for one event. This PR introduces improvement by using workflow-calls. With this PRs actions located inside one workflow and not splitted inside actions GitHub page


**Changes**

- Move changelog, gradle-cache, validation to workflow-calls
- Use ubuntu-latest for lighweight tasks instead of self-hosted

**Test plan**

- See this PR CI
- See [DEV](https://github.com/makeevrserg/Flipper-Android-App/actions/runs/10198634797)
- See [PR](https://github.com/makeevrserg/Flipper-Android-App/actions/runs/10198630466)
