### PR TITLE
Fix bottombar bottomsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Bad bottom sheet animation on infrared setup screen
 - [FIX] Share infrared remote after rename
 - [FIX] Fix app bar colors on remote controls
+- [FIX] Fix remote controls texts and favorite dropdown
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
@@ -107,9 +107,11 @@ fun LocalGridComposable(
                                 onCallback.invoke(LocalGridScreenDecomposeComponent.Callback.Deleted)
                             }
                         },
+                        onFavorite = localGridComponent::toggleFavorite,
                         onShare = onShare,
                         isEmulating = loadedModel.emulatedKey != null,
-                        isConnected = loadedModel.isConnected
+                        isConnected = loadedModel.isConnected,
+                        isFavorite = loadedModel.isFavorite,
                     )
                 }
             }

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
@@ -33,6 +33,10 @@ import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.remotecontrols.grid.saved.impl.R
 import com.flipperdevices.core.ui.res.R as DesignSystem
 import com.flipperdevices.remotecontrols.core.ui.R as RemoteControlsR
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 
 @Composable
 @Suppress("LongMethod")
@@ -40,8 +44,10 @@ internal fun ComposableInfraredDropDown(
     onRename: () -> Unit,
     onShare: () -> Unit,
     onDelete: () -> Unit,
+    onFavorite: () -> Unit,
     isEmulating: Boolean,
     isConnected: Boolean,
+    isFavorite: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var isShowHowToUseDialog by remember { mutableStateOf(false) }
@@ -75,15 +81,23 @@ internal fun ComposableInfraredDropDown(
         )
         DropdownMenu(
             expanded = isShowMoreOptions,
-            onDismissRequest = { isShowMoreOptions = false }
+            onDismissRequest = { isShowMoreOptions = false },
+            modifier = Modifier.animateContentSize()
         ) {
             ComposableInfraredDropDownItem(
-                text = stringResource(R.string.option_how_to_use),
-                painter = painterResource(R.drawable.ic_how_to_use),
+                text = when (isFavorite) {
+                    true -> stringResource(R.string.favorites_added)
+                    false -> stringResource(R.string.favorites_add)
+                },
+                painter = when (isFavorite) {
+                    true -> painterResource(com.flipperdevices.core.ui.res.R.drawable.ic_star_enabled)
+                    false -> painterResource(com.flipperdevices.core.ui.res.R.drawable.ic_star_disabled)
+                },
+                colorIcon = LocalPallet.current.keyFavorite,
                 onClick = {
-                    isShowHowToUseDialog = !isShowHowToUseDialog
-                    onChangeState.invoke()
-                }
+                    onFavorite.invoke()
+                },
+                isActive = !isEmulating
             )
             Divider(modifier = Modifier.padding(horizontal = 8.dp))
             ComposableInfraredDropDownItem(
@@ -102,6 +116,15 @@ internal fun ComposableInfraredDropDown(
                 onClick = {
                     onChangeState.invoke()
                     onShare.invoke()
+                }
+            )
+            Divider(modifier = Modifier.padding(horizontal = 8.dp))
+            ComposableInfraredDropDownItem(
+                text = stringResource(R.string.option_how_to_use),
+                painter = painterResource(R.drawable.ic_how_to_use),
+                onClick = {
+                    isShowHowToUseDialog = !isShowHowToUseDialog
+                    onChangeState.invoke()
                 }
             )
             Divider(modifier = Modifier.padding(horizontal = 8.dp))

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
@@ -3,6 +3,7 @@
 package com.flipperdevices.remotecontrols.impl.grid.local.composable.components
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -33,10 +34,6 @@ import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.remotecontrols.grid.saved.impl.R
 import com.flipperdevices.core.ui.res.R as DesignSystem
 import com.flipperdevices.remotecontrols.core.ui.R as RemoteControlsR
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 
 @Composable
 @Suppress("LongMethod")

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/LocalGridComponent.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/LocalGridComponent.kt
@@ -17,6 +17,7 @@ interface LocalGridComponent {
     fun onButtonClick(identifier: IfrKeyIdentifier)
     fun onRename(onEndAction: (FlipperKeyPath) -> Unit)
     fun onDelete(onEndAction: () -> Unit)
+    fun toggleFavorite()
     fun pop()
     fun dismissDialog()
 
@@ -28,7 +29,8 @@ interface LocalGridComponent {
             val flipperDialog: FlipperDispatchDialogApi.DialogType? = null,
             val emulatedKey: IfrKeyIdentifier?,
             val connectionState: InfraredEmulateState,
-            val keyPath: FlipperKeyPath
+            val keyPath: FlipperKeyPath,
+            val isFavorite: Boolean
         ) : Model {
             val isSynchronizing = listOf(
                 InfraredEmulateState.SYNCING,

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridComponentImpl.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridComponentImpl.kt
@@ -55,7 +55,8 @@ class LocalGridComponentImpl @AssistedInject constructor(
                     flipperDialog = dispatchState.toDialogType(),
                     emulatedKey = (dispatchState as? DispatchSignalApi.State.Emulating)?.ifrKeyIdentifier,
                     connectionState = connectionState,
-                    keyPath = gridState.keyPath
+                    keyPath = gridState.keyPath,
+                    isFavorite = gridState.isFavorite
                 )
 
                 LocalGridViewModel.State.Loading -> LocalGridComponent.Model.Loading
@@ -78,6 +79,8 @@ class LocalGridComponentImpl @AssistedInject constructor(
     override fun onRename(onEndAction: (FlipperKeyPath) -> Unit) = localGridViewModel.onRename(onEndAction)
 
     override fun onDelete(onEndAction: () -> Unit) = localGridViewModel.onDelete(onEndAction)
+
+    override fun toggleFavorite() = localGridViewModel.toggleFavorite()
 
     override fun pop() = onBack.invoke()
 

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/viewmodel/LocalGridViewModel.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/viewmodel/LocalGridViewModel.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.ifrmvp.model.PagesLayout
 import com.flipperdevices.infrared.editor.core.model.InfraredRemote
 import com.flipperdevices.infrared.editor.core.parser.InfraredKeyParser
 import com.flipperdevices.keyscreen.api.KeyStateHelperApi
+import com.flipperdevices.keyscreen.model.FavoriteState
 import com.flipperdevices.keyscreen.model.KeyScreenState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -58,7 +59,8 @@ class LocalGridViewModel @AssistedInject constructor(
                         State.Loaded(
                             pagesLayout = pagesLayout,
                             remotes = remotes,
-                            keyPath = keyPath
+                            keyPath = keyPath,
+                            isFavorite = it.favoriteState == FavoriteState.FAVORITE
                         )
                     }
                 }
@@ -69,13 +71,21 @@ class LocalGridViewModel @AssistedInject constructor(
 
     fun onDelete(onEndAction: () -> Unit) = keyStateHelper.onDelete(onEndAction)
 
+    fun toggleFavorite() {
+        val state = keyStateHelper.getKeyScreenState().value
+        val readyState = state as? KeyScreenState.Ready ?: return
+        val isFavorite = readyState.favoriteState == FavoriteState.FAVORITE
+        keyStateHelper.setFavorite(!isFavorite)
+    }
+
     sealed interface State {
         data object Loading : State
         data object Error : State
         data class Loaded(
             val pagesLayout: PagesLayout,
             val remotes: ImmutableList<InfraredRemote>,
-            val keyPath: FlipperKeyPath
+            val keyPath: FlipperKeyPath,
+            val isFavorite: Boolean
         ) : State
     }
 

--- a/components/remote-controls/grid/saved/impl/src/main/res/values/strings.xml
+++ b/components/remote-controls/grid/saved/impl/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="rc_dialog_how_to_use_btn">Got it</string>
     <string name="rc_dialog_how_to_use_title">How to Use</string>
     <string name="rc_dialog_how_to_use_text">Point Flipper Zero at the device. Tap or hold the button on your phone to send the signal remotely.</string>
+    <string name="favorites_add">Add to Favorites</string>
+    <string name="favorites_added">Added</string>
 </resources>

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/SetupScreen.kt
@@ -112,7 +112,8 @@ fun SetupScreen(
                 .padding(scaffoldPaddings),
             onNegativeClick = setupComponent::onFailedClick,
             onSuccessClick = setupComponent::onSuccessClick,
-            onSkipClick = setupComponent::onSkipClicked
+            onSkipClick = setupComponent::onSkipClicked,
+            onDismissConfirm = setupComponent::forgetLastEmulatedSignal
         )
     }
 }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ButtonContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ButtonContent.kt
@@ -66,8 +66,7 @@ fun ButtonContent(
         )
         Spacer(modifier = Modifier.height(14.dp))
         Text(
-            text = stringResource(SetupR.string.point_flipper)
-                .format(categoryName),
+            text = stringResource(SetupR.string.point_flipper),
             style = LocalTypography.current.bodyM14,
             color = LocalPalletV2.current.text.body.secondary,
             textAlign = TextAlign.Center,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ButtonContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ButtonContent.kt
@@ -49,7 +49,6 @@ fun ButtonContent(
     isSyncing: Boolean,
     isConnected: Boolean,
     emulatedKeyIdentifier: IfrKeyIdentifier?,
-    categoryName: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -85,7 +84,6 @@ private fun ComposableConfirmContentDarkPreview() {
         Column {
             ButtonContent(
                 onClick = {},
-                categoryName = "CATEGORY",
                 data = TextButtonData(text = "Hello"),
                 emulatedKeyIdentifier = null,
                 isSyncing = false,
@@ -93,7 +91,6 @@ private fun ComposableConfirmContentDarkPreview() {
             )
             ButtonContent(
                 onClick = {},
-                categoryName = "CATEGORY 2",
                 data = TextButtonData(text = "TV/AV"),
                 emulatedKeyIdentifier = null,
                 isSyncing = false,
@@ -101,7 +98,6 @@ private fun ComposableConfirmContentDarkPreview() {
             )
             ButtonContent(
                 onClick = {},
-                categoryName = "CATEGORY 2",
                 data = TextButtonData(text = "Hello world"),
                 emulatedKeyIdentifier = null,
                 isSyncing = false,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -142,9 +142,7 @@ fun AnimatedConfirmContent(
             ConfirmContent(
                 text = when (contentState) {
                     null -> ""
-                    else ->
-                        contentState.message
-                            .format(contentState.categoryName)
+                    else -> contentState.message
                 },
                 onNegativeClick = onNegativeClick,
                 onPositiveClick = onSuccessClick,

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/ConfirmContent.kt
@@ -9,11 +9,13 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -29,6 +31,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.flipperdevices.core.ui.ktx.clickableRipple
 import com.flipperdevices.core.ui.ktx.elements.ComposableFlipperButton
 import com.flipperdevices.core.ui.theme.FlipperThemeInternal
@@ -117,6 +121,7 @@ fun AnimatedConfirmContent(
     onNegativeClick: () -> Unit,
     onSuccessClick: () -> Unit,
     onSkipClick: () -> Unit,
+    onDismissConfirm: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -127,28 +132,54 @@ fun AnimatedConfirmContent(
             targetState = lastEmulatedSignal,
             label = lastEmulatedSignal?.signalModel?.id?.toString()
         )
-        transition.AnimatedVisibility(
-            visible = { localLastEmulatedSignal -> localLastEmulatedSignal != null },
-            enter = slideInVertically(initialOffsetY = { it / 2 }) + fadeIn(),
-            exit = slideOutVertically(targetOffsetY = { it / 2 }) + fadeOut(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter),
-        ) {
-            val contentState = when (this.transition.targetState) {
-                EnterExitState.Visible -> transition.targetState
-                else -> transition.currentState
+        if (transition.targetState != null || transition.currentState != null || transition.isRunning) {
+            Dialog(
+                onDismissRequest = onDismissConfirm,
+                properties = DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                    dismissOnClickOutside = true,
+                    dismissOnBackPress = true
+                )
+            ) {
+                transition.AnimatedVisibility(
+                    visible = { localLastEmulatedSignal -> localLastEmulatedSignal != null },
+                    enter = slideInVertically(initialOffsetY = { it / 2 }) + fadeIn(),
+                    exit = slideOutVertically(targetOffsetY = { it / 2 }) + fadeOut(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomCenter)
+                        // This is required to close dialog when "clicking outside of borders"
+                        // The dialog displayed at bottom, therefore, the dialog itself
+                        // fills entire screen to display content at bottom
+                        .clickable(onClick = onDismissConfirm),
+                ) {
+                    val contentState = when (this.transition.targetState) {
+                        EnterExitState.Visible -> transition.targetState
+                        else -> transition.currentState
+                    }
+
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        ConfirmContent(
+                            text = when (contentState) {
+                                null -> ""
+                                else -> contentState.message
+                            },
+                            onNegativeClick = onNegativeClick,
+                            onPositiveClick = onSuccessClick,
+                            onSkipClick = onSkipClick,
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                // Redefine clickable listener to not close dialog when clicking on dialog content
+                                .clickable { }
+                        )
+                    }
+                }
             }
-            ConfirmContent(
-                text = when (contentState) {
-                    null -> ""
-                    else -> contentState.message
-                },
-                onNegativeClick = onNegativeClick,
-                onPositiveClick = onSuccessClick,
-                onSkipClick = onSkipClick,
-                modifier = Modifier.align(Alignment.BottomCenter)
-            )
         }
     }
 }

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/composable/components/LoadedContent.kt
@@ -32,7 +32,6 @@ fun LoadedContent(
                     onClick = onDispatchSignalClick,
                     modifier = Modifier.align(Alignment.Center),
                     data = signalResponse.data,
-                    categoryName = signalResponse.categoryName,
                     emulatedKeyIdentifier = model.emulatedKeyIdentifier,
                     isSyncing = model.isSyncing,
                     isConnected = model.isConnected

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/SetupComponent.kt
@@ -27,6 +27,7 @@ interface SetupComponent {
     fun onFailedClick()
     fun onSkipClicked()
     fun dispatchSignal()
+    fun forgetLastEmulatedSignal()
 
     fun dismissDialog()
 

--- a/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
+++ b/components/remote-controls/setup/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/setup/presentation/decompose/internal/SetupComponentImpl.kt
@@ -203,6 +203,10 @@ class SetupComponentImpl @AssistedInject constructor(
         )
     }
 
+    override fun forgetLastEmulatedSignal() {
+        _lastEmulatedSignal.value = null
+    }
+
     private val backCallback = BackCallback(true) {
         if (historyViewModel.isEmpty) {
             onBackClick.invoke()

--- a/components/remote-controls/setup/impl/src/main/res/values/strings.xml
+++ b/components/remote-controls/setup/impl/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="no">No</string>
     <string name="skip">Skip</string>
     <string name="not_found_signal">Not found signal for your preferences</string>
-    <string name="point_flipper">Point Flipper Zero at the %s and tap the button</string>
+    <string name="point_flipper">Point your Flipper Zero at the device and tap the button above</string>
     <string name="setup_title">Set Up Remote</string>
     <string name="setup_subtitle">Add remote</string>
     <string name="remotecontrols_dialog_flipper_not_connected_title">Flipper Not Connected</string>


### PR DESCRIPTION
**Background**

The bottom sheet on setup remote control is displayed above bottom bar. This pr wrap it inside dialog and shows on top of  bottombar

**Changes**

-  Wrap confirm display inside dialog to display it on top of screen

**Test plan**
- Open setup menu
- Press button to see bottomsheet
- Press back or yes/no/skip 
- See it good animated and displayed on top of screen
