### PR TITLE
Add experimental flag for remote controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [Feature] Add flipper action dialogs into remote control and move it into bottombar
 - [Feature] Add error display into remote controls screens
 - [Feature] Add new icons for remote-controls
+- [Feature] Add experimental option to enable remote controls
 - [Refactor] Load RemoteControls from flipper, emulating animation
 - [Refactor] Update to Kotlin 2.0
 - [Refactor] Replace Ktorfit with Ktor requests in remote-controls

--- a/components/core/preference/src/commonMain/proto/settings.proto
+++ b/components/core/preference/src/commonMain/proto/settings.proto
@@ -60,4 +60,5 @@ message Settings {
   bool fatal_ble_security_exception_happens = 26;
   bool notification_topic_update_enabled = 27;
   bool notification_dialog_shown = 28;
+  bool show_remote_controls = 29;
 }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
@@ -27,6 +27,7 @@ import com.flipperdevices.settings.impl.composable.category.ExportKeysCategory
 import com.flipperdevices.settings.impl.composable.category.OtherSettingsCategory
 import com.flipperdevices.settings.impl.composable.category.VersionCategory
 import com.flipperdevices.settings.impl.model.DebugSettingAction
+import com.flipperdevices.settings.impl.model.DebugSettingSwitch
 import com.flipperdevices.settings.impl.model.SettingsNavigationConfig
 import com.flipperdevices.settings.impl.viewmodels.DebugViewModel
 import com.flipperdevices.settings.impl.viewmodels.NotificationViewModel
@@ -79,6 +80,9 @@ fun ComposableSettings(
                 settings = settings,
                 onSwitchExperimental = settingsViewModel::onSwitchExperimental,
                 onOpenFM = { onOpen(SettingsNavigationConfig.FileManager) },
+                onSwitchRemoteControls = {
+                    debugViewModel.onSwitch(DebugSettingSwitch.ShowRemoteControls, it)
+                }
             )
             ExportKeysCategory(
                 exportState = exportState,

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/category/ExperimentalCategory.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/category/ExperimentalCategory.kt
@@ -3,6 +3,7 @@ package com.flipperdevices.settings.impl.composable.category
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.flipperdevices.core.preference.pb.Settings
+import com.flipperdevices.core.ui.theme.LocalTypography
 import com.flipperdevices.settings.impl.R
 import com.flipperdevices.settings.impl.composable.components.CategoryElement
 import com.flipperdevices.settings.impl.composable.components.ClickableElement
@@ -12,6 +13,7 @@ fun ExperimentalCategory(
     settings: Settings,
     onOpenFM: () -> Unit,
     onSwitchExperimental: (Boolean) -> Unit,
+    onSwitchRemoteControls: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     CardCategory(modifier = modifier) {
@@ -26,6 +28,13 @@ fun ExperimentalCategory(
                 titleId = R.string.experimental_file_manager,
                 descriptionId = R.string.experimental_file_manager_desc,
                 onClick = onOpenFM
+            )
+            CategoryElement(
+                titleId = R.string.experimental_remote_control,
+                descriptionId = R.string.experimental_remote_control_desc,
+                state = settings.show_remote_controls,
+                onSwitchState = onSwitchRemoteControls,
+                titleTextStyle = LocalTypography.current.bodyR14
             )
         }
     }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/components/CategoryElement.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/components/CategoryElement.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import com.flipperdevices.core.ui.ktx.clickableRipple
 import com.flipperdevices.core.ui.theme.LocalTypography
 
@@ -14,6 +15,7 @@ fun CategoryElement(
     state: Boolean,
     modifier: Modifier = Modifier,
     @StringRes descriptionId: Int? = null,
+    titleTextStyle: TextStyle = LocalTypography.current.buttonB16,
     onSwitchState: (Boolean) -> Unit
 ) {
     Row(
@@ -24,7 +26,7 @@ fun CategoryElement(
             Modifier.weight(weight = 1f),
             titleId,
             descriptionId,
-            titleTextStyle = LocalTypography.current.buttonB16
+            titleTextStyle = titleTextStyle
         )
         FlipperSwitch(state = state, onSwitchState = onSwitchState)
     }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/model/DebugSetting.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/model/DebugSetting.kt
@@ -7,6 +7,7 @@ sealed interface DebugSettingSwitch {
     data object SkipAutoSync : DebugSettingSwitch
     data object FapHubDev : DebugSettingSwitch
     data object SelfUpdaterDebug : DebugSettingSwitch
+    data object ShowRemoteControls : DebugSettingSwitch
 }
 
 sealed interface DebugSettingAction {

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/DebugViewModel.kt
@@ -49,6 +49,7 @@ class DebugViewModel @Inject constructor(
             DebugSettingSwitch.SelfUpdaterDebug -> onSwitchSelfUpdaterDebug(flag)
             DebugSettingSwitch.SkipAutoSync -> onSwitchSkipAutoSync(flag)
             DebugSettingSwitch.SkipProvisioning -> onSwitchIgnoreSubGhzProvisioning(flag)
+            DebugSettingSwitch.ShowRemoteControls -> onShowRemoteControls(flag)
         }
     }
 
@@ -136,6 +137,16 @@ class DebugViewModel @Inject constructor(
                 )
             }
             askRestartApp()
+        }
+    }
+
+    private fun onShowRemoteControls(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsDataStore.updateData {
+                it.copy(
+                    show_remote_controls = enabled
+                )
+            }
         }
     }
 

