### PR TITLE
Add deeplink fallback for flipper scheme uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Fix remote-controls duplication ir files
 - [FIX] Fix infrared remotes card beta text color
 - [FIX] Fix disappeared file manager
+- [FIX] Add deeplink fallback for flipper scheme uri
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/api/KeyParserImpl.kt
+++ b/components/keyparser/impl/src/main/kotlin/com/flipperdevices/keyparser/impl/api/KeyParserImpl.kt
@@ -10,6 +10,7 @@ import com.flipperdevices.core.data.PredefinedEnumMap
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.info
 import com.flipperdevices.core.log.warn
 import com.flipperdevices.keyparser.api.KeyParser
 import com.flipperdevices.keyparser.api.model.FlipperKeyParsed
@@ -108,23 +109,29 @@ class KeyParserImpl @Inject constructor() : KeyParser, LogTagProvider {
     }
 
     override fun parseUriToCryptoKeyData(uri: Uri): FlipperKeyCrypto? {
-        val fragment = uri.encodedFragment ?: return null
+        val fragment = uri.encodedFragment
+        if (fragment == null) {
+            info { "Failed parse $uri because fragment is null" }
+            return null
+        }
         val parsedFragment = urlDecoder.decodeQuery(fragment)
 
         val path = parsedFragment
             .firstOrNull { it.first == QUERY_KEY_PATH }
             ?.second
-            ?: return null
 
         val key = parsedFragment
             .firstOrNull { it.first == QUERY_KEY }
             ?.second
-            ?: return null
 
         val fileId = parsedFragment
             .firstOrNull { it.first == QUERY_ID }
             ?.second
-            ?: return null
+
+        if (path == null || key == null || fileId == null) {
+            info { "Failed parse uri $uri because path, key or fileId is null ($path,$key,$fileId)" }
+            return null
+        }
 
         return FlipperKeyCrypto(
             fileId = fileId,


### PR DESCRIPTION
**Background**

Right now we have bug with deeplink handling on some bad devices

**Changes**

- Add in deeplink parse fallback query segment apply
- Improve logging for deeplink parse

**Test plan**

Try open link from browser. For example, https://flpr.app/sf/#path=nfc/Volna_11.nfc&key=-9iAwAho85pFALQKZEc2Bg&id=ReRwXA