### PR TITLE
Fix/infrared share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Fix flaky test
 - [FIX] Infinite dispatch after screen close on remote-control screens
 - [FIX] Bad bottom sheet animation on infrared setup screen
+- [FIX] Share infrared remote after rename
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/api/InfraredViewDecomposeComponentImpl.kt
+++ b/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/api/InfraredViewDecomposeComponentImpl.kt
@@ -56,7 +56,7 @@ class InfraredViewDecomposeComponentImpl @AssistedInject constructor(
         }
 
         shareBottomUiApi.ComposableShareBottomSheet(
-            viewModel.keyPath,
+            providerFlipperKeyPath = viewModel::getKeyPath,
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/api/InfraredViewDecomposeComponentImpl.kt
+++ b/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/api/InfraredViewDecomposeComponentImpl.kt
@@ -56,7 +56,7 @@ class InfraredViewDecomposeComponentImpl @AssistedInject constructor(
         }
 
         shareBottomUiApi.ComposableShareBottomSheet(
-            providerFlipperKeyPath = viewModel::getKeyPath,
+            provideFlipperKeyPath = viewModel::getKeyPath,
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/viewmodel/InfraredViewModel.kt
+++ b/components/infrared/impl/src/main/kotlin/com/flipperdevices/infrared/impl/viewmodel/InfraredViewModel.kt
@@ -10,6 +10,7 @@ import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.infrared.api.InfraredConnectionApi
 import com.flipperdevices.infrared.api.InfraredConnectionApi.InfraredEmulateState
 import com.flipperdevices.keyscreen.api.KeyStateHelperApi
+import com.flipperdevices.keyscreen.model.KeyScreenState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -19,15 +20,22 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class InfraredViewModel @AssistedInject constructor(
-    @Assisted val keyPath: FlipperKeyPath, // For get value to bottom sheet
+    @Assisted private val paramKeyPath: FlipperKeyPath, // For get value to bottom sheet
     keyStateHelperApi: KeyStateHelperApi.Builder,
     serviceProvider: FlipperServiceProvider,
     private val infraredConnectionApi: InfraredConnectionApi
 ) : DecomposeViewModel(), FlipperBleServiceConsumer, LogTagProvider {
     override val TAG: String = "InfraredViewModel"
 
-    private val keyStateHelper = keyStateHelperApi.build(keyPath, viewModelScope)
+    private val keyStateHelper = keyStateHelperApi.build(paramKeyPath, viewModelScope)
     fun getState() = keyStateHelper.getKeyScreenState()
+
+    fun getKeyPath(): FlipperKeyPath {
+        return (keyStateHelper.getKeyScreenState().value as? KeyScreenState.Ready)
+            ?.flipperKey
+            ?.getKeyPath()
+            ?: paramKeyPath
+    }
 
     private val emulateStateFlow = MutableStateFlow<InfraredEmulateState?>(null)
     fun getEmulateState() = emulateStateFlow.asStateFlow()

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
@@ -59,7 +59,7 @@ class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
             keyScreenViewModelFactory(keyPath)
         }
         shareBottomApi.ComposableShareBottomSheet(
-            flipperKeyPath = viewModel.keyPath,
+            providerFlipperKeyPath = viewModel::getKeyPath,
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
@@ -59,7 +59,7 @@ class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
             keyScreenViewModelFactory(keyPath)
         }
         shareBottomApi.ComposableShareBottomSheet(
-            providerFlipperKeyPath = viewModel::getKeyPath,
+            provideFlipperKeyPath = viewModel::getKeyPath,
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/KeyScreenViewModel.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/viewmodel/KeyScreenViewModel.kt
@@ -14,13 +14,20 @@ import kotlinx.coroutines.flow.StateFlow
 
 @Suppress("LongParameterList")
 class KeyScreenViewModel @AssistedInject constructor(
-    @Assisted val keyPath: FlipperKeyPath, // For get value to bottom sheet
+    @Assisted val paramKeyPath: FlipperKeyPath, // For get value to bottom sheet
     keyStateHelperApi: KeyStateHelperApi.Builder,
     private val metricApi: MetricApi
 ) : DecomposeViewModel(), LogTagProvider {
     override val TAG = "KeyScreenViewModel"
 
-    private val keyStateHelper = keyStateHelperApi.build(keyPath, viewModelScope)
+    private val keyStateHelper = keyStateHelperApi.build(paramKeyPath, viewModelScope)
+
+    fun getKeyPath(): FlipperKeyPath {
+        return (keyStateHelper.getKeyScreenState().value as? KeyScreenState.Ready)
+            ?.flipperKey
+            ?.getKeyPath()
+            ?: paramKeyPath
+    }
 
     fun getKeyScreenState(): StateFlow<KeyScreenState> = keyStateHelper.getKeyScreenState()
 

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
@@ -49,7 +49,7 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
     @Composable
     override fun Render() {
         shareBottomUiApi.ComposableShareBottomSheet(
-            providerFlipperKeyPath = { keyPath },
+            provideFlipperKeyPath = { keyPath },
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
@@ -49,7 +49,7 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
     @Composable
     override fun Render() {
         shareBottomUiApi.ComposableShareBottomSheet(
-            keyPath,
+            providerFlipperKeyPath = { keyPath },
             onSheetStateVisible = { isShown, onClose ->
                 val isBackPressHandled by isBackPressHandledFlow.collectAsState()
                 backCallback.isEnabled = isShown

--- a/components/share/api/src/main/java/com/flipperdevices/share/api/ShareBottomUIApi.kt
+++ b/components/share/api/src/main/java/com/flipperdevices/share/api/ShareBottomUIApi.kt
@@ -7,7 +7,7 @@ import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
 interface ShareBottomUIApi {
     @Composable
     fun ComposableShareBottomSheet(
-        providerFlipperKeyPath: () -> FlipperKeyPath,
+        provideFlipperKeyPath: () -> FlipperKeyPath,
         componentContext: ComponentContext,
         onSheetStateVisible: @Composable (isVisible: Boolean, onClose: () -> Unit) -> Unit,
         screenContent: @Composable (() -> Unit) -> Unit,

--- a/components/share/api/src/main/java/com/flipperdevices/share/api/ShareBottomUIApi.kt
+++ b/components/share/api/src/main/java/com/flipperdevices/share/api/ShareBottomUIApi.kt
@@ -7,7 +7,7 @@ import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
 interface ShareBottomUIApi {
     @Composable
     fun ComposableShareBottomSheet(
-        flipperKeyPath: FlipperKeyPath,
+        providerFlipperKeyPath: () -> FlipperKeyPath,
         componentContext: ComponentContext,
         onSheetStateVisible: @Composable (isVisible: Boolean, onClose: () -> Unit) -> Unit,
         screenContent: @Composable (() -> Unit) -> Unit,

--- a/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/api/ShareBottomUIImpl.kt
+++ b/components/share/uploader/src/main/kotlin/com/flipperdevices/uploader/api/ShareBottomUIImpl.kt
@@ -37,13 +37,13 @@ class ShareBottomUIImpl @Inject constructor(
     @Composable
     @Suppress("NonSkippableComposable")
     override fun ComposableShareBottomSheet(
-        flipperKeyPath: FlipperKeyPath,
+        provideFlipperKeyPath: () -> FlipperKeyPath,
         componentContext: ComponentContext,
         onSheetStateVisible: @Composable (isVisible: Boolean, onClose: () -> Unit) -> Unit,
         screenContent: @Composable (() -> Unit) -> Unit,
     ) {
-        val viewModel = componentContext.viewModelWithFactory(flipperKeyPath) {
-            uploaderViewModelFactory(flipperKeyPath)
+        val viewModel = componentContext.viewModelWithFactory(provideFlipperKeyPath.invoke()) {
+            uploaderViewModelFactory(provideFlipperKeyPath)
         }
 
         val scrimColor = if (MaterialTheme.colors.isLight) {


### PR DESCRIPTION
**Background**

When renaming infrared key you can't share it until you re-open screen

**Changes**

- Get keys as provider instead of value

**Test plan**

- Open infrared key
- Press share and see you can share it
- Rename key
- When infrared screen opened again press share
- See it also can be shared