--- a/components/settings/impl/src/main/res/values/strings.xml
+++ b/components/settings/impl/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="experimental_file_manager">File Manager</string>
     <string name="experimental_file_manager_desc">Navigate through Flipper files</string>
     <string name="experimental_remote_control">Remote controls</string>
+    <string name="experimental_remote_control_desc">Configure remote controls and use it with flipper</string>
     <string name="experimental_screen_streaming">Screen Streaming</string>
     <string name="experimental_screen_streaming_desc">Control Flipper via phone</string>
     <string name="experimental_application_catalog">Enable Apps in Hub</string>

--- a/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/api/ToolsMainScreenDecomposeComponentImpl.kt
+++ b/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/api/ToolsMainScreenDecomposeComponentImpl.kt
@@ -9,6 +9,7 @@ import com.arkivanov.decompose.router.stack.pushToFront
 import com.flipperdevices.core.ui.lifecycle.viewModelWithFactory
 import com.flipperdevices.toolstab.impl.composable.ComposableHub
 import com.flipperdevices.toolstab.impl.model.ToolsNavigationConfig
+import com.flipperdevices.toolstab.impl.viewmodel.DebugSettingsViewModel
 import com.flipperdevices.toolstab.impl.viewmodel.ToolsNotificationViewModel
 import com.flipperdevices.ui.decompose.ScreenDecomposeComponent
 import dagger.assisted.Assisted
@@ -19,7 +20,8 @@ import javax.inject.Provider
 class ToolsMainScreenDecomposeComponentImpl @AssistedInject constructor(
     @Assisted componentContext: ComponentContext,
     @Assisted private val navigation: StackNavigation<ToolsNavigationConfig>,
-    private val toolsNotificationViewModelProvider: Provider<ToolsNotificationViewModel>
+    private val toolsNotificationViewModelProvider: Provider<ToolsNotificationViewModel>,
+    private val debugSettingsViewModelProvider: Provider<DebugSettingsViewModel>,
 ) : ScreenDecomposeComponent(componentContext) {
     @Composable
     @Suppress("NonSkippableComposable")
@@ -27,10 +29,15 @@ class ToolsMainScreenDecomposeComponentImpl @AssistedInject constructor(
         val nfcAttackViewModel = viewModelWithFactory(key = null) {
             toolsNotificationViewModelProvider.get()
         }
+        val debugSettingsViewModel = viewModelWithFactory(key = null) {
+            debugSettingsViewModelProvider.get()
+        }
         val hasNotification by nfcAttackViewModel.hasNotificationStateFlow.collectAsState()
+        val showRemoteControls by debugSettingsViewModel.showRemoteControls.collectAsState()
 
         ComposableHub(
             hasNotification = hasNotification,
+            showRemoteControls=showRemoteControls,
             onOpenMfKey32 = {
                 navigation.pushToFront(ToolsNavigationConfig.MfKey32)
             },

--- a/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/composable/ComposableHub.kt
+++ b/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/composable/ComposableHub.kt
@@ -11,6 +11,7 @@ import com.flipperdevices.toolstab.impl.composable.elements.RemoteControlsCompos
 @Composable
 fun ComposableHub(
     hasNotification: Boolean,
+    showRemoteControls: Boolean,
     onOpenMfKey32: () -> Unit,
     onOpenRemoteControls: () -> Unit,
     modifier: Modifier = Modifier
@@ -23,8 +24,10 @@ fun ComposableHub(
             hasMfKey32Notification = hasNotification,
             onOpenMfKey32 = onOpenMfKey32
         )
-        RemoteControlsComposable(
-            onOpenRemoteControls = onOpenRemoteControls
-        )
+        if (showRemoteControls) {
+            RemoteControlsComposable(
+                onOpenRemoteControls = onOpenRemoteControls
+            )
+        }
     }
 }

--- a/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/viewmodel/DebugSettingsViewModel.kt
+++ b/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/viewmodel/DebugSettingsViewModel.kt
@@ -1,0 +1,18 @@
+package com.flipperdevices.toolstab.impl.viewmodel
+
+import androidx.datastore.core.DataStore
+import com.flipperdevices.core.preference.pb.Settings
+import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+class DebugSettingsViewModel @Inject constructor(
+    settingsDataStore: DataStore<Settings>
+) : DecomposeViewModel() {
+    val showRemoteControls: StateFlow<Boolean> = settingsDataStore.data
+        .map { it.show_remote_controls && it.enabled_experimental_functions }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+}


### PR DESCRIPTION
**Background**

The beta of remote controls can be opened without any difficulty. This pr add more challenge to open remote controls via switch toggle inside experimental options!

**Changes**

- Add experimental switch for remote controls

**Test plan**

- Open tools tab to see there's no remote controls
- Open experimental options and switch toggle for remote controls
- Return into tools tab and see there's now remote controls displayed
- Disable experimental options with still enabled show remote controls
- Return into tools tab and see it's now gone when experimental options are disabled
