### PR TITLE
Update tj-actions/changed-files

### DIFF
--- a/.github/workflows/call-check-changelog.yml
+++ b/.github/workflows/call-check-changelog.yml
@@ -12,7 +12,7 @@ jobs:
           submodules: 'recursive'
       - name: Get change status for CHANGELOG.md
         id: changed-changelog
-        uses: tj-actions/changed-files@58ae566dc69a926834e4798bcfe0436ff97c0599 # v26.1
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
         with:
           files: CHANGELOG.md
       - name: Failed if changelog not changed

--- a/.github/workflows/call-gradle-cache.yml
+++ b/.github/workflows/call-gradle-cache.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: 'recursive'
       - name: Check that gradle files changed
         id: gradle-related-changed
-        uses: tj-actions/changed-files@58ae566dc69a926834e4798bcfe0436ff97c0599 # v26.1
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
         with:
           files: |
             **.gradle.kts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [CI] Bump target SDK to 34
 - [CI] Update deps
 - [CI] Merge CI workflows in one
+- [CI] Update CI changed-files action
 
 # 1.7.1
 


### PR DESCRIPTION
**Background**

Version of `tj-actions/changed-files` is too old and doesn't work with merge-queue as intended, thus need to be updated to v44.5.7-`tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c`

**Changes**

- Update tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c

**Test plan**

- See CI and merge-queue
