### PR TITLE
Fix wrong animation confirm setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Fap manifest caching
 - [FIX] Remote controls design issues
 - [FIX] Fix flaky test
+- [FIX] Bad bottom sheet animation on infrared setup screen
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/remote-controls/setup/api/src/main/kotlin/com/flipperdevices/remotecontrols/api/DispatchSignalApi.kt
+++ b/components/remote-controls/setup/api/src/main/kotlin/com/flipperdevices/remotecontrols/api/DispatchSignalApi.kt
@@ -9,14 +9,17 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface DispatchSignalApi : InstanceKeeper.Instance {
     val state: StateFlow<State>
-    val isEmulated: StateFlow<Boolean>
 
     fun dismissBusyDialog()
 
     /**
      * Dispatch key from temporal file which contains only one key
      */
-    fun dispatch(config: EmulateConfig, identifier: IfrKeyIdentifier)
+    fun dispatch(
+        config: EmulateConfig,
+        identifier: IfrKeyIdentifier,
+        onDispatched: () -> Unit = {}
+    )
 
     fun reset()
 
@@ -26,7 +29,8 @@ interface DispatchSignalApi : InstanceKeeper.Instance {
     fun dispatch(
         identifier: IfrKeyIdentifier,
         remotes: List<InfraredRemote>,
-        ffPath: FlipperFilePath
+        ffPath: FlipperFilePath,
+        onDispatched: () -> Unit = {}
     )
 
     sealed interface State {

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
@@ -26,6 +26,18 @@ import com.flipperdevices.rootscreen.model.RootScreenConfig
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.ui.Alignment
+import com.flipperdevices.remotecontrols.impl.setup.composable.components.AnimatedConfirmContent
+import com.flipperdevices.remotecontrols.impl.setup.composable.components.ConfirmContent
 
 private val SetupComponent.Model.key: Any
     get() = when (this) {
@@ -45,6 +57,7 @@ fun SetupScreen(
     val model by remember(setupComponent, coroutineScope) {
         setupComponent.model(coroutineScope)
     }.collectAsState()
+    val lastEmulatedSignal by setupComponent.lastEmulatedSignal.collectAsState()
     LaunchedEffect(setupComponent.remoteFoundFlow) {
         setupComponent.remoteFoundFlow.onEach {
             setupComponent.onFileFound(it)
@@ -90,8 +103,6 @@ fun SetupScreen(
                     LoadedContent(
                         model = model,
                         modifier = Modifier.padding(scaffoldPaddings),
-                        onPositiveClick = setupComponent::onSuccessClick,
-                        onNegativeClick = setupComponent::onFailedClick,
                         onDispatchSignalClick = setupComponent::dispatchSignal
                     )
                 }
@@ -101,5 +112,13 @@ fun SetupScreen(
                 }
             }
         }
+        AnimatedConfirmContent(
+            lastEmulatedSignal = lastEmulatedSignal,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPaddings),
+            onNegativeClick = setupComponent::onFailedClick,
+            onSuccessClick = setupComponent::onSuccessClick,
+        )
     }
 }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -18,6 +19,7 @@ import com.flipperdevices.core.ui.dialog.composable.busy.ComposableFlipperBusy
 import com.flipperdevices.core.ui.theme.LocalPalletV2
 import com.flipperdevices.ifrmvp.core.ui.layout.shared.ErrorComposable
 import com.flipperdevices.ifrmvp.core.ui.layout.shared.SharedTopBar
+import com.flipperdevices.remotecontrols.impl.setup.composable.components.AnimatedConfirmContent
 import com.flipperdevices.remotecontrols.impl.setup.composable.components.LoadedContent
 import com.flipperdevices.remotecontrols.impl.setup.composable.components.SetupLoadingContent
 import com.flipperdevices.remotecontrols.impl.setup.presentation.decompose.SetupComponent
@@ -26,18 +28,6 @@ import com.flipperdevices.rootscreen.model.RootScreenConfig
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterExitState
-import androidx.compose.animation.core.updateTransition
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.ui.Alignment
-import com.flipperdevices.remotecontrols.impl.setup.composable.components.AnimatedConfirmContent
-import com.flipperdevices.remotecontrols.impl.setup.composable.components.ConfirmContent
 
 private val SetupComponent.Model.key: Any
     get() = when (this) {

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -100,8 +100,8 @@ fun ConfirmContent(
 
 @Composable
 fun AnimatedConfirmContent(
+    modifier: Modifier = Modifier,
     lastEmulatedSignal: SignalResponse?,
-    modifier: Modifier,
     onNegativeClick: () -> Unit,
     onSuccessClick: () -> Unit
 ) {

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -28,6 +28,16 @@ import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.core.ui.theme.LocalPalletV2
 import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import com.flipperdevices.ifrmvp.backend.model.SignalResponse
 
 @Composable
 fun ConfirmContent(
@@ -87,6 +97,48 @@ fun ConfirmContent(
             }
         }
     )
+}
+
+@Composable
+fun AnimatedConfirmContent(
+    lastEmulatedSignal: SignalResponse?,
+    modifier: Modifier,
+    onNegativeClick: () -> Unit,
+    onSuccessClick: () -> Unit
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        val transition = updateTransition(
+            targetState = lastEmulatedSignal,
+            label = lastEmulatedSignal?.signalModel?.id?.toString()
+        )
+        transition.AnimatedVisibility(
+            visible = { localLastEmulatedSignal -> localLastEmulatedSignal != null },
+            enter = slideInVertically(initialOffsetY = { it / 2 }) + fadeIn(),
+            exit = slideOutVertically(targetOffsetY = { it / 2 }) + fadeOut(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding(),
+        ) {
+            val contentState = when (this.transition.targetState) {
+                EnterExitState.Visible -> transition.targetState
+                else -> transition.currentState
+            }
+            ConfirmContent(
+                text = when (contentState) {
+                    null -> ""
+                    else -> contentState.message
+                        .format(contentState.categoryName)
+                },
+                onNegativeClick = onNegativeClick,
+                onPositiveClick = onSuccessClick,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
+    }
 }
 
 @Preview(

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -100,10 +100,10 @@ fun ConfirmContent(
 
 @Composable
 fun AnimatedConfirmContent(
-    modifier: Modifier = Modifier,
     lastEmulatedSignal: SignalResponse?,
     onNegativeClick: () -> Unit,
-    onSuccessClick: () -> Unit
+    onSuccessClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -1,6 +1,13 @@
 package com.flipperdevices.remotecontrols.impl.setup.composable.components
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +16,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -27,17 +35,8 @@ import com.flipperdevices.core.ui.ktx.elements.ComposableFlipperButton
 import com.flipperdevices.core.ui.theme.FlipperThemeInternal
 import com.flipperdevices.core.ui.theme.LocalPalletV2
 import com.flipperdevices.core.ui.theme.LocalTypography
-import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterExitState
-import androidx.compose.animation.core.updateTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import com.flipperdevices.ifrmvp.backend.model.SignalResponse
+import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
 
 @Composable
 fun ConfirmContent(
@@ -130,8 +129,9 @@ fun AnimatedConfirmContent(
             ConfirmContent(
                 text = when (contentState) {
                     null -> ""
-                    else -> contentState.message
-                        .format(contentState.categoryName)
+                    else ->
+                        contentState.message
+                            .format(contentState.categoryName)
                 },
                 onNegativeClick = onNegativeClick,
                 onPositiveClick = onSuccessClick,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
@@ -1,13 +1,8 @@
 package com.flipperdevices.remotecontrols.impl.setup.composable.components
 
 import android.content.res.Configuration
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,7 +14,6 @@ import com.flipperdevices.ifrmvp.core.ui.layout.shared.ErrorComposable
 import com.flipperdevices.infrared.api.InfraredConnectionApi
 import com.flipperdevices.remotecontrols.impl.setup.presentation.decompose.SetupComponent
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
-import androidx.compose.animation.Crossfade
 
 @Composable
 fun LoadedContent(

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
@@ -19,12 +19,11 @@ import com.flipperdevices.ifrmvp.core.ui.layout.shared.ErrorComposable
 import com.flipperdevices.infrared.api.InfraredConnectionApi
 import com.flipperdevices.remotecontrols.impl.setup.presentation.decompose.SetupComponent
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
+import androidx.compose.animation.Crossfade
 
 @Composable
 fun LoadedContent(
     model: SetupComponent.Model.Loaded,
-    onPositiveClick: () -> Unit,
-    onNegativeClick: () -> Unit,
     onDispatchSignalClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -44,22 +43,6 @@ fun LoadedContent(
                     isSyncing = model.isSyncing,
                     isConnected = model.isConnected
                 )
-                AnimatedVisibility(
-                    visible = model.isEmulated,
-                    enter = slideInVertically(initialOffsetY = { it / 2 }),
-                    exit = slideOutVertically(targetOffsetY = { it / 2 }),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .navigationBarsPadding(),
-                ) {
-                    ConfirmContent(
-                        text = signalResponse.message.format(signalResponse.categoryName),
-                        onNegativeClick = onNegativeClick,
-                        onPositiveClick = onPositiveClick,
-                        modifier = Modifier.align(Alignment.BottomCenter)
-                    )
-                }
             }
 
             else -> {
@@ -82,12 +65,9 @@ private fun LoadedContentPreview() {
         LoadedContent(
             model = SetupComponent.Model.Loaded(
                 response = SignalResponseModel(),
-                isEmulated = true,
                 emulatedKeyIdentifier = null,
                 connectionState = InfraredConnectionApi.InfraredEmulateState.ALL_GOOD
             ),
-            onPositiveClick = {},
-            onNegativeClick = {},
             onDispatchSignalClick = {}
         )
     }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
@@ -2,6 +2,7 @@ package com.flipperdevices.remotecontrols.impl.setup.presentation.decompose
 
 import com.arkivanov.decompose.ComponentContext
 import com.flipperdevices.ifrmvp.backend.model.IfrFileModel
+import com.flipperdevices.ifrmvp.backend.model.SignalResponse
 import com.flipperdevices.ifrmvp.backend.model.SignalResponseModel
 import com.flipperdevices.ifrmvp.model.IfrKeyIdentifier
 import com.flipperdevices.infrared.api.InfraredConnectionApi.InfraredEmulateState
@@ -15,6 +16,7 @@ interface SetupComponent {
     fun model(coroutineScope: CoroutineScope): StateFlow<Model>
 
     val remoteFoundFlow: Flow<IfrFileModel>
+    val lastEmulatedSignal: StateFlow<SignalResponse?>
     val param: SetupScreenDecomposeComponent.Param
 
     fun onBackClick()
@@ -35,7 +37,6 @@ interface SetupComponent {
             val response: SignalResponseModel,
             val isFlipperBusy: Boolean = false,
             val emulatedKeyIdentifier: IfrKeyIdentifier?,
-            val isEmulated: Boolean,
             val connectionState: InfraredEmulateState
         ) : Model {
             val isSyncing: Boolean = listOf(

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/DispatchSignalViewModel.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/DispatchSignalViewModel.kt
@@ -42,23 +42,20 @@ class DispatchSignalViewModel @Inject constructor(
     private val _state = MutableStateFlow<DispatchSignalApi.State>(DispatchSignalApi.State.Pending)
     override val state = _state.asStateFlow()
 
-    private val _isEmulated = MutableStateFlow(false)
-    override val isEmulated = _isEmulated.asStateFlow()
-
     private var latestDispatchJob: Job? = null
 
     override fun reset() {
         viewModelScope.launch {
             latestDispatchJob?.cancelAndJoin()
             _state.value = DispatchSignalApi.State.Pending
-            _isEmulated.value = false
         }
     }
 
     override fun dispatch(
         identifier: IfrKeyIdentifier,
         remotes: List<InfraredRemote>,
-        ffPath: FlipperFilePath
+        ffPath: FlipperFilePath,
+        onDispatched: () -> Unit
     ) {
         val i = remotes.indexOfFirst { remote ->
             when (identifier) {
@@ -93,14 +90,18 @@ class DispatchSignalViewModel @Inject constructor(
             args = remote.name,
             index = i
         )
-        dispatch(config, identifier)
+        dispatch(config, identifier, onDispatched)
     }
 
     override fun dismissBusyDialog() {
         _state.value = DispatchSignalApi.State.Pending
     }
 
-    override fun dispatch(config: EmulateConfig, identifier: IfrKeyIdentifier) {
+    override fun dispatch(
+        config: EmulateConfig,
+        identifier: IfrKeyIdentifier,
+        onDispatched: () -> Unit
+    ) {
         if (latestDispatchJob?.isActive == true) return
         latestDispatchJob = viewModelScope.launch(Dispatchers.Main) {
             _state.emit(DispatchSignalApi.State.Pending)
@@ -119,7 +120,7 @@ class DispatchSignalViewModel @Inject constructor(
                             delay(DEFAULT_SIGNAL_DELAY)
                             emulateHelper.stopEmulate(this, serviceApi.requestApi)
                             _state.emit(DispatchSignalApi.State.Pending)
-                            _isEmulated.emit(true)
+                            onDispatched.invoke()
                         } catch (ignored: AlreadyOpenedAppException) {
                             _state.emit(DispatchSignalApi.State.FlipperIsBusy)
                         } catch (e: Exception) {


### PR DESCRIPTION
**Background**

On setup screen of infrared remotes bottom sheet animation has bad behaviour on state change

**Changes**

- Use transitions to implement target state and current state for bottom sheet animation

**Test plan**

- Open setup screen
- Press button, waith for bottom sheet opened with beautiful animation
- Click yes or no and see another beautiful close animation
