### PR TITLE
remove share from remote controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Share infrared remote after rename
 - [FIX] Fix app bar colors on remote controls
 - [FIX] Fix remote controls texts and favorite dropdown
+- [FIX] Remove share from remote controls
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/LocalGridComposable.kt
@@ -35,7 +35,6 @@ fun LocalGridComposable(
     localGridComponent: LocalGridComponent,
     flipperDispatchDialogApi: FlipperDispatchDialogApi,
     onCallback: (LocalGridScreenDecomposeComponent.Callback) -> Unit,
-    onShare: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -108,7 +107,6 @@ fun LocalGridComposable(
                             }
                         },
                         onFavorite = localGridComponent::toggleFavorite,
-                        onShare = onShare,
                         isEmulating = loadedModel.emulatedKey != null,
                         isConnected = loadedModel.isConnected,
                         isFavorite = loadedModel.isFavorite,

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/composable/components/GridOptions.kt
@@ -39,7 +39,6 @@ import com.flipperdevices.remotecontrols.core.ui.R as RemoteControlsR
 @Suppress("LongMethod")
 internal fun ComposableInfraredDropDown(
     onRename: () -> Unit,
-    onShare: () -> Unit,
     onDelete: () -> Unit,
     onFavorite: () -> Unit,
     isEmulating: Boolean,
@@ -105,15 +104,6 @@ internal fun ComposableInfraredDropDown(
                     onRename.invoke()
                 },
                 isActive = !isEmulating
-            )
-            Divider(modifier = Modifier.padding(horizontal = 8.dp))
-            ComposableInfraredDropDownItem(
-                text = stringResource(R.string.option_share),
-                painter = painterResource(DesignSystem.drawable.ic_upload),
-                onClick = {
-                    onChangeState.invoke()
-                    onShare.invoke()
-                }
             )
             Divider(modifier = Modifier.padding(horizontal = 8.dp))
             ComposableInfraredDropDownItem(

--- a/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
+++ b/components/remote-controls/grid/saved/impl/src/main/kotlin/com/flipperdevices/remotecontrols/impl/grid/local/presentation/decompose/internal/LocalGridScreenDecomposeComponentImpl.kt
@@ -1,8 +1,6 @@
 package com.flipperdevices.remotecontrols.impl.grid.local.presentation.decompose.internal
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.datastore.core.DataStore
 import com.arkivanov.decompose.ComponentContext
@@ -15,7 +13,6 @@ import com.flipperdevices.remotecontrols.api.FlipperDispatchDialogApi
 import com.flipperdevices.remotecontrols.impl.grid.local.api.LocalGridScreenDecomposeComponent
 import com.flipperdevices.remotecontrols.impl.grid.local.composable.LocalGridComposable
 import com.flipperdevices.remotecontrols.impl.grid.local.presentation.decompose.LocalGridComponent
-import com.flipperdevices.share.api.ShareBottomUIApi
 import com.flipperdevices.ui.decompose.DecomposeOnBackParameter
 import com.flipperdevices.ui.decompose.statusbar.ThemeStatusBarIconStyleProvider
 import dagger.assisted.Assisted
@@ -32,7 +29,6 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
     @Assisted onBack: DecomposeOnBackParameter,
     @Assisted private val onCallback: (Callback) -> Unit,
     localGridComponentFactory: LocalGridComponent.Factory,
-    private val shareBottomUiApi: ShareBottomUIApi,
     flipperDispatchDialogApiFactory: FlipperDispatchDialogApi.Factory,
     dataStore: DataStore<Settings>
 ) : LocalGridScreenDecomposeComponent(componentContext) {
@@ -53,28 +49,11 @@ class LocalGridScreenDecomposeComponentImpl @AssistedInject constructor(
 
     @Composable
     override fun Render() {
-        shareBottomUiApi.ComposableShareBottomSheet(
-            provideFlipperKeyPath = { keyPath },
-            onSheetStateVisible = { isShown, onClose ->
-                val isBackPressHandled by isBackPressHandledFlow.collectAsState()
-                backCallback.isEnabled = isShown
-
-                LaunchedEffect(isBackPressHandled) {
-                    if (isBackPressHandled) {
-                        onClose()
-                        isBackPressHandledFlow.emit(false)
-                    }
-                }
-            },
-            componentContext = this
-        ) { onShare ->
-            LocalGridComposable(
-                localGridComponent = localGridComponent,
-                flipperDispatchDialogApi = flipperDispatchDialogApi,
-                onCallback = onCallback,
-                onShare = onShare
-            )
-        }
+        LocalGridComposable(
+            localGridComponent = localGridComponent,
+            flipperDispatchDialogApi = flipperDispatchDialogApi,
+            onCallback = onCallback,
+        )
     }
 
     override fun isStatusBarIconLight(systemIsDark: Boolean): Boolean {


### PR DESCRIPTION
**Background**

We can't currently share the ui with ir file

**Changes**

- Remove share from remote controls screen

**Test plan**
- Open saved remote control screen 
- See there's no share option
