### PR TITLE
Remotecontrols/fix colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Infinite dispatch after screen close on remote-control screens
 - [FIX] Bad bottom sheet animation on infrared setup screen
 - [FIX] Share infrared remote after rename
+- [FIX] Fix app bar colors on remote controls
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/changelog/impl/src/main/kotlin/com/flipperdevices/changelog/impl/api/ChangelogScreenDecomposeComponentImpl.kt
+++ b/components/changelog/impl/src/main/kotlin/com/flipperdevices/changelog/impl/api/ChangelogScreenDecomposeComponentImpl.kt
@@ -8,14 +8,12 @@ import com.flipperdevices.changelog.api.ChangelogFormatterApi
 import com.flipperdevices.changelog.api.ChangelogScreenDecomposeComponent
 import com.flipperdevices.changelog.impl.composable.ChangelogScreenComposable
 import com.flipperdevices.core.di.AppGraph
-import com.flipperdevices.core.preference.pb.SelectedTheme
 import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
+import com.flipperdevices.ui.decompose.statusbar.ThemeStatusBarIconStyleProvider
 import com.flipperdevices.updater.model.UpdateRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import me.gulya.anvil.assisted.ContributesAssistedFactory
 
 @ContributesAssistedFactory(AppGraph::class, ChangelogScreenDecomposeComponent.Factory::class)
