### PR TITLE
Remotecontrols/add history callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [Feature] Add How to Use dialog into remote-controls
 - [Feature] Skip infrared signals on setup screen
 - [Feature] Better user-ux when configuring remote control
+- [Feature] Navigate to previous setup item on remote controls
 - [Refactor] Load RemoteControls from flipper, emulating animation
 - [Refactor] Update to Kotlin 2.0
 - [Refactor] Replace Ktorfit with Ktor requests in remote-controls

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.remotecontrols.impl.setup.presentation.decompose.internal
 
 import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.essenty.backhandler.BackCallback
 import com.arkivanov.essenty.instancekeeper.getOrCreate
 import com.flipperdevices.bridge.dao.api.model.FlipperFilePath
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyType
@@ -136,10 +137,11 @@ class SetupComponentImpl @AssistedInject constructor(
     override fun tryLoad() {
         if (dispatchSignalApi.state.value is DispatchSignalApi.State.Emulating) return
         dispatchSignalApi.reset()
+        val historyData = historyViewModel.data
         createCurrentSignalViewModel.load(
-            successResults = historyViewModel.state.value.successfulSignals,
-            failedResults = historyViewModel.state.value.failedSignals,
-            skippedResults = historyViewModel.state.value.skippedSignals
+            successResults = historyData.successfulSignals,
+            failedResults = historyData.failedSignals,
+            skippedResults = historyData.skippedSignals
         )
         _lastEmulatedSignal.value = null
     }
@@ -201,7 +203,20 @@ class SetupComponentImpl @AssistedInject constructor(
         )
     }
 
-    override fun onBackClick() = onBackClick.invoke()
+    private val backCallback = BackCallback(true) {
+        if (historyViewModel.isEmpty) {
+            onBackClick.invoke()
+        } else {
+            historyViewModel.forgetLast()
+        }
+        tryLoad()
+    }
+
+    override fun onBackClick() = backCallback.onBack()
+
+    init {
+        backHandler.register(backCallback)
+    }
 }
 
 private val ABSOLUTE_TEMP_FOLDER_PATH = "/${FlipperKeyType.INFRARED.flipperDir}/temp"


### PR DESCRIPTION
**Background**

When setup of remotecontrol is in progress, we can't return to previous setup item

**Changes**

- Add back handler on setup screen

**Test plan**

- Open setup screen, press some buttons
- Press back or arrow at top left to return previous setup entry