### PR TITLE
Remotes fix beta color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Remove share from remote controls
 - [FIX] Remove "RPC" argument from screen streaming request
 - [FIX] Fix remote-controls duplication ir files
+- [FIX] Fix infrared remotes card beta text color
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/composable/elements/RemoteControlsComposable.kt
+++ b/components/toolstab/impl/src/main/java/com/flipperdevices/toolstab/impl/composable/elements/RemoteControlsComposable.kt
@@ -104,11 +104,11 @@ private fun RemoteControls(
     Text(
         text = stringResource(R.string.card_beta),
         style = LocalTypography.current.subtitleR12,
-        color = LocalPallet.current.text30,
+        color = LocalPalletV2.current.action.fwUpdate.background.primary.default,
         modifier = Modifier
             .border(
                 1.dp,
-                LocalPalletV2.current.action.neutral.border.secondary.default,
+                LocalPalletV2.current.action.fwUpdate.background.primary.default,
                 RoundedCornerShape(30.dp)
             )
             .clip(RoundedCornerShape(30.dp))


### PR DESCRIPTION
**Background**

Current infrared card has grey color of "beta text"

**Changes**

- Change color of beta text on infrared color

**Test plan**

- Open tools tab
- See green text on beta text card