@@ -24,8 +22,11 @@ class ChangelogScreenDecomposeComponentImpl @AssistedInject constructor(
     @Assisted private val updateRequest: UpdateRequest,
     @Assisted private val onBack: DecomposeOnBackParameter,
     private val changelogFormatter: ChangelogFormatterApi,
-    private val dataStore: DataStore<Settings>
+    dataStore: DataStore<Settings>
 ) : ChangelogScreenDecomposeComponent(componentContext) {
+
+    private val themeStatusBarIconStyleProvider = ThemeStatusBarIconStyleProvider(dataStore)
+
     @Composable
     override fun Render() {
         val changelog = updateRequest.changelog
@@ -43,12 +44,6 @@ class ChangelogScreenDecomposeComponentImpl @AssistedInject constructor(
     }
 
     override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {
-        val settings = runBlocking { dataStore.data.first() }
-        return when (settings.selected_theme) {
-            SelectedTheme.SYSTEM,
-            is SelectedTheme.Unrecognized -> systemIsDark
-            SelectedTheme.DARK -> true
-            SelectedTheme.LIGHT -> false
-        }
+        return themeStatusBarIconStyleProvider.isStatusBarIconLight(systemIsDark)
     }
 }

--- a/components/core/ui/decompose/build.gradle.kts
+++ b/components/core/ui/decompose/build.gradle.kts
@@ -8,6 +8,8 @@ android.namespace = "com.flipperdevices.ui.decompose"
 commonDependencies {
     implementation(projects.components.core.activityholder)
 
+    implementation(projects.components.core.preference)
+
     implementation(libs.compose.ui)
     implementation(libs.compose.foundation)
 

--- a/components/core/ui/decompose/src/androidMain/kotlin/com/flipperdevices/ui/decompose/AndroidWindowDecorator.kt
+++ b/components/core/ui/decompose/src/androidMain/kotlin/com/flipperdevices/ui/decompose/AndroidWindowDecorator.kt
@@ -5,8 +5,8 @@ import android.os.Build
 import android.view.View
 import android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 import com.flipperdevices.core.activityholder.CurrentActivityHolder
-import com.flipperdevices.ui.decompose.internal.StatusBarIconStyleProvider
 import com.flipperdevices.ui.decompose.internal.WindowDecorator
+import com.flipperdevices.ui.decompose.statusbar.StatusBarIconStyleProvider
 
 internal class AndroidWindowDecorator(
     private val statusBarIconStyleProvider: StatusBarIconStyleProvider

--- a/components/core/ui/decompose/src/androidMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
+++ b/components/core/ui/decompose/src/androidMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.ui.decompose.internal
 
 import com.flipperdevices.ui.decompose.AndroidWindowDecorator
+import com.flipperdevices.ui.decompose.statusbar.StatusBarIconStyleProvider
 
 internal actual fun createWindowDecorator(
     statusBarIconStyleProvider: StatusBarIconStyleProvider

--- a/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/ScreenDecomposeComponent.kt
+++ b/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/ScreenDecomposeComponent.kt
@@ -2,9 +2,9 @@ package com.flipperdevices.ui.decompose
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.essenty.lifecycle.Lifecycle
-import com.flipperdevices.ui.decompose.internal.StatusBarIconStyleProvider
 import com.flipperdevices.ui.decompose.internal.WindowDecorator
 import com.flipperdevices.ui.decompose.internal.createWindowDecorator
+import com.flipperdevices.ui.decompose.statusbar.StatusBarIconStyleProvider
 
 abstract class ScreenDecomposeComponent(
     componentContext: ComponentContext

--- a/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
+++ b/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
@@ -1,5 +1,7 @@
 package com.flipperdevices.ui.decompose.internal
 
+import com.flipperdevices.ui.decompose.statusbar.StatusBarIconStyleProvider
+
 internal expect fun createWindowDecorator(
     statusBarIconStyleProvider: StatusBarIconStyleProvider
 ): WindowDecorator

--- a/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/statusbar/StatusBarIconStyleProvider.kt
+++ b/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/statusbar/StatusBarIconStyleProvider.kt
@@ -1,4 +1,4 @@
-package com.flipperdevices.ui.decompose.internal
+package com.flipperdevices.ui.decompose.statusbar
 
 internal interface StatusBarIconStyleProvider {
     fun isStatusBarIconLight(systemIsDark: Boolean): Boolean

--- a/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/statusbar/ThemeStatusBarIconStyleProvider.kt
+++ b/components/core/ui/decompose/src/commonMain/kotlin/com/flipperdevices/ui/decompose/statusbar/ThemeStatusBarIconStyleProvider.kt
@@ -1,0 +1,23 @@
+package com.flipperdevices.ui.decompose.statusbar
+
+import androidx.datastore.core.DataStore
+import com.flipperdevices.core.preference.pb.SelectedTheme
+import com.flipperdevices.core.preference.pb.Settings
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+class ThemeStatusBarIconStyleProvider(
+    private val dataStore: DataStore<Settings>
+) : StatusBarIconStyleProvider {
+
+    override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {
+        val settings = runBlocking { dataStore.data.first() }
+        return when (settings.selected_theme) {
+            SelectedTheme.SYSTEM,
+            is SelectedTheme.Unrecognized -> systemIsDark
+
+            SelectedTheme.DARK -> true
+            SelectedTheme.LIGHT -> false
+        }
+    }
+}

--- a/components/core/ui/decompose/src/desktopMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
+++ b/components/core/ui/decompose/src/desktopMain/kotlin/com/flipperdevices/ui/decompose/internal/WindowDecoratorFactory.kt
@@ -1,5 +1,7 @@
 package com.flipperdevices.ui.decompose.internal
 
+import com.flipperdevices.ui.decompose.statusbar.StatusBarIconStyleProvider
+
 internal actual fun createWindowDecorator(
     statusBarIconStyleProvider: StatusBarIconStyleProvider
 ): WindowDecorator = DesktopWindowDecorator()

--- a/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
+++ b/components/keyscreen/impl/src/main/java/com/flipperdevices/keyscreen/impl/api/KeyScreenViewDecomposeComponentImpl.kt
@@ -14,7 +14,6 @@ import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.essenty.backhandler.BackCallback
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
 import com.flipperdevices.bridge.synchronization.api.SynchronizationUiApi
-import com.flipperdevices.core.preference.pb.SelectedTheme
 import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.core.ui.lifecycle.viewModelWithFactory
 import com.flipperdevices.core.ui.theme.LocalPallet
@@ -25,13 +24,12 @@ import com.flipperdevices.keyscreen.impl.viewmodel.KeyScreenViewModel
 import com.flipperdevices.share.api.ShareBottomUIApi
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
 import com.flipperdevices.ui.decompose.ScreenDecomposeComponent
+import com.flipperdevices.ui.decompose.statusbar.ThemeStatusBarIconStyleProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.runBlocking
 
 @Suppress("LongParameterList")
 class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
@@ -43,10 +41,11 @@ class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
     private val shareBottomApi: ShareBottomUIApi,
     private val synchronizationUiApi: SynchronizationUiApi,
     private val keyEmulateApi: KeyEmulateApi,
-    private val dataStore: DataStore<Settings>
+    dataStore: DataStore<Settings>
 ) : ScreenDecomposeComponent(componentContext) {
     private val isBackPressHandledFlow = MutableStateFlow(false)
     private val backCallback = BackCallback(false) { isBackPressHandledFlow.update { true } }
+    private val themeStatusBarIconStyleProvider = ThemeStatusBarIconStyleProvider(dataStore)
 
     init {
         backHandler.register(backCallback)
@@ -96,14 +95,7 @@ class KeyScreenViewDecomposeComponentImpl @AssistedInject constructor(
     }
 
     override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {
-        val settings = runBlocking { dataStore.data.first() }
-        return when (settings.selected_theme) {
-            SelectedTheme.SYSTEM,
-            is SelectedTheme.Unrecognized -> systemIsDark
-
-            SelectedTheme.DARK -> true
-            SelectedTheme.LIGHT -> false
-        }
+        return themeStatusBarIconStyleProvider.isStatusBarIconLight(systemIsDark)
     }
 
     @AssistedFactory

--- a/components/remote-controls/core-ui/src/main/kotlin/com/flipperdevices/ifrmvp/core/ui/layout/shared/SharedTopBar.kt
+++ b/components/remote-controls/core-ui/src/main/kotlin/com/flipperdevices/ifrmvp/core/ui/layout/shared/SharedTopBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -29,14 +30,16 @@ import com.flipperdevices.core.ui.res.R as DesignSystem
 @Composable
 fun SharedTopBar(
     onBackClick: () -> Unit,
+    title: @Composable () -> Unit,
+    subtitle: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    title: String = "",
-    subtitle: String = "",
+    background: Color = LocalPalletV2.current.surface.navBar.body.accentBrand,
+    backIconTint: Color = LocalPalletV2.current.icon.blackAndWhite.blackOnColor,
     actions: @Composable BoxScope.() -> Unit = {}
 ) {
     Row(
         modifier = modifier
-            .background(LocalPalletV2.current.surface.navBar.body.accentBrand)
+            .background(background)
             .statusBarsPadding()
             .padding(horizontal = 14.dp, vertical = 16.dp)
             .fillMaxWidth(),
@@ -53,7 +56,7 @@ fun SharedTopBar(
                         .clickableRipple(bounded = false, onClick = onBackClick),
                     painter = painterResource(DesignSystem.drawable.ic_back),
                     contentDescription = null,
-                    tint = LocalPalletV2.current.icon.blackAndWhite.blackOnColor
+                    tint = backIconTint
                 )
             }
         )
@@ -63,20 +66,9 @@ fun SharedTopBar(
                 .weight(weight = 2f, fill = false)
                 .padding(horizontal = 8.dp)
         ) {
-            Text(
-                text = title,
-                color = LocalPalletV2.current.text.title.blackOnColor,
-                style = LocalTypography.current.titleEB18,
-                textAlign = TextAlign.Center,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+            title.invoke()
 
-            Text(
-                text = subtitle,
-                color = LocalPalletV2.current.text.title.blackOnColor,
-                style = LocalTypography.current.subtitleM12
-            )
+            subtitle.invoke()
         }
         Box(
             modifier = Modifier.weight(weight = 1f),
@@ -86,6 +78,43 @@ fun SharedTopBar(
             }
         )
     }
+}
+
+@Composable
+fun SharedTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    background: Color = LocalPalletV2.current.surface.navBar.body.accentBrand,
+    backIconTint: Color = LocalPalletV2.current.icon.blackAndWhite.blackOnColor,
+    textColor: Color = LocalPalletV2.current.text.title.blackOnColor,
+    title: String = "",
+    subtitle: String = "",
+    actions: @Composable BoxScope.() -> Unit = {}
+) {
+    SharedTopBar(
+        onBackClick = onBackClick,
+        actions = actions,
+        modifier = modifier,
+        background = background,
+        backIconTint = backIconTint,
+        title = {
+            Text(
+                text = title,
+                color = textColor,
+                style = LocalTypography.current.titleEB18,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        subtitle = {
+            Text(
+                text = subtitle,
+                color = textColor,
+                style = LocalTypography.current.subtitleM12
+            )
+        }
+    )
 }
 
 @Preview

--- a/components/remote-controls/grid/remote/impl/build.gradle.kts
+++ b/components/remote-controls/grid/remote/impl/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.components.core.ui.ktx)
     implementation(projects.components.core.ui.res)
     implementation(projects.components.core.ui.dialog)
+    implementation(projects.components.core.preference)
 
     implementation(projects.components.bridge.dao.api)
     implementation(projects.components.bridge.service.api)

--- a/components/remote-controls/grid/remote/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/remote/composable/components/RemoteGridTopBar.kt
+++ b/components/remote-controls/grid/remote/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/remote/composable/components/RemoteGridTopBar.kt
@@ -1,11 +1,13 @@
 package com.flipperdevices.remotecontrols.impl.grid.remote.composable.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -27,13 +29,17 @@ internal fun RemoteGridTopBar(
     SharedTopBar(
         onBackClick = onBack,
         title = remoteName.orEmpty(),
+        background = LocalPalletV2.current.surface.navBar.body.main,
+        backIconTint = LocalPalletV2.current.icon.blackAndWhite.default,
+        textColor = LocalPalletV2.current.text.title.primary,
         subtitle = when {
             saveProgress == null -> {
                 stringResource(R.string.remote_subtitle)
             }
 
             else -> {
-                stringResource(R.string.uploading_to_flipper).format("$saveProgress%")
+                val progress by animateIntAsState(saveProgress)
+                stringResource(R.string.uploading_to_flipper).format("$progress%")
             }
         },
         actions = {
@@ -45,7 +51,7 @@ internal fun RemoteGridTopBar(
                 Row(modifier = Modifier) {
                     Text(
                         text = stringResource(R.string.save),
-                        color = LocalPalletV2.current.text.title.blackOnColor,
+                        color = LocalPalletV2.current.text.title.primary,
                         style = LocalTypography.current.titleEB18,
                         textAlign = TextAlign.Center,
                         maxLines = 1,

--- a/components/remote-controls/grid/remote/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/remote/presentation/decompose/internal/RemoteGridScreenDecomposeComponentImpl.kt
+++ b/components/remote-controls/grid/remote/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/remote/presentation/decompose/internal/RemoteGridScreenDecomposeComponentImpl.kt
@@ -1,9 +1,11 @@
 package com.flipperdevices.remotecontrols.impl.grid.remote.presentation.decompose.internal
 
 import androidx.compose.runtime.Composable
+import androidx.datastore.core.DataStore
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.childContext
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.faphub.errors.api.FapHubComposableErrorsRenderer
 import com.flipperdevices.keyedit.api.NotSavedFlipperKey
 import com.flipperdevices.remotecontrols.api.FlipperDispatchDialogApi
@@ -12,6 +14,7 @@ import com.flipperdevices.remotecontrols.grid.remote.api.RemoteGridScreenDecompo
 import com.flipperdevices.remotecontrols.impl.grid.remote.composable.RemoteGridComposable
 import com.flipperdevices.remotecontrols.impl.grid.remote.presentation.decompose.RemoteGridComponent
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
+import com.flipperdevices.ui.decompose.statusbar.ThemeStatusBarIconStyleProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import me.gulya.anvil.assisted.ContributesAssistedFactory
@@ -25,7 +28,8 @@ class RemoteGridScreenDecomposeComponentImpl @AssistedInject constructor(
     @Assisted onSaveKey: (NotSavedFlipperKey) -> Unit,
     remoteGridComponentFactory: RemoteGridComponent.Factory,
     flipperDispatchDialogApiFactory: FlipperDispatchDialogApi.Factory,
-    private val errorsRenderer: FapHubComposableErrorsRenderer
+    private val errorsRenderer: FapHubComposableErrorsRenderer,
+    dataStore: DataStore<Settings>
 ) : RemoteGridScreenDecomposeComponent(componentContext) {
     private val gridComponent = remoteGridComponentFactory.invoke(
         componentContext = childContext("GridComponent"),
@@ -34,6 +38,7 @@ class RemoteGridScreenDecomposeComponentImpl @AssistedInject constructor(
         onSaveKey = onSaveKey
     )
     private val flipperDispatchDialogApi = flipperDispatchDialogApiFactory.invoke(onBack = onBack)
+    private val themeStatusBarIconStyleProvider = ThemeStatusBarIconStyleProvider(dataStore)
 
     @Composable
     override fun Render() {
@@ -42,5 +47,9 @@ class RemoteGridScreenDecomposeComponentImpl @AssistedInject constructor(
             errorsRenderer = errorsRenderer,
             flipperDispatchDialogApi = flipperDispatchDialogApi
         )
+    }
+
+    override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {
+        return themeStatusBarIconStyleProvider.isStatusBarIconLight(systemIsDark)
     }
 }

--- a/components/remote-controls/grid/saved/impl/build.gradle.kts
+++ b/components/remote-controls/grid/saved/impl/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.components.core.ui.ktx)
     implementation(projects.components.core.ui.res)
     implementation(projects.components.core.ui.dialog)
+    implementation(projects.components.core.preference)
 
     implementation(projects.components.bridge.dao.api)
     implementation(projects.components.bridge.service.api)

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
@@ -1,10 +1,13 @@
 package com.flipperdevices.remotecontrols.impl.grid.local.composable
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -15,15 +18,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.theme.LocalPalletV2
+import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.ifrmvp.core.ui.layout.shared.SharedTopBar
 import com.flipperdevices.infrared.api.InfraredConnectionApi.InfraredEmulateState
 import com.flipperdevices.remotecontrols.api.FlipperDispatchDialogApi
 import com.flipperdevices.remotecontrols.grid.saved.impl.R
 import com.flipperdevices.remotecontrols.impl.grid.local.api.LocalGridScreenDecomposeComponent
 import com.flipperdevices.remotecontrols.impl.grid.local.composable.components.ComposableInfraredDropDown
-import com.flipperdevices.remotecontrols.impl.grid.local.composable.components.ComposableSynchronizationNotification
+import com.flipperdevices.remotecontrols.impl.grid.local.composable.components.ComposableNotification
 import com.flipperdevices.remotecontrols.impl.grid.local.composable.components.LocalGridComposableContent
 import com.flipperdevices.remotecontrols.impl.grid.local.presentation.decompose.LocalGridComponent
 
@@ -52,8 +58,45 @@ fun LocalGridComposable(
             (model as? LocalGridComponent.Model.Loaded)?.let { loadedModel ->
                 SharedTopBar(
                     onBackClick = localGridComponent::pop,
-                    title = loadedModel.keyPath.path.nameWithoutExtension,
-                    subtitle = stringResource(R.string.remote_subtitle)
+                    background = LocalPalletV2.current.surface.navBar.body.main,
+                    backIconTint = LocalPalletV2.current.icon.blackAndWhite.default,
+                    title = {
+                        Text(
+                            text = loadedModel.keyPath.path.nameWithoutExtension,
+                            color = LocalPalletV2.current.text.title.primary,
+                            style = LocalTypography.current.titleEB18,
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    },
+                    subtitle = {
+                        Crossfade((model as? LocalGridComponent.Model.Loaded)?.connectionState) { connectionState ->
+                            when (connectionState) {
+                                InfraredEmulateState.ALL_GOOD -> {
+                                    Text(
+                                        text = stringResource(R.string.remote_subtitle),
+                                        color = LocalPalletV2.current.text.title.primary,
+                                        style = LocalTypography.current.subtitleM12,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+
+                                InfraredEmulateState.NOT_CONNECTED,
+                                InfraredEmulateState.CONNECTING,
+                                InfraredEmulateState.SYNCING,
+                                InfraredEmulateState.UPDATE_FLIPPER -> {
+                                    ComposableNotification(
+                                        state = connectionState,
+                                        modifier = Modifier
+                                    )
+                                }
+
+                                null -> Unit
+                            }
+                        }
+                    }
                 ) {
                     ComposableInfraredDropDown(
                         onRename = {
@@ -96,7 +139,6 @@ fun LocalGridComposable(
                 val state = (model as? LocalGridComponent.Model.Loaded)
                     ?.connectionState
                     ?: InfraredEmulateState.ALL_GOOD
-                ComposableSynchronizationNotification(state)
             }
         }
     )

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
@@ -1,8 +1,6 @@
 package com.flipperdevices.remotecontrols.impl.grid.local.composable
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -15,12 +13,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.flipperdevices.core.ui.theme.LocalPalletV2
 import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.ifrmvp.core.ui.layout.shared.SharedTopBar
@@ -129,17 +125,6 @@ fun LocalGridComposable(
                     .padding(scaffoldPaddings)
                     .navigationBarsPadding()
             )
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .navigationBarsPadding()
-                    .padding(14.dp),
-                contentAlignment = Alignment.BottomCenter
-            ) {
-                val state = (model as? LocalGridComponent.Model.Loaded)
-                    ?.connectionState
-                    ?: InfraredEmulateState.ALL_GOOD
-            }
         }
     )
 }

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
@@ -52,7 +52,7 @@ internal fun ComposableInfraredDropDown(
     val isDropDownEnabled = isConnected && !isEmulating
     val moreIconTint by animateColorAsState(
         if (isDropDownEnabled) {
-            LocalPalletV2.current.icon.blackAndWhite.blackOnColor
+            LocalPalletV2.current.icon.blackAndWhite.default
         } else {
             LocalPalletV2.current.action.neutral.icon.primary.disabled
         }

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
@@ -4,17 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.datastore.core.DataStore
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.childContext
 import com.arkivanov.essenty.backhandler.BackCallback
 import com.flipperdevices.bridge.dao.api.model.FlipperKeyPath
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.remotecontrols.api.FlipperDispatchDialogApi
 import com.flipperdevices.remotecontrols.impl.grid.local.api.LocalGridScreenDecomposeComponent
 import com.flipperdevices.remotecontrols.impl.grid.local.composable.LocalGridComposable
 import com.flipperdevices.remotecontrols.impl.grid.local.presentation.decompose.LocalGridComponent
 import com.flipperdevices.share.api.ShareBottomUIApi
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
+import com.flipperdevices.ui.decompose.statusbar.ThemeStatusBarIconStyleProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +34,7 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
     localGridComponentFactory: LocalGridComponent.Factory,
     private val shareBottomUiApi: ShareBottomUIApi,
     flipperDispatchDialogApiFactory: FlipperDispatchDialogApi.Factory,
+    dataStore: DataStore<Settings>
 ) : LocalGridScreenDecomposeComponent(componentContext) {
     private val localGridComponent = localGridComponentFactory.invoke(
         componentContext = childContext("GridComponent_local"),
@@ -41,6 +45,7 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
 
     private val isBackPressHandledFlow = MutableStateFlow(false)
     private val backCallback = BackCallback(false) { isBackPressHandledFlow.update { true } }
+    private val themeStatusBarIconStyleProvider = ThemeStatusBarIconStyleProvider(dataStore)
 
     init {
         backHandler.register(backCallback)
@@ -70,5 +75,9 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
                 onShare = onShare
             )
         }
+    }
+
+    override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {
+        return themeStatusBarIconStyleProvider.isStatusBarIconLight(systemIsDark)
     }
 }


### PR DESCRIPTION
**Background**

Remote controls screen has orange app bar, which are different on figma design.

**Changes**

- Fix app bar colors on remote control screens
- Add ThemeStatusBarIconStyleProvider to share it in 4 places with same implementation
- Remove snackbar animation and replace it with app bar texts

**Test plan**

- Open remote controls saved/remote screen
- See app bar now non-orange colors and system bar colors are ok
- See there's no snackbar, the status instead shown on app bar
