### PR TITLE
fix build when metrics disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 1.8.1 - In Progress
 
+- [FIX] Fix build when no metrics enabled
+
 # 1.8.0
 Attention: don't forget to add the flag for F-Droid before release
 
@@ -71,7 +73,6 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Add deeplink fallback for flipper scheme uri
 - [FIX] Change description of remotes library card
 - [FIX] Fix bytes race in new api
-- [FIX] Fix build when no metrics enabled
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Attention: don't forget to add the flag for F-Droid before release
 - [FIX] Add deeplink fallback for flipper scheme uri
 - [FIX] Change description of remotes library card
 - [FIX] Fix bytes race in new api
+- [FIX] Fix build when no metrics enabled
 - [CI] Fix merge-queue files diff
 - [CI] Add https://github.com/LionZXY/detekt-decompose-rule
 - [CI] Enabling detekt module for android and kmp modules

--- a/components/analytics/metric/noop/src/main/java/com/flipperdevices/metric/noop/NoopMetricAndroidApiImpl.kt
+++ b/components/analytics/metric/noop/src/main/java/com/flipperdevices/metric/noop/NoopMetricAndroidApiImpl.kt
@@ -1,0 +1,19 @@
+package com.flipperdevices.metric.noop
+
+import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.metric.api.MetricAndroidApi
+import com.flipperdevices.metric.api.MetricApi
+import com.flipperdevices.metric.api.events.ComplexEvent
+import com.flipperdevices.metric.api.events.SessionState
+import com.flipperdevices.metric.api.events.SimpleEvent
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppGraph::class, MetricAndroidApi::class)
+class NoopMetricAndroidApiImpl @Inject constructor() : MetricApi, MetricAndroidApi {
+    override fun reportSessionState(state: SessionState) = Unit
+
+    override fun reportSimpleEvent(simpleEvent: SimpleEvent, arg: String?) = Unit
+
+    override fun reportComplexEvent(complexEvent: ComplexEvent) = Unit
+}


### PR DESCRIPTION
**Background**

Android Project can't be build with disabled metrics due to it's inject in SingleActivity  #988 

**Changes**

- Add NoOp for AndroiMetricsApi

**Test plan**

- Assemble project with disabled metrics
