### PR TITLE
add skip for signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [Feature] Add onetap widget
 - [Feature] Save, edit, share remote control
 - [Feature] More UI elements for remote-controls
+- [Feature] Skip infrared signals on setup screen
 - [Refactor] Load RemoteControls from flipper, emulating animation
 - [Refactor] Update to Kotlin 2.0
 - [Refactor] Replace Ktorfit with Ktor requests in remote-controls

--- a/components/remote-controls/api-backend/src/commonMain/kotlin/com/flipperdevices/ifrmvp/backend/model/SignalRequestModel.kt
+++ b/components/remote-controls/api-backend/src/commonMain/kotlin/com/flipperdevices/ifrmvp/backend/model/SignalRequestModel.kt
@@ -9,6 +9,8 @@ data class SignalRequestModel(
     val successResults: List<SignalResultData> = emptyList(),
     @SerialName("failed_results")
     val failedResults: List<SignalResultData> = emptyList(),
+    @SerialName("skipped_results")
+    val skippedResults: List<SignalResultData> = emptyList(),
     @SerialName("brand_id")
     val brandId: Long
 ) {

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
@@ -109,6 +109,7 @@ fun SetupScreen(
                 .padding(scaffoldPaddings),
             onNegativeClick = setupComponent::onFailedClick,
             onSuccessClick = setupComponent::onSuccessClick,
+            onSkipClick = setupComponent::onSkipClicked
         )
     }
 }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -38,11 +38,13 @@ import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.ifrmvp.backend.model.SignalResponse
 import com.flipperdevices.remotecontrols.setup.impl.R as SetupR
 
+@Suppress("LongMethod")
 @Composable
 fun ConfirmContent(
     text: String,
     onPositiveClick: () -> Unit,
     onNegativeClick: () -> Unit,
+    onSkipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -76,7 +78,8 @@ fun ConfirmContent(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 42.dp, horizontal = 38.dp)
+                        .padding(horizontal = 38.dp)
+                        .padding(top = 42.dp)
                 ) {
                     Text(
                         text = stringResource(SetupR.string.no),
@@ -93,6 +96,17 @@ fun ConfirmContent(
                         onClick = onPositiveClick
                     )
                 }
+                Text(
+                    text = stringResource(SetupR.string.skip),
+                    style = LocalTypography.current.buttonB16,
+                    color = LocalPalletV2.current.action.blue.text.default,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(30.dp))
+                        .clickableRipple(onClick = onSkipClick)
+                        .padding(vertical = 18.dp, horizontal = 36.dp)
+                        .padding(bottom = 22.dp),
+                )
             }
         }
     )
@@ -103,6 +117,7 @@ fun AnimatedConfirmContent(
     lastEmulatedSignal: SignalResponse?,
     onNegativeClick: () -> Unit,
     onSuccessClick: () -> Unit,
+    onSkipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -135,6 +150,7 @@ fun AnimatedConfirmContent(
                 },
                 onNegativeClick = onNegativeClick,
                 onPositiveClick = onSuccessClick,
+                onSkipClick = onSkipClick,
                 modifier = Modifier.align(Alignment.BottomCenter)
             )
         }
@@ -152,7 +168,8 @@ private fun ComposableConfirmContentLightPreview() {
         ConfirmContent(
             text = "Super mega text of preview confirm element",
             onPositiveClick = {},
-            onNegativeClick = {}
+            onNegativeClick = {},
+            onSkipClick = {}
         )
     }
 }
@@ -168,7 +185,8 @@ private fun ComposableConfirmContentDarkPreview() {
         ConfirmContent(
             text = "Super mega text of preview confirm element",
             onPositiveClick = {},
-            onNegativeClick = {}
+            onNegativeClick = {},
+            onSkipClick = {}
         )
     }
 }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
@@ -23,6 +23,7 @@ interface SetupComponent {
 
     fun onSuccessClick()
     fun onFailedClick()
+    fun onSkipClicked()
     fun dispatchSignal()
 
     fun dismissBusyDialog()

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
@@ -138,7 +138,8 @@ class SetupComponentImpl @AssistedInject constructor(
         dispatchSignalApi.reset()
         createCurrentSignalViewModel.load(
             successResults = historyViewModel.state.value.successfulSignals,
-            failedResults = historyViewModel.state.value.failedSignals
+            failedResults = historyViewModel.state.value.failedSignals,
+            skippedResults = historyViewModel.state.value.skippedSignals
         )
         _lastEmulatedSignal.value = null
     }
@@ -160,6 +161,14 @@ class SetupComponentImpl @AssistedInject constructor(
             ?: return
         val signalModel = state.response.signalResponse?.signalModel ?: return
         historyViewModel.rememberFailed(signalModel)
+        tryLoad()
+    }
+
+    override fun onSkipClicked() {
+        val state = createCurrentSignalViewModel.state.value as? CurrentSignalViewModel.State.Loaded
+            ?: return
+        val signalModel = state.response.signalResponse?.signalModel ?: return
+        historyViewModel.rememberSkipped(signalModel)
         tryLoad()
     }
 

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/CurrentSignalViewModel.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/CurrentSignalViewModel.kt
@@ -26,13 +26,15 @@ class CurrentSignalViewModel @AssistedInject constructor(
 
     fun load(
         successResults: List<SignalResultData>,
-        failedResults: List<SignalResultData>
+        failedResults: List<SignalResultData>,
+        skippedResults: List<SignalResultData>
     ) = viewModelScope.launch {
         _state.emit(State.Loading)
         val result = runCatching {
             val request = SignalRequestModel(
                 successResults = successResults,
                 failedResults = failedResults,
+                skippedResults = skippedResults,
                 brandId = param.brandId,
             )
             infraredBackendApi.getSignal(request)
@@ -45,7 +47,7 @@ class CurrentSignalViewModel @AssistedInject constructor(
     }
 
     init {
-        load(emptyList(), emptyList())
+        load(emptyList(), emptyList(), emptyList())
     }
 
     sealed interface State {

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/HistoryViewModel.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/viewmodel/HistoryViewModel.kt
@@ -26,8 +26,16 @@ class HistoryViewModel @Inject constructor() : DecomposeViewModel() {
         _state.update { it.copy(failedSignals = it.failedSignals + signalResultData) }
     }
 
+    fun rememberSkipped(signalModel: SignalModel) {
+        val signalResultData = SignalResultData(
+            signalId = signalModel.id,
+        )
+        _state.update { it.copy(skippedSignals = it.skippedSignals + signalResultData) }
+    }
+
     data class State(
         val successfulSignals: List<SignalResultData> = emptyList(),
-        val failedSignals: List<SignalResultData> = emptyList()
+        val failedSignals: List<SignalResultData> = emptyList(),
+        val skippedSignals: List<SignalResultData> = emptyList()
     )
 }

--- a/components/remote-controls/setup/impl/src/main/res/values/strings.xml
+++ b/components/remote-controls/setup/impl/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <!--    Settings-->
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="skip">Skip</string>
     <string name="not_found_signal">Not found signal for your preferences</string>
     <string name="point_flipper">Point Flipper Zero at the %s and tap the button</string>
     <string name="setup_title">Set Up Remote</string>


### PR DESCRIPTION
**Background**
When setup of remote in progress, some button can be not avaliable, thus we need to skip them instead of yes/no

**Changes**

- Add signal skip backend integration

**Test plan**

- Open setup and try skip some buttons
