### PR TITLE
Migrate update to new BLE api

### DIFF
--- a/components/bridge/connection/device/fzero/impl/build.gradle.kts
+++ b/components/bridge/connection/device/fzero/impl/build.gradle.kts
@@ -30,6 +30,7 @@ commonDependencies {
     implementation(projects.components.bridge.connection.feature.deviceColor.api)
     implementation(projects.components.bridge.connection.feature.appstart.api)
     implementation(projects.components.bridge.connection.feature.screenstreaming.api)
+    implementation(projects.components.bridge.connection.feature.update.api)
 
     implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.immutable.collections)

--- a/components/bridge/connection/device/fzero/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/device/fzero/impl/utils/FZeroFeatureClassToEnumMapper.kt
+++ b/components/bridge/connection/device/fzero/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/device/fzero/impl/utils/FZeroFeatureClassToEnumMapper.kt
@@ -18,6 +18,7 @@ import com.flipperdevices.bridge.connection.feature.seriallagsdetector.api.FLags
 import com.flipperdevices.bridge.connection.feature.serialspeed.api.FSpeedFeatureApi
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toPersistentMap
 import kotlin.reflect.KClass
@@ -45,6 +46,7 @@ object FZeroFeatureClassToEnumMapper {
             FDeviceFeature.APP_START -> FAppStartFeatureApi::class
             FDeviceFeature.SCREEN_STREAMING -> FScreenStreamingFeatureApi::class
             FDeviceFeature.SCREEN_UNLOCK -> FScreenUnlockFeatureApi::class
+            FDeviceFeature.UPDATE -> FUpdateFeatureApi::class
         }
     }
 

--- a/components/bridge/connection/feature/common/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/common/api/FDeviceFeature.kt
+++ b/components/bridge/connection/feature/common/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/common/api/FDeviceFeature.kt
@@ -18,7 +18,8 @@ enum class FDeviceFeature {
     SDK_VERSION,
     APP_START,
     SCREEN_STREAMING,
-    SCREEN_UNLOCK
+    SCREEN_UNLOCK,
+    UPDATE
 }
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/components/bridge/connection/feature/update/api/build.gradle.kts
+++ b/components/bridge/connection/feature/update/api/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+}
+
+android.namespace = "com.flipperdevices.bridge.connection.feature.update.api"
+
+commonDependencies {
+    implementation(projects.components.core.data)
+    implementation(projects.components.core.ktx)
+
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.transport.common.api)
+    implementation(projects.components.bridge.connection.feature.rpcinfo.api)
+    implementation(projects.components.bridge.connection.pbutils)
+
+    implementation(libs.kotlin.immutable.collections)
+    implementation(libs.kotlin.coroutines)
+}

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/BootApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/BootApi.kt
@@ -1,0 +1,8 @@
+package com.flipperdevices.bridge.connection.feature.update.api
+
+import com.flipperdevices.protobuf.system.RebootRequest
+
+interface BootApi {
+    suspend fun systemUpdate(updateManifestPath: String): Result<Unit>
+    suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit>
+}

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/DisplayApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/DisplayApi.kt
@@ -1,0 +1,6 @@
+package com.flipperdevices.bridge.connection.feature.update.api
+
+interface DisplayApi {
+    suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit>
+    suspend fun stopVirtualDisplay(): Result<Unit>
+}

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
@@ -1,11 +1,8 @@
 package com.flipperdevices.bridge.connection.feature.update.api
 
 import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
-import com.flipperdevices.protobuf.system.RebootRequest
 
 interface FUpdateFeatureApi : FDeviceFeatureApi {
-    suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit>
-    suspend fun stopVirtualDisplay(): Result<Unit>
-    suspend fun systemUpdate(updateManifestPath: String): Result<Unit>
-    suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit>
+    fun displayApi(): DisplayApi
+    fun bootApi(): BootApi
 }

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
@@ -5,4 +5,8 @@ import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
 interface FUpdateFeatureApi : FDeviceFeatureApi {
     fun displayApi(): DisplayApi
     fun bootApi(): BootApi
+
+    companion object {
+        const val MANIFEST_FILE = "/ext/Manifest"
+    }
 }

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/FUpdateFeatureApi.kt
@@ -1,0 +1,11 @@
+package com.flipperdevices.bridge.connection.feature.update.api
+
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
+import com.flipperdevices.protobuf.system.RebootRequest
+
+interface FUpdateFeatureApi : FDeviceFeatureApi {
+    suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit>
+    suspend fun stopVirtualDisplay(): Result<Unit>
+    suspend fun systemUpdate(updateManifestPath: String): Result<Unit>
+    suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit>
+}

--- a/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/RegionApi.kt
+++ b/components/bridge/connection/feature/update/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/api/RegionApi.kt
@@ -1,0 +1,8 @@
+package com.flipperdevices.bridge.connection.feature.update.api
+
+interface RegionApi {
+    companion object {
+        const val REGION_FILE = "/int/.region_data"
+        const val UNKNOWN_REGION = "WW"
+    }
+}

--- a/components/bridge/connection/feature/update/impl/build.gradle.kts
+++ b/components/bridge/connection/feature/update/impl/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+    id("flipper.anvil-multiplatform")
+}
+
+android.namespace = "com.flipperdevices.bridge.connection.feature.update.impl"
+
+commonDependencies {
+    implementation(projects.components.bridge.connection.feature.update.api)
+
+    implementation(projects.components.core.di)
+    implementation(projects.components.core.log)
+    implementation(projects.components.core.ktx)
+
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.transport.common.api)
+    implementation(projects.components.bridge.connection.feature.rpc.api)
+    implementation(projects.components.bridge.connection.feature.rpc.model)
+    implementation(projects.components.bridge.connection.feature.rpcinfo.api)
+
+    implementation(projects.components.bridge.connection.pbutils)
+
+    implementation(libs.kotlin.coroutines)
+}

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/BootApiImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/BootApiImpl.kt
@@ -1,0 +1,33 @@
+package com.flipperdevices.bridge.connection.feature.update.impl.api
+
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequestPriority
+import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
+import com.flipperdevices.bridge.connection.feature.update.api.BootApi
+import com.flipperdevices.protobuf.Main
+import com.flipperdevices.protobuf.system.RebootRequest
+import com.flipperdevices.protobuf.system.UpdateRequest
+
+class BootApiImpl(
+    private val rpcFeatureApi: FRpcFeatureApi
+) : BootApi {
+    override suspend fun systemUpdate(updateManifestPath: String): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                system_update_request = UpdateRequest(
+                    update_manifest = updateManifestPath
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    override suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                system_reboot_request = RebootRequest(
+                    mode = mode
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+}

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/DisplayApiImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/DisplayApiImpl.kt
@@ -1,0 +1,37 @@
+package com.flipperdevices.bridge.connection.feature.update.impl.api
+
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequestPriority
+import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
+import com.flipperdevices.bridge.connection.feature.update.api.DisplayApi
+import com.flipperdevices.protobuf.Main
+import com.flipperdevices.protobuf.screen.ScreenFrame
+import com.flipperdevices.protobuf.screen.StartVirtualDisplayRequest
+import com.flipperdevices.protobuf.screen.StopVirtualDisplayRequest
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import okio.ByteString.Companion.toByteString
+
+class DisplayApiImpl @AssistedInject constructor(
+    @Assisted private val rpcFeatureApi: FRpcFeatureApi,
+) : DisplayApi {
+    override suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                gui_start_virtual_display_request = StartVirtualDisplayRequest(
+                    first_frame = ScreenFrame(
+                        data_ = byteArray.toByteString()
+                    )
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    override suspend fun stopVirtualDisplay(): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                gui_stop_virtual_display_request = StopVirtualDisplayRequest()
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+}

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
@@ -1,0 +1,84 @@
+package com.flipperdevices.bridge.connection.feature.update.impl.api
+
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequestPriority
+import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.protobuf.Main
+import com.flipperdevices.protobuf.Region
+import com.flipperdevices.protobuf.screen.ScreenFrame
+import com.flipperdevices.protobuf.screen.StartVirtualDisplayRequest
+import com.flipperdevices.protobuf.screen.StopVirtualDisplayRequest
+import com.flipperdevices.protobuf.system.PlayAudiovisualAlertRequest
+import com.flipperdevices.protobuf.system.RebootRequest
+import com.flipperdevices.protobuf.system.UpdateRequest
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.map
+import okio.ByteString
+import okio.ByteString.Companion.encode
+import okio.ByteString.Companion.toByteString
+import java.nio.charset.Charset
+
+class FUpdateFeatureApiImpl @AssistedInject constructor(
+    @Assisted private val rpcFeatureApi: FRpcFeatureApi,
+) : FUpdateFeatureApi,
+    LogTagProvider {
+    override val TAG = "FAlarmFeatureApi"
+
+    override suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                gui_start_virtual_display_request = StartVirtualDisplayRequest(
+                    first_frame = ScreenFrame(
+                        data_ = byteArray.toByteString()
+                    )
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    override suspend fun stopVirtualDisplay(): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                gui_stop_virtual_display_request = StopVirtualDisplayRequest()
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    override suspend fun systemUpdate(updateManifestPath: String): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                system_update_request = UpdateRequest(
+                    update_manifest = updateManifestPath
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    override suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit> {
+        return rpcFeatureApi.requestOnce(
+            Main(
+                system_reboot_request = RebootRequest(
+                    mode = mode
+                )
+            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
+        ).map { }
+    }
+
+    suspend fun region(finalCodeRegion: String, bands: List<Region.Band>) {
+        Region(
+            country_code = finalCodeRegion.encode(Charset.forName("ASCII")),
+            bands = bands
+        )
+    }
+
+    @AssistedFactory
+    fun interface InternalFactory {
+        operator fun invoke(
+            rpcFeatureApi: FRpcFeatureApi,
+        ): FUpdateFeatureApiImpl
+    }
+}

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
@@ -10,14 +10,12 @@ import com.flipperdevices.protobuf.Region
 import com.flipperdevices.protobuf.screen.ScreenFrame
 import com.flipperdevices.protobuf.screen.StartVirtualDisplayRequest
 import com.flipperdevices.protobuf.screen.StopVirtualDisplayRequest
-import com.flipperdevices.protobuf.system.PlayAudiovisualAlertRequest
 import com.flipperdevices.protobuf.system.RebootRequest
 import com.flipperdevices.protobuf.system.UpdateRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.map
-import okio.ByteString
 import okio.ByteString.Companion.encode
 import okio.ByteString.Companion.toByteString
 import java.nio.charset.Charset

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureApiImpl.kt
@@ -1,82 +1,29 @@
 package com.flipperdevices.bridge.connection.feature.update.impl.api
 
-import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
-import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequestPriority
-import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
+import com.flipperdevices.bridge.connection.feature.update.api.BootApi
+import com.flipperdevices.bridge.connection.feature.update.api.DisplayApi
 import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import com.flipperdevices.core.log.LogTagProvider
-import com.flipperdevices.protobuf.Main
-import com.flipperdevices.protobuf.Region
-import com.flipperdevices.protobuf.screen.ScreenFrame
-import com.flipperdevices.protobuf.screen.StartVirtualDisplayRequest
-import com.flipperdevices.protobuf.screen.StopVirtualDisplayRequest
-import com.flipperdevices.protobuf.system.RebootRequest
-import com.flipperdevices.protobuf.system.UpdateRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.map
-import okio.ByteString.Companion.encode
-import okio.ByteString.Companion.toByteString
-import java.nio.charset.Charset
 
 class FUpdateFeatureApiImpl @AssistedInject constructor(
-    @Assisted private val rpcFeatureApi: FRpcFeatureApi,
+    @Assisted private val displayApi: DisplayApi,
+    @Assisted private val bootApi: BootApi,
 ) : FUpdateFeatureApi,
     LogTagProvider {
     override val TAG = "FAlarmFeatureApi"
 
-    override suspend fun startVirtualDisplay(byteArray: ByteArray): Result<Unit> {
-        return rpcFeatureApi.requestOnce(
-            Main(
-                gui_start_virtual_display_request = StartVirtualDisplayRequest(
-                    first_frame = ScreenFrame(
-                        data_ = byteArray.toByteString()
-                    )
-                )
-            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).map { }
-    }
+    override fun bootApi(): BootApi = bootApi
 
-    override suspend fun stopVirtualDisplay(): Result<Unit> {
-        return rpcFeatureApi.requestOnce(
-            Main(
-                gui_stop_virtual_display_request = StopVirtualDisplayRequest()
-            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).map { }
-    }
-
-    override suspend fun systemUpdate(updateManifestPath: String): Result<Unit> {
-        return rpcFeatureApi.requestOnce(
-            Main(
-                system_update_request = UpdateRequest(
-                    update_manifest = updateManifestPath
-                )
-            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).map { }
-    }
-
-    override suspend fun reboot(mode: RebootRequest.RebootMode): Result<Unit> {
-        return rpcFeatureApi.requestOnce(
-            Main(
-                system_reboot_request = RebootRequest(
-                    mode = mode
-                )
-            ).wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).map { }
-    }
-
-    suspend fun region(finalCodeRegion: String, bands: List<Region.Band>) {
-        Region(
-            country_code = finalCodeRegion.encode(Charset.forName("ASCII")),
-            bands = bands
-        )
-    }
+    override fun displayApi(): DisplayApi = displayApi
 
     @AssistedFactory
     fun interface InternalFactory {
         operator fun invoke(
-            rpcFeatureApi: FRpcFeatureApi,
+            displayApi: DisplayApi,
+            bootApi: BootApi,
         ): FUpdateFeatureApiImpl
     }
 }

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureFactoryImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureFactoryImpl.kt
@@ -23,7 +23,12 @@ class FUpdateFeatureFactoryImpl @Inject constructor(
     ): FDeviceFeatureApi? {
         val rpcApi = unsafeFeatureDeviceApi.getUnsafe(FRpcFeatureApi::class) ?: return null
         return factory(
-            rpcFeatureApi = rpcApi,
+            displayApi = DisplayApiImpl(
+                rpcFeatureApi = rpcApi
+            ),
+            bootApi = BootApiImpl(
+                rpcFeatureApi = rpcApi
+            )
         )
     }
 }

--- a/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureFactoryImpl.kt
+++ b/components/bridge/connection/feature/update/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/update/impl/api/FUpdateFeatureFactoryImpl.kt
@@ -1,0 +1,29 @@
+package com.flipperdevices.bridge.connection.feature.update.impl.api
+
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeature
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureQualifier
+import com.flipperdevices.bridge.connection.feature.common.api.FUnsafeDeviceFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.transport.common.api.FConnectedDeviceApi
+import com.flipperdevices.core.di.AppGraph
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@FDeviceFeatureQualifier(FDeviceFeature.UPDATE)
+@ContributesMultibinding(AppGraph::class, FDeviceFeatureApi.Factory::class)
+class FUpdateFeatureFactoryImpl @Inject constructor(
+    private val factory: FUpdateFeatureApiImpl.InternalFactory
+) : FDeviceFeatureApi.Factory {
+    override suspend fun invoke(
+        unsafeFeatureDeviceApi: FUnsafeDeviceFeatureApi,
+        scope: CoroutineScope,
+        connectedDevice: FConnectedDeviceApi
+    ): FDeviceFeatureApi? {
+        val rpcApi = unsafeFeatureDeviceApi.getUnsafe(FRpcFeatureApi::class) ?: return null
+        return factory(
+            rpcFeatureApi = rpcApi,
+        )
+    }
+}

--- a/components/updater/api/build.gradle.kts
+++ b/components/updater/api/build.gradle.kts
@@ -7,12 +7,13 @@ plugins {
 android.namespace = "com.flipperdevices.updater.api"
 
 dependencies {
-    implementation(projects.components.bridge.service.api)
     implementation(projects.components.deeplink.api)
     implementation(projects.components.core.ktx)
     implementation(projects.components.core.ui.decompose)
 
     implementation(libs.kotlin.serialization.json)
+
+    implementation(projects.components.bridge.connection.feature.getinfo.api)
 
     implementation(libs.kotlin.coroutines)
     implementation(libs.compose.ui)

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/api/FlipperVersionProviderApi.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/api/FlipperVersionProviderApi.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.updater.api
 
-import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
 import com.flipperdevices.updater.model.FirmwareVersion
 import kotlinx.coroutines.flow.Flow
 

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/api/FlipperVersionProviderApi.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/api/FlipperVersionProviderApi.kt
@@ -1,13 +1,9 @@
 package com.flipperdevices.updater.api
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
 import com.flipperdevices.updater.model.FirmwareVersion
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface FlipperVersionProviderApi {
-    fun getCurrentFlipperVersion(
-        coroutineScope: CoroutineScope,
-        serviceApi: FlipperServiceApi
-    ): Flow<FirmwareVersion?>
+    fun getCurrentFlipperVersion(): Flow<FirmwareVersion?>
 }

--- a/components/updater/api/src/main/java/com/flipperdevices/updater/api/UpdateStateApi.kt
+++ b/components/updater/api/src/main/java/com/flipperdevices/updater/api/UpdateStateApi.kt
@@ -1,13 +1,11 @@
 package com.flipperdevices.updater.api
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
 import com.flipperdevices.updater.model.FlipperUpdateState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface UpdateStateApi {
     fun getFlipperUpdateState(
-        serviceApi: FlipperServiceApi,
         scope: CoroutineScope
     ): Flow<FlipperUpdateState>
 }

--- a/components/updater/card/build.gradle.kts
+++ b/components/updater/card/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 
     implementation(projects.components.bridge.connection.feature.provider.api)
     implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.feature.update.api)
     implementation(projects.components.bridge.connection.orchestrator.api)
     implementation(projects.components.bridge.connection.feature.protocolversion.api)
     implementation(projects.components.bridge.connection.feature.storage.api)

--- a/components/updater/card/build.gradle.kts
+++ b/components/updater/card/build.gradle.kts
@@ -25,11 +25,6 @@ dependencies {
     implementation(projects.components.info.shared)
     implementation(projects.components.rootscreen.api)
 
-    implementation(projects.components.bridge.api)
-    implementation(projects.components.bridge.rpcinfo.api)
-    implementation(projects.components.bridge.service.api)
-    implementation(projects.components.bridge.pbutils)
-
     implementation(projects.components.analytics.metric.api)
 
     implementation(libs.lifecycle.viewmodel.ktx)
@@ -38,6 +33,16 @@ dependencies {
 
     implementation(libs.annotations)
     implementation(libs.appcompat)
+
+    implementation(projects.components.bridge.connection.feature.provider.api)
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.orchestrator.api)
+    implementation(projects.components.bridge.connection.feature.protocolversion.api)
+    implementation(projects.components.bridge.connection.feature.storage.api)
+    implementation(projects.components.bridge.connection.feature.storageinfo.api)
+    implementation(projects.components.bridge.connection.feature.getinfo.api)
+    implementation(projects.components.bridge.connection.feature.rpcinfo.api)
+    implementation(projects.components.bridge.connection.pbutils)
 
     // Compose
     implementation(libs.compose.ui)

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdateStateApiImpl.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdateStateApiImpl.kt
@@ -17,7 +17,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
@@ -40,8 +39,8 @@ class UpdateStateApiImpl @Inject constructor(
             versionParser.getCurrentFlipperVersion(),
             updaterApi.getState()
         ) { deviceConnection, connectionState, flipperVersion, updaterState ->
-            val isReady = connectionState?.value == FlipperSupportedState.READY
-                    && deviceConnection is FDeviceConnectStatus.Connected
+            val isReady = connectionState?.value == FlipperSupportedState.READY &&
+                deviceConnection is FDeviceConnectStatus.Connected
 
             return@combine if (isReady && flipperVersion != null) {
                 when (updaterState.state) {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdateStateApiImpl.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/api/UpdateStateApiImpl.kt
@@ -1,8 +1,12 @@
 package com.flipperdevices.updater.card.api
 
-import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
-import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.protocolversion.api.FVersionFeatureApi
+import com.flipperdevices.bridge.connection.feature.protocolversion.model.FlipperSupportedState
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureStatus
+import com.flipperdevices.bridge.connection.feature.provider.api.get
+import com.flipperdevices.bridge.connection.orchestrator.api.FDeviceOrchestrator
+import com.flipperdevices.bridge.connection.orchestrator.api.model.FDeviceConnectStatus
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.api.FlipperVersionProviderApi
 import com.flipperdevices.updater.api.UpdateStateApi
@@ -13,24 +17,31 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 
 @ContributesBinding(AppGraph::class, UpdateStateApi::class)
 class UpdateStateApiImpl @Inject constructor(
     private val versionParser: FlipperVersionProviderApi,
-    private val updaterApi: UpdaterApi
+    private val updaterApi: UpdaterApi,
+    private val fFeatureProvider: FFeatureProvider,
+    private val fDeviceOrchestrator: FDeviceOrchestrator
 ) : UpdateStateApi {
     override fun getFlipperUpdateState(
-        serviceApi: FlipperServiceApi,
         scope: CoroutineScope
     ): Flow<FlipperUpdateState> {
         return combine(
-            serviceApi.connectionInformationApi.getConnectionStateFlow(),
-            versionParser.getCurrentFlipperVersion(scope, serviceApi),
+            fDeviceOrchestrator.getState(),
+            fFeatureProvider.get<FVersionFeatureApi>()
+                .map { status -> status as? FFeatureStatus.Supported<FVersionFeatureApi> }
+                .mapLatest { status -> status?.featureApi?.getSupportedStateFlow() },
+            versionParser.getCurrentFlipperVersion(),
             updaterApi.getState()
-        ) { connectionState, flipperVersion, updaterState ->
-            val isReady = connectionState is ConnectionState.Ready &&
-                connectionState.supportedState == FlipperSupportedState.READY
+        ) { deviceConnection, connectionState, flipperVersion, updaterState ->
+            val isReady = connectionState?.value == FlipperSupportedState.READY
+                    && deviceConnection is FDeviceConnectStatus.Connected
 
             return@combine if (isReady && flipperVersion != null) {
                 when (updaterState.state) {
@@ -40,15 +51,18 @@ class UpdateStateApiImpl @Inject constructor(
                         )
                         FlipperUpdateState.Ready
                     }
+
                     is UpdatingState.Complete ->
                         FlipperUpdateState.Complete(updaterState.request?.updateTo)
+
                     is UpdatingState.Failed ->
                         FlipperUpdateState.Failed(updaterState.request?.updateTo)
+
                     else -> FlipperUpdateState.Ready
                 }
             } else if (updaterState.state is UpdatingState.Rebooting) {
                 FlipperUpdateState.Updating
-            } else if (connectionState is ConnectionState.Disconnected) {
+            } else if (deviceConnection is FDeviceConnectStatus.Disconnected) {
                 FlipperUpdateState.NotConnected
             } else {
                 FlipperUpdateState.ConnectingInProgress

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/FileExistHelper.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/FileExistHelper.kt
@@ -1,29 +1,24 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.api.manager.FlipperRequestApi
-import com.flipperdevices.bridge.api.model.FlipperRequestPriority
-import com.flipperdevices.bridge.api.model.wrapToRequest
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.core.log.info
-import com.flipperdevices.protobuf.Flipper
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.storage.md5sumRequest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 class FileExistHelper @Inject constructor() {
-    fun isFileExist(pathToFile: String, requestApi: FlipperRequestApi): Flow<Boolean> {
-        return requestApi.request(
-            main {
-                storageMd5SumRequest = md5sumRequest {
-                    path = pathToFile
-                }
-            }.wrapToRequest(FlipperRequestPriority.BACKGROUND)
-        ).map { response ->
-            // if md5sum return not ok, we suppose file not exist
-            val exist = (response.commandStatus == Flipper.CommandStatus.OK)
-            info { "Exist file($pathToFile) is exist: $exist" }
-            exist
+    fun isFileExist(pathToFile: String, fListingStorageApi: FListingStorageApi): Flow<Boolean> {
+        return flow {
+            fListingStorageApi.lsWithMd5Flow(pathToFile)
+                .map { it.getOrNull().orEmpty().isNotEmpty() }
+                .onEach { isExist ->
+                    info { "Exist file($pathToFile) is exist: $isExist" }
+                    emit(isExist)
+                }.collect()
         }
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/FileExistHelper.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/FileExistHelper.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.flow.Flow

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
@@ -1,6 +1,6 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferDelegate
 import com.squareup.anvil.annotations.ContributesBinding
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
 interface UpdateOfferProviderApi {
-    fun isUpdateRequire(serviceApi: FlipperServiceApi): Flow<Boolean>
+    fun isUpdateRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean>
 }
 
 @ContributesBinding(AppGraph::class, UpdateOfferProviderApi::class)
@@ -19,15 +19,10 @@ class UpdateOfferProvider @Inject constructor(
     private val delegates: MutableSet<UpdateOfferDelegate>
 ) : UpdateOfferProviderApi {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override fun isUpdateRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
-        return serviceApi.connectionInformationApi.getConnectionStateFlow()
-            .flatMapLatest { _ ->
-                combine(
-                    delegates.map { it.isRequire(serviceApi) }
-                ) { delegate ->
-                    return@combine delegate.any { it }
-                }
-            }
+    override fun isUpdateRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
+        return combine(
+            flows = delegates.map { it.isRequire(fStorageFeatureApi) },
+            transform = { delegate -> return@combine delegate.any { it } }
+        )
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/UpdateOfferProvider.kt
@@ -4,10 +4,8 @@ import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureA
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferDelegate
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
 interface UpdateOfferProviderApi {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlways.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlways.kt
@@ -1,7 +1,8 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import androidx.datastore.core.DataStore
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.preference.pb.Settings
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -14,7 +15,7 @@ class UpdateOfferDebugFlagAlways @Inject constructor(
     private val dataStoreSettings: DataStore<Settings>
 ) : UpdateOfferDelegate {
 
-    override fun isRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
+    override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
         return dataStoreSettings.data.map { it.always_update }
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlways.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlways.kt
@@ -2,7 +2,6 @@ package com.flipperdevices.updater.card.helpers.delegates
 
 import androidx.datastore.core.DataStore
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
-import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.preference.pb.Settings
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDelegate.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDelegate.kt
@@ -1,8 +1,9 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import kotlinx.coroutines.flow.Flow
 
 interface UpdateOfferDelegate {
-    fun isRequire(serviceApi: FlipperServiceApi): Flow<Boolean>
+    fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean>
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDelegate.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDelegate.kt
@@ -1,7 +1,6 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
-import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import kotlinx.coroutines.flow.Flow
 
 interface UpdateOfferDelegate {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -15,11 +16,7 @@ class UpdateOfferFlipperManifest @Inject constructor(
 
     override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
         return fileExistHelper
-            .isFileExist(MANIFEST_FILE, fStorageFeatureApi.listingApi())
+            .isFileExist(FUpdateFeatureApi.MANIFEST_FILE, fStorageFeatureApi.listingApi())
             .map { it.not() }
-    }
-
-    companion object {
-        const val MANIFEST_FILE = "/ext/Manifest"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
@@ -1,8 +1,6 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
-import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
-import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifest.kt
@@ -1,7 +1,8 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
+import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -14,9 +15,13 @@ class UpdateOfferFlipperManifest @Inject constructor(
     private val fileExistHelper: FileExistHelper
 ) : UpdateOfferDelegate {
 
-    override fun isRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
+    override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
         return fileExistHelper
-            .isFileExist(Constants.PATH.MANIFEST_FILE, serviceApi.requestApi)
+            .isFileExist(MANIFEST_FILE, fStorageFeatureApi.listingApi())
             .map { it.not() }
+    }
+
+    companion object {
+        const val MANIFEST_FILE = "/ext/Manifest"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
@@ -1,7 +1,7 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -14,9 +14,13 @@ class UpdateOfferFlipperRegionFile @Inject constructor(
     private val fileExistHelper: FileExistHelper
 ) : UpdateOfferDelegate {
 
-    override fun isRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
+    override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
         return fileExistHelper
-            .isFileExist(Constants.PATH.REGION_FILE, serviceApi.requestApi)
+            .isFileExist(REGION_FILE, fStorageFeatureApi.listingApi())
             .map { it.not() }
+    }
+
+    companion object {
+        const val REGION_FILE = "/int/.region_data"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.RegionApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -15,11 +16,7 @@ class UpdateOfferFlipperRegionFile @Inject constructor(
 
     override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
         return fileExistHelper
-            .isFileExist(REGION_FILE, fStorageFeatureApi.listingApi())
+            .isFileExist(RegionApi.REGION_FILE, fStorageFeatureApi.listingApi())
             .map { it.not() }
-    }
-
-    companion object {
-        const val REGION_FILE = "/int/.region_data"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionFile.kt
@@ -1,7 +1,6 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
-import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
@@ -1,46 +1,50 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.api.model.FlipperRequestPriority
-import com.flipperdevices.bridge.api.model.wrapToRequest
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.provider.api.getSync
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.model.StorageRequestPriority
+import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
-import com.flipperdevices.protobuf.Flipper
-import com.flipperdevices.protobuf.Flipper.Region
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.storage.readRequest
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.flipperdevices.protobuf.Region
 import com.flipperdevices.updater.subghz.helpers.SubGhzProvisioningHelper
 import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import okio.Sink
+import okio.buffer
 import java.nio.charset.Charset
 import javax.inject.Inject
 
 @ContributesMultibinding(scope = AppGraph::class, boundType = UpdateOfferDelegate::class)
 class UpdateOfferRegionChange @Inject constructor(
     private val subGhzProvisioningHelper: SubGhzProvisioningHelper
-) : UpdateOfferDelegate {
+) : UpdateOfferDelegate, LogTagProvider {
+    override val TAG: String = "UpdateOfferRegionChange"
 
-    override fun isRequire(serviceApi: FlipperServiceApi): Flow<Boolean> {
-        return serviceApi.requestApi.request(
-            main {
-                storageReadRequest = readRequest {
-                    path = Constants.PATH.REGION_FILE
+    override fun isRequire(fStorageFeatureApi: FStorageFeatureApi): Flow<Boolean> {
+        return flow {
+            runCatching {
+                coroutineScope {
+                    fStorageFeatureApi.downloadApi().source(REGION_FILE, this)
+                        .buffer()
+                        .readByteArray()
                 }
-            }.wrapToRequest(FlipperRequestPriority.BACKGROUND)
-        ).map { response ->
-            if (response.commandStatus != Flipper.CommandStatus.OK) return@map true
-            if (!response.hasStorageReadResponse()) return@map true
-
-            try {
-                val array = response.storageReadResponse.file.data
-                val region = Region.parseFrom(array)
-                val code = region.countryCode.toString(Charset.forName("ASCII"))
-
-                return@map subGhzProvisioningHelper.getRegion() != code
-            } catch (@Suppress("SwallowedException") exception: Exception) {
-                return@map true
+            }.onFailure {
+                error(it) { "#isRequire could not read region file!" }
+                emit(true)
+            }.onSuccess {
+                val region = Region.ADAPTER.decode(it)
+                val code = region.country_code.string(Charset.forName("ASCII"))
+                emit(subGhzProvisioningHelper.getRegion() != code)
             }
         }
+    }
+
+    companion object {
+        const val REGION_FILE = "/int/.region_data"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
@@ -34,12 +34,17 @@ class UpdateOfferRegionChange @Inject constructor(
                         .readByteArray()
                 }
             }.onFailure {
+                it.printStackTrace()
                 error(it) { "#isRequire could not read region file!" }
                 emit(true)
             }.onSuccess {
                 val region = Region.ADAPTER.decode(it)
                 val code = region.country_code.string(Charset.forName("ASCII"))
-                emit(subGhzProvisioningHelper.getRegion() != code)
+                val provisionedRegion = runCatching {
+                    subGhzProvisioningHelper.getRegion()
+                }.onFailure { it.printStackTrace() }.getOrNull()
+                println("provisionedRegion: $provisionedRegion; code: $code")
+                emit(provisionedRegion != code)
             }
         }
     }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
@@ -1,6 +1,7 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.RegionApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -24,12 +25,11 @@ class UpdateOfferRegionChange @Inject constructor(
         return flow {
             runCatching {
                 coroutineScope {
-                    fStorageFeatureApi.downloadApi().source(REGION_FILE, this)
+                    fStorageFeatureApi.downloadApi().source(RegionApi.REGION_FILE, this)
                         .buffer()
                         .readByteArray()
                 }
             }.onFailure {
-                it.printStackTrace()
                 error(it) { "#isRequire could not read region file!" }
                 emit(true)
             }.onSuccess {
@@ -37,13 +37,9 @@ class UpdateOfferRegionChange @Inject constructor(
                 val code = region.country_code.string(Charset.forName("ASCII"))
                 val provisionedRegion = runCatching {
                     subGhzProvisioningHelper.getRegion()
-                }.onFailure { it.printStackTrace() }.getOrNull()
+                }.getOrNull()
                 emit(provisionedRegion != code)
             }
         }
-    }
-
-    companion object {
-        const val REGION_FILE = "/int/.region_data"
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
@@ -38,7 +38,6 @@ class UpdateOfferRegionChange @Inject constructor(
                 val provisionedRegion = runCatching {
                     subGhzProvisioningHelper.getRegion()
                 }.onFailure { it.printStackTrace() }.getOrNull()
-                println("provisionedRegion: $provisionedRegion; code: $code")
                 emit(provisionedRegion != code)
             }
         }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChange.kt
@@ -1,9 +1,6 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.connection.feature.provider.api.getSync
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
-import com.flipperdevices.bridge.connection.feature.storage.api.model.StorageRequestPriority
-import com.flipperdevices.bridge.connection.feature.storageinfo.api.FStorageInfoFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -13,8 +10,6 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import okio.Sink
 import okio.buffer
 import java.nio.charset.Charset
 import javax.inject.Inject

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/model/BatteryState.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/model/BatteryState.kt
@@ -4,7 +4,7 @@ private const val ALLOWED_BATTERY_CHARGE = 0.09f
 
 sealed class BatteryState {
     data object Unknown : BatteryState()
-    class Ready(
+    data class Ready(
         val isCharging: Boolean,
         val batteryLevel: Float
     ) : BatteryState()

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -1,7 +1,6 @@
 package com.flipperdevices.updater.card.viewmodel
 
 import androidx.datastore.core.DataStore
-import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
 import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
 import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureStatus
 import com.flipperdevices.bridge.connection.feature.provider.api.get
@@ -108,7 +107,7 @@ class UpdateCardViewModel @AssistedInject constructor(
     init {
         fFeatureProvider.get<FStorageFeatureApi>()
             .map { status -> status as? FFeatureStatus.Supported<FStorageFeatureApi> }
-            .onEach {fStorageFeatureStatus->
+            .onEach { fStorageFeatureStatus ->
                 if (fStorageFeatureStatus == null) {
                     cardStateJob?.cancelAndJoin()
                     cardStateJob = null

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateCardViewModel.kt
@@ -1,11 +1,15 @@
 package com.flipperdevices.updater.card.viewmodel
 
 import androidx.datastore.core.DataStore
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
-import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
-import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureStatus
+import com.flipperdevices.bridge.connection.feature.provider.api.get
+import com.flipperdevices.bridge.connection.feature.provider.api.getSync
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.core.ktx.jre.launchWithLock
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.verbose
 import com.flipperdevices.core.preference.pb.SelectedChannel
 import com.flipperdevices.core.preference.pb.Settings
@@ -28,6 +32,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 
@@ -35,13 +42,12 @@ import kotlinx.coroutines.sync.Mutex
 class UpdateCardViewModel @AssistedInject constructor(
     private val downloaderApi: DownloaderApi,
     private val flipperVersionProviderApi: FlipperVersionProviderApi,
-    private val serviceProvider: FlipperServiceProvider,
     private val dataStoreSettings: DataStore<Settings>,
     private val updateOfferHelper: UpdateOfferProviderApi,
     private val storageExistHelper: StorageExistHelper,
-    @Assisted private val deeplink: Deeplink.BottomBar.DeviceTab.WebUpdate?
+    @Assisted private val deeplink: Deeplink.BottomBar.DeviceTab.WebUpdate?,
+    private val fFeatureProvider: FFeatureProvider
 ) : DecomposeViewModel(),
-    FlipperBleServiceConsumer,
     LogTagProvider {
     override val TAG = "UpdateCardViewModel"
 
@@ -61,7 +67,6 @@ class UpdateCardViewModel @AssistedInject constructor(
                 updateChanelFlow.emit(it.selected_channel.toFirmwareChannel())
             }
         }
-        serviceProvider.provideServiceApi(this, this)
     }
 
     fun getUpdateCardState(): StateFlow<UpdateCardState> = updateCardState
@@ -85,40 +90,54 @@ class UpdateCardViewModel @AssistedInject constructor(
     }
 
     fun refresh() {
-        serviceProvider.provideServiceApi(this) {
-            launchWithLock(mutex, viewModelScope, "retry") {
-                // in this case we get heavy information from fw server and flipper
-                // that's why we set state in progress
-                updateCardState.emit(UpdateCardState.InProgress)
-                cardStateJob?.cancelAndJoin()
-                storageExistHelper.invalidate(viewModelScope, it, force = true)
-                invalidateUnsafe(it)
-            }
+        launchWithLock(mutex, viewModelScope, "retry") {
+            // in this case we get heavy information from fw server and flipper
+            // that's why we set state in progress
+            updateCardState.emit(UpdateCardState.InProgress)
+            cardStateJob?.cancelAndJoin()
+            storageExistHelper.invalidate(viewModelScope, force = true)
+            invalidateUnsafe(
+                fStorageFeatureApi = fFeatureProvider.getSync<FStorageFeatureApi>() ?: run {
+                    error { "#refresh could not get FStorageFeatureApi" }
+                    return@launchWithLock
+                }
+            )
         }
     }
 
-    override fun onServiceApiReady(
-        serviceApi: FlipperServiceApi
+    init {
+        fFeatureProvider.get<FStorageFeatureApi>()
+            .map { status -> status as? FFeatureStatus.Supported<FStorageFeatureApi> }
+            .onEach {fStorageFeatureStatus->
+                if (fStorageFeatureStatus == null) {
+                    cardStateJob?.cancelAndJoin()
+                    cardStateJob = null
+                } else {
+                    launchWithLock(mutex, viewModelScope, "onServiceApiReady") {
+                        invalidateUnsafe(
+                            fStorageFeatureApi = fStorageFeatureStatus.featureApi
+                        )
+                    }
+                }
+            }.launchIn(viewModelScope)
+    }
+
+    private suspend fun invalidateUnsafe(
+        fStorageFeatureApi: FStorageFeatureApi
     ) {
-        launchWithLock(mutex, viewModelScope, "onServiceApiReady") {
-            invalidateUnsafe(serviceApi)
-        }
-    }
-
-    private suspend fun invalidateUnsafe(serviceApi: FlipperServiceApi) {
         cardStateJob?.cancelAndJoin()
         cardStateJob = null
         cardStateJob = viewModelScope.launch {
-            storageExistHelper.invalidate(this, serviceApi, force = false)
+            storageExistHelper.invalidate(this, force = false)
             val latestVersionAsync = async {
                 val result = runCatching { downloaderApi.getLatestVersion() }
                 verbose { "latestVersionAsyncResult: $result" }
                 return@async result
             }
             combine(
-                flipperVersionProviderApi.getCurrentFlipperVersion(viewModelScope, serviceApi),
+                flipperVersionProviderApi.getCurrentFlipperVersion(),
                 storageExistHelper.isExternalStorageExist(),
-                updateOfferHelper.isUpdateRequire(serviceApi),
+                updateOfferHelper.isUpdateRequire(fStorageFeatureApi),
                 updateChanelFlow,
                 deeplinkFlow
             ) { flipperFirmwareVersion, isFlashExist, isAlwaysUpdate, updateChannel, deeplink ->

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
@@ -46,11 +46,13 @@ class UpdateRequestViewModel @Inject constructor(
         .map { gattInfo ->
             if (gattInfo == null) {
                 BatteryState.Unknown
-
             } else {
-                BatteryState.Ready(gattInfo.isCharging, gattInfo.batteryLevel ?: 0f)
+                gattInfo.batteryLevel?.let { batteryLevel ->
+                    BatteryState.Ready(gattInfo.isCharging, batteryLevel)
+                } ?: BatteryState.Unknown
             }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, BatteryState.Unknown)
+        }.stateIn(viewModelScope, SharingStarted.Lazily, BatteryState.Unknown)
+
     fun getBatteryState(): StateFlow<BatteryState> = batteryFlow
 
     private val pendingFlow = MutableStateFlow<UpdatePendingState?>(null)

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
@@ -1,8 +1,9 @@
 package com.flipperdevices.updater.card.viewmodel
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
-import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
-import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureStatus
+import com.flipperdevices.bridge.connection.feature.provider.api.get
 import com.flipperdevices.bridge.synchronization.api.SynchronizationApi
 import com.flipperdevices.bridge.synchronization.api.SynchronizationState
 import com.flipperdevices.core.ktx.android.filename
@@ -17,10 +18,15 @@ import com.flipperdevices.updater.model.FirmwareVersion
 import com.flipperdevices.updater.model.InternalStorageFirmware
 import com.flipperdevices.updater.model.UpdateRequest
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.File
@@ -30,17 +36,27 @@ private const val EXT_UPDATER_FILE = "tgz"
 private const val SIZE_FOLDER_UPDATE_MAX = 1024L * 1024L * 1024L * 10 // 10Mb
 
 class UpdateRequestViewModel @Inject constructor(
-    serviceProvider: FlipperServiceProvider,
-    private val synchronizationApi: SynchronizationApi
-) : DecomposeViewModel(), FlipperBleServiceConsumer {
+    private val synchronizationApi: SynchronizationApi,
+    private val fFeatureProvider: FFeatureProvider
+) : DecomposeViewModel() {
 
-    private val batteryFlow = MutableStateFlow<BatteryState>(BatteryState.Unknown)
+    private val batteryFlow = fFeatureProvider.get<FGattInfoFeatureApi>()
+        .map { status -> status as? FFeatureStatus.Supported<FGattInfoFeatureApi> }
+        .flatMapLatest { status -> status?.featureApi?.getGattInfoFlow() ?: flowOf(null) }
+        .map { gattInfo ->
+            if (gattInfo == null) {
+                BatteryState.Unknown
+
+            } else {
+                BatteryState.Ready(gattInfo.isCharging, gattInfo.batteryLevel ?: 0f)
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, BatteryState.Unknown)
     fun getBatteryState(): StateFlow<BatteryState> = batteryFlow
+
     private val pendingFlow = MutableStateFlow<UpdatePendingState?>(null)
     fun getUpdatePendingState(): StateFlow<UpdatePendingState?> = pendingFlow
 
     init {
-        serviceProvider.provideServiceApi(consumer = this, lifecycleOwner = this)
         synchronizationApi.getSynchronizationState().onEach { syncState ->
             pendingFlow.update {
                 if (it != null && it is UpdatePendingState.Ready) {
@@ -50,18 +66,7 @@ class UpdateRequestViewModel @Inject constructor(
                 }
             }
         }.launchIn(viewModelScope)
-    }
 
-    override fun onServiceApiReady(serviceApi: FlipperServiceApi) {
-        serviceApi.flipperInformationApi.getInformationFlow().onEach {
-            val batteryLevel = it.batteryLevel
-            val state = if (batteryLevel == null) {
-                BatteryState.Unknown
-            } else {
-                BatteryState.Ready(it.isCharging, batteryLevel)
-            }
-            batteryFlow.emit(state)
-        }.launchIn(viewModelScope)
     }
 
     fun onUpdateRequest(updatePending: UpdatePending) {
@@ -89,7 +94,12 @@ class UpdateRequestViewModel @Inject constructor(
 
     private suspend fun startUpdateFromServer(updatePending: UpdatePending.Request) {
         val syncState = synchronizationApi.getSynchronizationState().first()
-        pendingFlow.emit(UpdatePendingState.Ready(updatePending.updateRequest, syncState.toSyncingState()))
+        pendingFlow.emit(
+            UpdatePendingState.Ready(
+                updatePending.updateRequest,
+                syncState.toSyncingState()
+            )
+        )
     }
 
     private fun startUpdateFromFile(updatePending: UpdatePending.URI) {
@@ -128,6 +138,7 @@ class UpdateRequestViewModel @Inject constructor(
     private fun SynchronizationState.toSyncingState(): SyncingState = when (this) {
         SynchronizationState.NotStarted,
         SynchronizationState.Finished -> SyncingState.COMPLETE
+
         is SynchronizationState.InProgress -> SyncingState.IN_PROGRESS
     }
 }

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModel.kt
@@ -68,7 +68,6 @@ class UpdateRequestViewModel @Inject constructor(
                 }
             }
         }.launchIn(viewModelScope)
-
     }
 
     fun onUpdateRequest(updatePending: UpdatePending) {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateStateViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateStateViewModel.kt
@@ -8,7 +8,6 @@ import com.flipperdevices.updater.api.UpdateStateApi
 import com.flipperdevices.updater.api.UpdaterApi
 import com.flipperdevices.updater.model.FlipperUpdateState
 import com.flipperdevices.updater.model.UpdatingState
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -23,7 +22,6 @@ class UpdateStateViewModel @Inject constructor(
 ) : DecomposeViewModel() {
     private val flipperStateFlow = updateStateApi.getFlipperUpdateState(viewModelScope)
         .stateIn(viewModelScope, SharingStarted.Eagerly, FlipperUpdateState.NotConnected)
-
 
     init {
         updaterApi.getState().onEach {

--- a/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateStateViewModel.kt
+++ b/components/updater/card/src/main/java/com/flipperdevices/updater/card/viewmodel/UpdateStateViewModel.kt
@@ -1,8 +1,5 @@
 package com.flipperdevices.updater.card.viewmodel
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
-import com.flipperdevices.bridge.service.api.provider.FlipperBleServiceConsumer
-import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
 import com.flipperdevices.core.ui.lifecycle.DecomposeViewModel
 import com.flipperdevices.metric.api.MetricApi
 import com.flipperdevices.metric.api.events.complex.UpdateFlipperEnd
@@ -12,24 +9,23 @@ import com.flipperdevices.updater.api.UpdaterApi
 import com.flipperdevices.updater.model.FlipperUpdateState
 import com.flipperdevices.updater.model.UpdatingState
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 class UpdateStateViewModel @Inject constructor(
-    serviceProvider: FlipperServiceProvider,
     private val updaterApi: UpdaterApi,
     private val metricApi: MetricApi,
     private val updateStateApi: UpdateStateApi
-) : DecomposeViewModel(), FlipperBleServiceConsumer {
-    private val flipperStateFlow = MutableStateFlow<FlipperUpdateState>(
-        FlipperUpdateState.NotConnected
-    )
+) : DecomposeViewModel() {
+    private val flipperStateFlow = updateStateApi.getFlipperUpdateState(viewModelScope)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, FlipperUpdateState.NotConnected)
+
 
     init {
-        serviceProvider.provideServiceApi(consumer = this, lifecycleOwner = this)
-
         updaterApi.getState().onEach {
             val updateRequest = it.request
             val endStatus = when (it.state) {
@@ -51,12 +47,6 @@ class UpdateStateViewModel @Inject constructor(
     }
 
     fun getUpdateState(): StateFlow<FlipperUpdateState> = flipperStateFlow
-
-    override fun onServiceApiReady(serviceApi: FlipperServiceApi) {
-        updateStateApi.getFlipperUpdateState(serviceApi, viewModelScope).onEach {
-            flipperStateFlow.emit(it)
-        }.launchIn(viewModelScope)
-    }
 
     fun onDismissUpdateDialog() {
         updaterApi.resetState()

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/FileExistHelperTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/FileExistHelperTest.kt
@@ -1,12 +1,13 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.api.manager.FlipperRequestApi
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.storage.md5sumResponse
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
+import com.flipperdevices.bridge.connection.feature.storage.api.model.ListingItemWithHash
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -14,25 +15,31 @@ import org.junit.Test
 
 class FileExistHelperTest {
 
-    private lateinit var requestApi: FlipperRequestApi
+    private val fListingStorageApi: FListingStorageApi = mockk()
     private lateinit var fileExistHelper: FileExistHelper
 
     @Before
     fun setup() {
         fileExistHelper = FileExistHelper()
-        requestApi = mockk()
     }
 
     @Test
     fun `exist file`() = runTest {
-        every { requestApi.request(command = any()) } returns flow {
-            main {
-                storageMd5SumResponse = md5sumResponse {
-                    md5Sum = "md5Sum"
-                }
+        every {
+            runBlocking {
+                fListingStorageApi.lsWithMd5Flow("")
             }
+        } returns flow {
+            Result.success(
+                ListingItemWithHash(
+                    fileName = "filename",
+                    fileType = null,
+                    size = 0L,
+                    md5 = "md5"
+                )
+            )
         }
-        val existFileFlow = fileExistHelper.isFileExist("", requestApi)
+        val existFileFlow = fileExistHelper.isFileExist("", fListingStorageApi)
         existFileFlow.collectLatest {
             Assert.assertEquals(it, true)
         }
@@ -40,11 +47,14 @@ class FileExistHelperTest {
 
     @Test
     fun `Not exist file`() = runTest {
-        every { requestApi.request(command = any()) } returns flow {
-            main {
+        every {
+            runBlocking {
+                fListingStorageApi.lsWithMd5Flow("")
             }
+        } returns flow {
+            Result.failure<ListingItemWithHash>(Throwable("Test throwable path not exists"))
         }
-        val existFileFlow = fileExistHelper.isFileExist("", requestApi)
+        val existFileFlow = fileExistHelper.isFileExist("", fListingStorageApi)
         existFileFlow.collectLatest {
             Assert.assertEquals(it, false)
         }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/FileExistHelperTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/FileExistHelperTest.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.bridge.connection.feature.storage.api.model.ListingItemWithHash
 import io.mockk.every

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/UpdateOfferProviderTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/UpdateOfferProviderTest.kt
@@ -34,11 +34,6 @@ class UpdateOfferProviderTest {
         every { delegateFlagAlways.isRequire(fStorageFeatureApi) } returns flowOf(false)
         every { delegateManifest.isRequire(fStorageFeatureApi) } returns flowOf(false)
         every { delegateRegionFile.isRequire(fStorageFeatureApi) } returns flowOf(false)
-//        val connectionInformationApi: FlipperConnectionInformationApi = mockk {
-//            every { getConnectionStateFlow() } returns
-//                flowOf(ConnectionState.Ready(supportedState = FlipperSupportedState.READY))
-//        }
-//        every { fStorageFeatureApi.connectionInformationApi } returns connectionInformationApi
     }
 
     @Test

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/UpdateOfferProviderTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/UpdateOfferProviderTest.kt
@@ -1,9 +1,6 @@
 package com.flipperdevices.updater.card.helpers
 
-import com.flipperdevices.bridge.api.manager.delegates.FlipperConnectionInformationApi
-import com.flipperdevices.bridge.api.manager.ktx.state.ConnectionState
-import com.flipperdevices.bridge.api.manager.ktx.state.FlipperSupportedState
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferDebugFlagAlways
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferFlipperManifest
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferFlipperRegionFile
@@ -21,7 +18,7 @@ class UpdateOfferProviderTest {
     private val delegateFlagAlways: UpdateOfferDebugFlagAlways = mockk()
     private val delegateManifest: UpdateOfferFlipperManifest = mockk()
     private val delegateRegionFile: UpdateOfferFlipperRegionFile = mockk()
-    private val serviceApi: FlipperServiceApi = mockk()
+    private val fStorageFeatureApi: FStorageFeatureApi = mockk()
     private val updateOfferHelper = UpdateOfferProvider(
         delegates = mutableSetOf(
             delegateRegion,
@@ -33,52 +30,52 @@ class UpdateOfferProviderTest {
 
     @Before
     fun setup() {
-        every { delegateRegion.isRequire(serviceApi) } returns flowOf(false)
-        every { delegateFlagAlways.isRequire(serviceApi) } returns flowOf(false)
-        every { delegateManifest.isRequire(serviceApi) } returns flowOf(false)
-        every { delegateRegionFile.isRequire(serviceApi) } returns flowOf(false)
-        val connectionInformationApi: FlipperConnectionInformationApi = mockk {
-            every { getConnectionStateFlow() } returns
-                flowOf(ConnectionState.Ready(supportedState = FlipperSupportedState.READY))
-        }
-        every { serviceApi.connectionInformationApi } returns connectionInformationApi
+        every { delegateRegion.isRequire(fStorageFeatureApi) } returns flowOf(false)
+        every { delegateFlagAlways.isRequire(fStorageFeatureApi) } returns flowOf(false)
+        every { delegateManifest.isRequire(fStorageFeatureApi) } returns flowOf(false)
+        every { delegateRegionFile.isRequire(fStorageFeatureApi) } returns flowOf(false)
+//        val connectionInformationApi: FlipperConnectionInformationApi = mockk {
+//            every { getConnectionStateFlow() } returns
+//                flowOf(ConnectionState.Ready(supportedState = FlipperSupportedState.READY))
+//        }
+//        every { fStorageFeatureApi.connectionInformationApi } returns connectionInformationApi
     }
 
     @Test
     fun `Update not offer`() = runTest {
-        updateOfferHelper.isUpdateRequire(serviceApi).collect {
+        updateOfferHelper.isUpdateRequire(fStorageFeatureApi).collect {
             Assert.assertFalse(it)
         }
     }
 
     @Test
     fun `Region changes`() = runTest {
-        every { delegateRegion.isRequire(serviceApi) } returns flowOf(true)
-        updateOfferHelper.isUpdateRequire(serviceApi).collect {
+        every { delegateRegion.isRequire(fStorageFeatureApi) } returns flowOf(true)
+        updateOfferHelper.isUpdateRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
 
     @Test
     fun `Always update in setting`() = runTest {
-        every { delegateFlagAlways.isRequire(serviceApi) } returns flowOf(true)
-        updateOfferHelper.isUpdateRequire(serviceApi).collect {
+        every { delegateFlagAlways.isRequire(fStorageFeatureApi) } returns flowOf(true)
+        updateOfferHelper.isUpdateRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
 
     @Test
     fun `Manifest file not exist`() = runTest {
-        every { delegateManifest.isRequire(serviceApi) } returns flowOf(true)
-        updateOfferHelper.isUpdateRequire(serviceApi).collect {
+        every { delegateManifest.isRequire(fStorageFeatureApi) } returns flowOf(true)
+        updateOfferHelper.isUpdateRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
 
     @Test
     fun `Region file not exist`() = runTest {
-        every { delegateRegion.isRequire(serviceApi) } returns flowOf(true)
-        updateOfferHelper.isUpdateRequire(serviceApi).collect {
+        every { delegateRegion.isRequire(fStorageFeatureApi) } returns flowOf(true)
+        updateOfferHelper.isUpdateRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlwaysTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlwaysTest.kt
@@ -2,20 +2,29 @@ package com.flipperdevices.updater.card.helpers.delegates
 
 import androidx.datastore.core.DataStore
 import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.core.preference.pb.Settings
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class UpdateOfferDebugFlagAlwaysTest {
+    private val fListingStorageApi: FListingStorageApi = mockk()
     private val fStorageFeatureApi: FStorageFeatureApi = mockk()
     private val dataStoreSettings: DataStore<Settings> = mockk()
     private val delegate: UpdateOfferDelegate = UpdateOfferDebugFlagAlways(
         dataStoreSettings = dataStoreSettings
     )
+
+    @Before
+    fun setup() {
+        coEvery { fStorageFeatureApi.listingApi() } returns fListingStorageApi
+    }
 
     @Test
     fun `Flag in settings true`() = runTest {

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlwaysTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferDebugFlagAlwaysTest.kt
@@ -1,7 +1,7 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
 import androidx.datastore.core.DataStore
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
 import com.flipperdevices.core.preference.pb.Settings
 import io.mockk.every
 import io.mockk.mockk
@@ -11,7 +11,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class UpdateOfferDebugFlagAlwaysTest {
-    private val serviceApi: FlipperServiceApi = mockk()
+    private val fStorageFeatureApi: FStorageFeatureApi = mockk()
     private val dataStoreSettings: DataStore<Settings> = mockk()
     private val delegate: UpdateOfferDelegate = UpdateOfferDebugFlagAlways(
         dataStoreSettings = dataStoreSettings
@@ -24,7 +24,7 @@ class UpdateOfferDebugFlagAlwaysTest {
                 always_update = true
             )
         )
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
@@ -36,7 +36,7 @@ class UpdateOfferDebugFlagAlwaysTest {
                 always_update = false
             )
         )
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertFalse(it)
         }
     }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
@@ -1,8 +1,9 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.updater.card.helpers.FileExistHelper
+import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferFlipperManifest.Companion.MANIFEST_FILE
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
@@ -11,7 +12,8 @@ import org.junit.Assert
 import org.junit.Test
 
 class UpdateOfferFlipperManifestTest {
-    private val serviceApi: FlipperServiceApi = mockk()
+    private val fListingStorageApi: FListingStorageApi = mockk()
+    private val fStorageFeatureApi: FStorageFeatureApi = mockk()
     private val fileExistHelper: FileExistHelper = mockk()
     private val delegate: UpdateOfferDelegate = UpdateOfferFlipperManifest(
         fileExistHelper = fileExistHelper
@@ -20,9 +22,9 @@ class UpdateOfferFlipperManifestTest {
     @Test
     fun `Manifest not exist`() = runTest {
         every {
-            fileExistHelper.isFileExist(Constants.PATH.MANIFEST_FILE, serviceApi.requestApi)
+            fileExistHelper.isFileExist(MANIFEST_FILE, fListingStorageApi)
         } returns flowOf(false)
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
@@ -30,9 +32,9 @@ class UpdateOfferFlipperManifestTest {
     @Test
     fun `Manifest exist`() = runTest {
         every {
-            fileExistHelper.isFileExist(Constants.PATH.MANIFEST_FILE, serviceApi.requestApi)
+            fileExistHelper.isFileExist(MANIFEST_FILE, fListingStorageApi)
         } returns flowOf(true)
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertFalse(it)
         }
     }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
@@ -35,6 +35,7 @@ class UpdateOfferFlipperManifestTest {
             Assert.assertTrue(it)
         }
     }
+
     @Test
     fun `Manifest exist`() = runTest {
         every {

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperManifestTest.kt
@@ -4,11 +4,13 @@ import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureA
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.flipperdevices.updater.card.helpers.delegates.UpdateOfferFlipperManifest.Companion.MANIFEST_FILE
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class UpdateOfferFlipperManifestTest {
@@ -19,6 +21,11 @@ class UpdateOfferFlipperManifestTest {
         fileExistHelper = fileExistHelper
     )
 
+    @Before
+    fun setup() {
+        coEvery { fStorageFeatureApi.listingApi() } returns fListingStorageApi
+    }
+
     @Test
     fun `Manifest not exist`() = runTest {
         every {
@@ -28,7 +35,6 @@ class UpdateOfferFlipperManifestTest {
             Assert.assertTrue(it)
         }
     }
-
     @Test
     fun `Manifest exist`() = runTest {
         every {

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionTest.kt
@@ -4,11 +4,13 @@ import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureA
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.updater.card.helpers.FileExistHelper
 import com.flipperdevices.updater.subghz.helpers.REGION_FILE
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class UpdateOfferFlipperRegionTest {
@@ -18,6 +20,11 @@ class UpdateOfferFlipperRegionTest {
     private val delegate: UpdateOfferDelegate = UpdateOfferFlipperRegionFile(
         fileExistHelper = fileExistHelper
     )
+
+    @Before
+    fun setup() {
+        coEvery { fStorageFeatureApi.listingApi() } returns fListingStorageApi
+    }
 
     @Test
     fun `Manifest not exist`() = runTest {

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferFlipperRegionTest.kt
@@ -1,8 +1,9 @@
 package com.flipperdevices.updater.card.helpers.delegates
 
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.storage.api.FStorageFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
 import com.flipperdevices.updater.card.helpers.FileExistHelper
+import com.flipperdevices.updater.subghz.helpers.REGION_FILE
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
@@ -11,7 +12,8 @@ import org.junit.Assert
 import org.junit.Test
 
 class UpdateOfferFlipperRegionTest {
-    private val serviceApi: FlipperServiceApi = mockk()
+    private val fListingStorageApi: FListingStorageApi = mockk()
+    private val fStorageFeatureApi: FStorageFeatureApi = mockk()
     private val fileExistHelper: FileExistHelper = mockk()
     private val delegate: UpdateOfferDelegate = UpdateOfferFlipperRegionFile(
         fileExistHelper = fileExistHelper
@@ -20,9 +22,9 @@ class UpdateOfferFlipperRegionTest {
     @Test
     fun `Manifest not exist`() = runTest {
         every {
-            fileExistHelper.isFileExist(Constants.PATH.REGION_FILE, serviceApi.requestApi)
+            fileExistHelper.isFileExist(REGION_FILE, fListingStorageApi)
         } returns flowOf(false)
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertTrue(it)
         }
     }
@@ -30,9 +32,9 @@ class UpdateOfferFlipperRegionTest {
     @Test
     fun `Manifest exist`() = runTest {
         every {
-            fileExistHelper.isFileExist(Constants.PATH.REGION_FILE, serviceApi.requestApi)
+            fileExistHelper.isFileExist(REGION_FILE, fListingStorageApi)
         } returns flowOf(true)
-        delegate.isRequire(serviceApi).collect {
+        delegate.isRequire(fStorageFeatureApi).collect {
             Assert.assertFalse(it)
         }
     }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChangeTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/helpers/delegates/UpdateOfferRegionChangeTest.kt
@@ -10,16 +10,13 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import okio.BufferedSource
 import okio.ByteString.Companion.encode
 import okio.source
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
-import java.io.InputStream
 import java.nio.charset.Charset
 
 class UpdateOfferRegionChangeTest {
@@ -46,21 +43,27 @@ class UpdateOfferRegionChangeTest {
 
     @Test
     fun `Same region in storage and now`() = runTest {
-        coEvery { fFileDownloadApi.source(REGION_FILE, any()) } returns ByteArrayInputStream(region("UA").toByteArray()).source()
+        coEvery {
+            fFileDownloadApi.source(REGION_FILE, any())
+        } returns ByteArrayInputStream(region("UA").toByteArray()).source()
         coEvery { subGhzProvisioningHelper.getRegion() } returns "UA"
         delegate.isRequire(fStorageFeatureApi).collect { Assert.assertFalse(it) }
     }
 
     @Test
     fun `Different region in storage and now`() = runTest {
-        coEvery { fFileDownloadApi.source(REGION_FILE, any()) } returns ByteArrayInputStream(region("USA").toByteArray()).source()
+        coEvery {
+            fFileDownloadApi.source(REGION_FILE, any())
+        } returns ByteArrayInputStream(region("USA").toByteArray()).source()
         coEvery { subGhzProvisioningHelper.getRegion() } returns "UA"
         delegate.isRequire(fStorageFeatureApi).collect { Assert.assertTrue(it) }
     }
 
     @Test
     fun `Exception when we get current region`() = runTest {
-        coEvery { fFileDownloadApi.source(REGION_FILE, any()) } returns ByteArrayInputStream(region("USA").toByteArray()).source()
+        coEvery {
+            fFileDownloadApi.source(REGION_FILE, any())
+        } returns ByteArrayInputStream(region("USA").toByteArray()).source()
         coEvery { subGhzProvisioningHelper.getRegion() }.throws(Exception("Some error"))
         delegate.isRequire(fStorageFeatureApi).collect { Assert.assertTrue(it) }
     }

--- a/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
+++ b/components/updater/card/src/test/kotlin/com/flipperdevices/updater/card/viewmodel/UpdateRequestViewModelTest.kt
@@ -30,7 +30,6 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf

--- a/components/updater/impl/build.gradle.kts
+++ b/components/updater/impl/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
     implementation(projects.components.updater.api)
     implementation(projects.components.updater.subghz)
 
-    implementation(projects.components.bridge.api)
-    implementation(projects.components.bridge.pbutils)
-    implementation(projects.components.bridge.service.api)
-    implementation(projects.components.bridge.rpc.api)
     implementation(projects.components.deeplink.api)
 
     implementation(projects.components.core.di)
@@ -26,6 +22,15 @@ dependencies {
 
     implementation(projects.components.analytics.metric.api)
     implementation(projects.components.faphub.installedtab.api)
+
+    implementation(projects.components.bridge.connection.feature.provider.api)
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.feature.storage.api)
+    implementation(projects.components.bridge.connection.feature.getinfo.api)
+    implementation(projects.components.bridge.connection.feature.update.api)
+    implementation(projects.components.bridge.connection.feature.rpc.api)
+    implementation(projects.components.bridge.connection.pbutils)
+    implementation(projects.components.bridge.connection.orchestrator.api)
 
     implementation(libs.lifecycle.runtime.ktx)
 

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
@@ -67,23 +67,21 @@ class UpdaterTask @Inject constructor(
         input: UpdateRequest,
         stateListener: suspend (UpdatingState) -> Unit
     ) {
-        val fUpdateFeatureApi: FUpdateFeatureApi = fFeatureProvider.getSync() ?: run {
+        val fUpdateFeatureApi = fFeatureProvider.getSync<FUpdateFeatureApi>() ?: run {
             error { "#startInternal could not get FUpdateFeatureApi" }
             return
         }
-        val fGetInfoFeatureApi: FGetInfoFeatureApi = fFeatureProvider.getSync() ?: run {
+        val fGetInfoFeatureApi = fFeatureProvider.getSync<FGetInfoFeatureApi>() ?: run {
             error { "#startInternal could not get FGetInfoFeatureApi" }
             return
         }
-        val fFileUploadApi = fFeatureProvider.getSync<FStorageFeatureApi>()?.uploadApi() ?: run {
-            error { "#startInternal could not get FFileUploadApi" }
+        val fStorageFeatureApi = fFeatureProvider.getSync<FStorageFeatureApi>() ?: run {
+            error { "#startInternal could not get FStorageFeatureApi" }
             return
         }
-        val fListingStorageApi: FListingStorageApi =
-            fFeatureProvider.getSync<FStorageFeatureApi>()?.listingApi() ?: run {
-                error { "#startInternal could not get FListingStorageApi" }
-                return
-            }
+        val fFileUploadApi = fStorageFeatureApi.uploadApi()
+        val fListingStorageApi: FListingStorageApi = fStorageFeatureApi.listingApi()
+
         try {
             startInternalUnwrapped(
                 input = input,

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
@@ -79,10 +79,11 @@ class UpdaterTask @Inject constructor(
             error { "#startInternal could not get FFileUploadApi" }
             return
         }
-        val fListingStorageApi: FListingStorageApi = fFeatureProvider.getSync<FStorageFeatureApi>()?.listingApi() ?: run {
-            error { "#startInternal could not get FListingStorageApi" }
-            return
-        }
+        val fListingStorageApi: FListingStorageApi =
+            fFeatureProvider.getSync<FStorageFeatureApi>()?.listingApi() ?: run {
+                error { "#startInternal could not get FListingStorageApi" }
+                return
+            }
         try {
             startInternalUnwrapped(
                 input = input,
@@ -100,7 +101,7 @@ class UpdaterTask @Inject constructor(
             )
         } finally {
             withContext(NonCancellable) {
-                flipperUpdateImageHelper.stopImageOnFlipperSafe(fUpdateFeatureApi)
+                flipperUpdateImageHelper.stopImageOnFlipperSafe(fUpdateFeatureApi.displayApi())
             }
         }
     }
@@ -178,7 +179,7 @@ class UpdaterTask @Inject constructor(
             uploadToFlipperHelper.uploadToFlipper(
                 flipperPath = flipperPath,
                 updaterFolder = updaterFolder,
-                fUpdateFeatureApi = fUpdateFeatureApi,
+                bootApi = fUpdateFeatureApi.bootApi(),
                 fListingStorageApi = fListingStorageApi,
                 fFileUploadApi = fFileUploadApi,
                 stateListener = stateListener
@@ -220,7 +221,7 @@ class UpdaterTask @Inject constructor(
         fFileUploadApi: FFileUploadApi,
         fUpdateFeatureApi: FUpdateFeatureApi
     ): String {
-        flipperUpdateImageHelper.loadImageOnFlipper(fUpdateFeatureApi)
+        flipperUpdateImageHelper.loadImageOnFlipper(fUpdateFeatureApi.displayApi())
 
         val updateName: String = updaterFolder
             .listFiles()

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/UpdaterTask.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.updater.impl
 
-import android.content.Context
 import com.flipperdevices.bridge.connection.feature.getinfo.api.FGetInfoFeatureApi
 import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
 import com.flipperdevices.bridge.connection.feature.provider.api.getSync
@@ -15,7 +14,6 @@ import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.ui.lifecycle.FOneTimeExecutionBleTask
-import com.flipperdevices.core.ui.lifecycle.OneTimeExecutionBleTask
 import com.flipperdevices.faphub.installedtab.api.FapNeedUpdatePopUpHelper
 import com.flipperdevices.updater.impl.model.IntFlashFullException
 import com.flipperdevices.updater.impl.model.UpdateContentException
@@ -32,7 +30,6 @@ import com.flipperdevices.updater.subghz.model.FailedUploadSubGhzException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -56,7 +53,6 @@ class UpdaterTask @Inject constructor(
 ) : FOneTimeExecutionBleTask<UpdateRequest, UpdatingState>(),
     LogTagProvider {
     override val TAG = "UpdaterTask"
-
 
     private var isStoppedManually = false
 

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FlipperVersionProviderApiImpl.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FlipperVersionProviderApiImpl.kt
@@ -1,31 +1,41 @@
 package com.flipperdevices.updater.impl.api
 
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureStatus
+import com.flipperdevices.bridge.connection.feature.provider.api.get
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.updater.api.FirmwareVersionBuilderApi
 import com.flipperdevices.updater.api.FlipperVersionProviderApi
 import com.flipperdevices.updater.model.FirmwareVersion
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 
-@ContributesBinding(AppGraph::class)
+@ContributesBinding(AppGraph::class, FlipperVersionProviderApi::class)
 class FlipperVersionProviderApiImpl @Inject constructor(
-    private val firmwareVersionBuilderApi: FirmwareVersionBuilderApi
-) : FlipperVersionProviderApi {
-    override fun getCurrentFlipperVersion(
-        coroutineScope: CoroutineScope,
-        serviceApi: FlipperServiceApi
-    ): Flow<FirmwareVersion?> {
-        return serviceApi.flipperInformationApi.getInformationFlow().map {
-            val softwareVersion = it.softwareVersion
-            return@map if (softwareVersion != null) {
-                firmwareVersionBuilderApi.buildFirmwareVersionFromString(softwareVersion)
-            } else {
-                null
+    private val firmwareVersionBuilderApi: FirmwareVersionBuilderApi,
+    private val fFeatureProvider: FFeatureProvider
+) : FlipperVersionProviderApi, LogTagProvider {
+    override val TAG: String = "FlipperVersionProviderApiImpl"
+
+    override fun getCurrentFlipperVersion(): Flow<FirmwareVersion?>  {
+        return fFeatureProvider.get<FGattInfoFeatureApi>()
+            .map { status -> status as? FFeatureStatus.Supported<FGattInfoFeatureApi> }
+            .flatMapLatest { status -> status?.featureApi?.getGattInfoFlow() ?: flowOf(null) }
+            .map { gattInfo -> gattInfo?.softwareVersion }
+            .map { softwareVersion ->
+                if (softwareVersion != null) {
+                    firmwareVersionBuilderApi.buildFirmwareVersionFromString(softwareVersion)
+                } else {
+                    null
+                }
             }
-        }
     }
+
 }

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FlipperVersionProviderApiImpl.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/FlipperVersionProviderApiImpl.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 
 @ContributesBinding(AppGraph::class, FlipperVersionProviderApi::class)
@@ -24,7 +23,7 @@ class FlipperVersionProviderApiImpl @Inject constructor(
 ) : FlipperVersionProviderApi, LogTagProvider {
     override val TAG: String = "FlipperVersionProviderApiImpl"
 
-    override fun getCurrentFlipperVersion(): Flow<FirmwareVersion?>  {
+    override fun getCurrentFlipperVersion(): Flow<FirmwareVersion?> {
         return fFeatureProvider.get<FGattInfoFeatureApi>()
             .map { status -> status as? FFeatureStatus.Supported<FGattInfoFeatureApi> }
             .flatMapLatest { status -> status?.featureApi?.getGattInfoFlow() ?: flowOf(null) }
@@ -37,5 +36,4 @@ class FlipperVersionProviderApiImpl @Inject constructor(
                 }
             }
     }
-
 }

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/UpdaterApiImpl.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/UpdaterApiImpl.kt
@@ -1,8 +1,8 @@
 package com.flipperdevices.updater.impl.api
 
 import android.content.Context
-import com.flipperdevices.bridge.rpc.api.FlipperStorageApi
-import com.flipperdevices.bridge.service.api.provider.FlipperServiceProvider
+import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
+import com.flipperdevices.bridge.connection.orchestrator.api.FDeviceOrchestrator
 import com.flipperdevices.core.FlipperStorageProvider
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.log.LogTagProvider
@@ -14,6 +14,7 @@ import com.flipperdevices.metric.api.events.complex.UpdateFlipperStart
 import com.flipperdevices.metric.api.events.complex.UpdateStatus
 import com.flipperdevices.updater.api.UpdaterApi
 import com.flipperdevices.updater.impl.UpdaterTask
+import com.flipperdevices.updater.impl.tasks.FlipperUpdateImageHelper
 import com.flipperdevices.updater.impl.tasks.UploadToFlipperHelper
 import com.flipperdevices.updater.impl.tasks.downloader.UpdateContentDownloader
 import com.flipperdevices.updater.model.FirmwareChannel
@@ -36,15 +37,15 @@ import javax.inject.Singleton
 @Suppress("LongParameterList")
 @ContributesBinding(AppGraph::class, UpdaterApi::class)
 class UpdaterApiImpl @Inject constructor(
-    private val serviceProvider: FlipperServiceProvider,
     private val updateContentDownloader: MutableSet<UpdateContentDownloader>,
     private val subGhzProvisioningHelper: SubGhzProvisioningHelper,
     private val uploadToFlipperHelper: UploadToFlipperHelper,
-    private val context: Context,
     private val metricApi: MetricApi,
-    private val flipperStorageApi: FlipperStorageApi,
     private val fapNeedUpdatePopUpHelper: FapNeedUpdatePopUpHelper,
-    private val storageProvider: FlipperStorageProvider
+    private val storageProvider: FlipperStorageProvider,
+    private val fFeatureProvider: FFeatureProvider,
+    private val flipperUpdateImageHelper: FlipperUpdateImageHelper,
+    private val orchestrator: FDeviceOrchestrator,
 ) : UpdaterApi, LogTagProvider {
     override val TAG = "UpdaterApi"
 
@@ -68,14 +69,14 @@ class UpdaterApiImpl @Inject constructor(
          * The main idea is to simplify the code in complex places
          */
         val localActiveTask = UpdaterTask(
-            serviceProvider,
-            context,
-            uploadToFlipperHelper,
-            subGhzProvisioningHelper,
-            updateContentDownloader,
-            flipperStorageApi,
-            fapNeedUpdatePopUpHelper,
-            storageProvider
+            uploadToFlipperHelper = uploadToFlipperHelper,
+            subGhzProvisioningHelper = subGhzProvisioningHelper,
+            updateContentDownloader = updateContentDownloader,
+            fapNeedUpdatePopUpHelper = fapNeedUpdatePopUpHelper,
+            storageProvider = storageProvider,
+            flipperUpdateImageHelper = flipperUpdateImageHelper,
+            orchestrator = orchestrator,
+            fFeatureProvider = fFeatureProvider
         )
         currentActiveTask = localActiveTask
 

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/UpdaterApiImpl.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/api/UpdaterApiImpl.kt
@@ -1,6 +1,5 @@
 package com.flipperdevices.updater.impl.api
 
-import android.content.Context
 import com.flipperdevices.bridge.connection.feature.provider.api.FFeatureProvider
 import com.flipperdevices.bridge.connection.orchestrator.api.FDeviceOrchestrator
 import com.flipperdevices.core.FlipperStorageProvider

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
@@ -1,15 +1,15 @@
 package com.flipperdevices.updater.impl.tasks
 
 import android.content.Context
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import com.flipperdevices.core.ui.res.R as DesignSystem
-import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import javax.inject.Inject
+import com.flipperdevices.core.ui.res.R as DesignSystem
 
 private const val STOP_IMAGE_TIMEOUT_MS = 5 * 1000L
 
@@ -23,7 +23,6 @@ class FlipperUpdateImageHelper @Inject constructor(
         val bytes = loadImageFromResource()
         fUpdateFeatureApi.startVirtualDisplay(bytes)
             .onFailure { error(it) { "#loadImageOnFlipper could not start virtual display" } }
-
     }
 
     suspend fun stopImageOnFlipperSafe(fUpdateFeatureApi: FUpdateFeatureApi) = try {

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
@@ -1,7 +1,7 @@
 package com.flipperdevices.updater.impl.tasks
 
 import android.content.Context
-import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.DisplayApi
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
@@ -18,17 +18,17 @@ class FlipperUpdateImageHelper @Inject constructor(
 ) : LogTagProvider {
     override val TAG = "FlipperUpdateImageHelper"
 
-    suspend fun loadImageOnFlipper(fUpdateFeatureApi: FUpdateFeatureApi) {
+    suspend fun loadImageOnFlipper(displayApi: DisplayApi) {
         info { "Start streaming" }
         val bytes = loadImageFromResource()
-        fUpdateFeatureApi.startVirtualDisplay(bytes)
+        displayApi.startVirtualDisplay(bytes)
             .onFailure { error(it) { "#loadImageOnFlipper could not start virtual display" } }
     }
 
-    suspend fun stopImageOnFlipperSafe(fUpdateFeatureApi: FUpdateFeatureApi) = try {
+    suspend fun stopImageOnFlipperSafe(displayApi: DisplayApi) = try {
         info { "Request stop streaming" }
         withTimeout(STOP_IMAGE_TIMEOUT_MS) {
-            fUpdateFeatureApi.stopVirtualDisplay()
+            displayApi.stopVirtualDisplay()
                 .onFailure { error(it) { "#loadImageOnFlipper could not stop virtual display" } }
         }
     } catch (e: Exception) {

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/FlipperUpdateImageHelper.kt
@@ -1,56 +1,36 @@
 package com.flipperdevices.updater.impl.tasks
 
 import android.content.Context
-import com.flipperdevices.bridge.api.manager.FlipperRequestApi
-import com.flipperdevices.bridge.api.model.FlipperRequestPriority
-import com.flipperdevices.bridge.api.model.wrapToRequest
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.screen.screenFrame
-import com.flipperdevices.protobuf.screen.startVirtualDisplayRequest
-import com.flipperdevices.protobuf.screen.stopVirtualDisplayRequest
-import com.google.protobuf.ByteString
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import com.flipperdevices.core.ui.res.R as DesignSystem
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
+import javax.inject.Inject
 
 private const val STOP_IMAGE_TIMEOUT_MS = 5 * 1000L
 
-class FlipperUpdateImageHelper(
-    private val context: Context
+class FlipperUpdateImageHelper @Inject constructor(
+    private val context: Context,
 ) : LogTagProvider {
     override val TAG = "FlipperUpdateImageHelper"
 
-    suspend fun loadImageOnFlipper(
-        requestApi: FlipperRequestApi
-    ) {
+    suspend fun loadImageOnFlipper(fUpdateFeatureApi: FUpdateFeatureApi) {
         info { "Start streaming" }
         val bytes = loadImageFromResource()
-        requestApi.request(
-            main {
-                guiStartVirtualDisplayRequest = startVirtualDisplayRequest {
-                    firstFrame = screenFrame {
-                        data = ByteString.copyFrom(bytes)
-                    }
-                }
-            }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).first()
+        fUpdateFeatureApi.startVirtualDisplay(bytes)
+            .onFailure { error(it) { "#loadImageOnFlipper could not start virtual display" } }
+
     }
 
-    suspend fun stopImageOnFlipperSafe(
-        requestApi: FlipperRequestApi
-    ) = try {
+    suspend fun stopImageOnFlipperSafe(fUpdateFeatureApi: FUpdateFeatureApi) = try {
         info { "Request stop streaming" }
         withTimeout(STOP_IMAGE_TIMEOUT_MS) {
-            requestApi.request(
-                main {
-                    guiStopVirtualDisplayRequest = stopVirtualDisplayRequest { }
-                }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
-            ).first()
+            fUpdateFeatureApi.stopVirtualDisplay()
+                .onFailure { error(it) { "#loadImageOnFlipper could not stop virtual display" } }
         }
     } catch (e: Exception) {
         error(e) { "Error while stop streaming" }

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
@@ -4,7 +4,7 @@ import com.flipperdevices.bridge.connection.feature.rpc.api.exception.FRpcExcept
 import com.flipperdevices.bridge.connection.feature.rpc.api.exception.FRpcInvalidParametersException
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
-import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
+import com.flipperdevices.bridge.connection.feature.update.api.BootApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.md5
@@ -29,7 +29,7 @@ interface UploadToFlipperHelper {
     suspend fun uploadToFlipper(
         flipperPath: String,
         updaterFolder: File,
-        fUpdateFeatureApi: FUpdateFeatureApi,
+        bootApi: BootApi,
         fListingStorageApi: FListingStorageApi,
         fFileUploadApi: FFileUploadApi,
         stateListener: suspend (UpdatingState) -> Unit
@@ -43,7 +43,7 @@ class UploadToFlipperHelperImpl @Inject constructor() : UploadToFlipperHelper, L
     override suspend fun uploadToFlipper(
         flipperPath: String,
         updaterFolder: File,
-        fUpdateFeatureApi: FUpdateFeatureApi,
+        bootApi: BootApi,
         fListingStorageApi: FListingStorageApi,
         fFileUploadApi: FFileUploadApi,
         stateListener: suspend (UpdatingState) -> Unit
@@ -64,7 +64,7 @@ class UploadToFlipperHelperImpl @Inject constructor() : UploadToFlipperHelper, L
             },
         )
         try {
-            fUpdateFeatureApi.systemUpdate("$flipperPath/update.fuf")
+            bootApi.systemUpdate("$flipperPath/update.fuf")
         } catch (e: FRpcInvalidParametersException) {
             val code = e.response.system_update_response?.code
             if (code == UpdateResponse.UpdateResultCode.IntFull) {
@@ -76,7 +76,7 @@ class UploadToFlipperHelperImpl @Inject constructor() : UploadToFlipperHelper, L
             error("Failed send update request with status unknown exception: ${e.message}")
         }
 
-        fUpdateFeatureApi.reboot(RebootRequest.RebootMode.UPDATE)
+        bootApi.reboot(RebootRequest.RebootMode.UPDATE)
             .onFailure { error(it) { "#uploadToFlipper could not reboot device" } }
     }
 

--- a/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
+++ b/components/updater/impl/src/main/java/com/flipperdevices/updater/impl/tasks/UploadToFlipperHelper.kt
@@ -1,28 +1,27 @@
 package com.flipperdevices.updater.impl.tasks
 
-import com.flipperdevices.bridge.api.manager.FlipperRequestApi
-import com.flipperdevices.bridge.api.model.FlipperRequestPriority
-import com.flipperdevices.bridge.api.model.wrapToRequest
-import com.flipperdevices.bridge.rpc.api.FlipperStorageApi
+import com.flipperdevices.bridge.connection.feature.rpc.api.exception.FRpcException
+import com.flipperdevices.bridge.connection.feature.rpc.api.exception.FRpcInvalidParametersException
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FListingStorageApi
+import com.flipperdevices.bridge.connection.feature.update.api.FUpdateFeatureApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.ktx.jre.md5
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.progress.ProgressListener
 import com.flipperdevices.core.progress.ProgressWrapperTracker
-import com.flipperdevices.protobuf.Flipper
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.storage.file
-import com.flipperdevices.protobuf.storage.md5sumRequest
-import com.flipperdevices.protobuf.system.System
-import com.flipperdevices.protobuf.system.rebootRequest
-import com.flipperdevices.protobuf.system.updateRequest
+import com.flipperdevices.protobuf.system.RebootRequest
+import com.flipperdevices.protobuf.system.UpdateResponse
 import com.flipperdevices.updater.impl.model.IntFlashFullException
 import com.flipperdevices.updater.model.UpdatingState
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
 import java.io.File
 import javax.inject.Inject
 
@@ -30,74 +29,72 @@ interface UploadToFlipperHelper {
     suspend fun uploadToFlipper(
         flipperPath: String,
         updaterFolder: File,
-        requestApi: FlipperRequestApi,
+        fUpdateFeatureApi: FUpdateFeatureApi,
+        fListingStorageApi: FListingStorageApi,
+        fFileUploadApi: FFileUploadApi,
         stateListener: suspend (UpdatingState) -> Unit
     )
 }
 
 @ContributesBinding(AppGraph::class, UploadToFlipperHelper::class)
-class UploadToFlipperHelperImpl @Inject constructor(
-    private val flipperStorageApi: FlipperStorageApi
-) : UploadToFlipperHelper, LogTagProvider {
+class UploadToFlipperHelperImpl @Inject constructor() : UploadToFlipperHelper, LogTagProvider {
     override val TAG = "UploadToFlipperHelper"
 
     override suspend fun uploadToFlipper(
         flipperPath: String,
         updaterFolder: File,
-        requestApi: FlipperRequestApi,
+        fUpdateFeatureApi: FUpdateFeatureApi,
+        fListingStorageApi: FListingStorageApi,
+        fFileUploadApi: FFileUploadApi,
         stateListener: suspend (UpdatingState) -> Unit
     ) {
         upload(
-            requestApi,
-            updaterFolder,
-            flipperPath
-        ) { percent ->
-            withContext(FlipperDispatchers.workStealingDispatcher) {
-                stateListener(
-                    UpdatingState.UploadOnFlipper(
-                        percent = percent
+            folder = updaterFolder,
+            pathOnFlipper = flipperPath,
+            fListingStorageApi = fListingStorageApi,
+            fFileUploadApi = fFileUploadApi,
+            progressListener = { percent ->
+                withContext(FlipperDispatchers.workStealingDispatcher) {
+                    stateListener(
+                        UpdatingState.UploadOnFlipper(
+                            percent = percent
+                        )
                     )
-                )
-            }
-        }
-
-        val response = requestApi.request(
-            main {
-                systemUpdateRequest = updateRequest {
-                    updateManifest = "$flipperPath/update.fuf"
                 }
-            }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).first()
-        when (response.commandStatus) {
-            Flipper.CommandStatus.ERROR_INVALID_PARAMETERS -> {
-                val code = response.systemUpdateResponse.code
-                if (code == System.UpdateResponse.UpdateResultCode.IntFull) {
-                    throw IntFlashFullException()
-                }
-            }
-
-            Flipper.CommandStatus.OK -> {}
-            else -> error("Failed send update request with status ${response.commandStatus}")
-        }
-
-        requestApi.requestWithoutAnswer(
-            main {
-                systemRebootRequest = rebootRequest {
-                    mode = System.RebootRequest.RebootMode.UPDATE
-                }
-            }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
+            },
         )
+        try {
+            fUpdateFeatureApi.systemUpdate("$flipperPath/update.fuf")
+        } catch (e: FRpcInvalidParametersException) {
+            val code = e.response.system_update_response?.code
+            if (code == UpdateResponse.UpdateResultCode.IntFull) {
+                throw IntFlashFullException()
+            }
+        } catch (e: FRpcException) {
+            error("Failed send update request with status ${e.response.command_status}")
+        } catch (e: Exception) {
+            error("Failed send update request with status unknown exception: ${e.message}")
+        }
+
+        fUpdateFeatureApi.reboot(RebootRequest.RebootMode.UPDATE)
+            .onFailure { error(it) { "#uploadToFlipper could not reboot device" } }
     }
 
     private suspend fun upload(
-        requestApi: FlipperRequestApi,
         folder: File,
         pathOnFlipper: String,
-        progressListener: ProgressListener
+        progressListener: ProgressListener,
+        fListingStorageApi: FListingStorageApi,
+        fFileUploadApi: FFileUploadApi,
     ) {
-        val fileList = folder.walk().filterNot { it.isDirectory }.toList().filterNot {
-            if (fileAlreadyUploaded(requestApi, it, File(pathOnFlipper, it.name).path)) {
-                info { "Skip $it because file already uploaded" }
+        val fileList = folder.walk().filterNot { it.isDirectory }.toList().filterNot { file ->
+            val isAlreadyUploaded = fileAlreadyUploaded(
+                file = file,
+                pathOnFlipper = pathOnFlipper.toPath().resolve(file.name),
+                fListingStorageApi = fListingStorageApi
+            )
+            if (isAlreadyUploaded) {
+                info { "Skip $file because file already uploaded" }
                 return@filterNot true
             } else {
                 return@filterNot false
@@ -113,9 +110,9 @@ class UploadToFlipperHelperImpl @Inject constructor(
 
         fileList.forEach { singleFile ->
             val flipperFilePath = File(pathOnFlipper, singleFile.name).path
-            flipperStorageApi.upload(
+            fFileUploadApi.upload(
                 pathOnFlipper = flipperFilePath,
-                fileOnAndroid = singleFile,
+                fileOnAndroid = singleFile.toOkioPath(),
                 progressListener = ProgressWrapperTracker(
                     progressListener = progressListener,
                     min = sizeUploaded.toFloat() / totalSize.toFloat(),
@@ -127,24 +124,16 @@ class UploadToFlipperHelperImpl @Inject constructor(
     }
 
     private suspend fun fileAlreadyUploaded(
-        requestApi: FlipperRequestApi,
         file: File,
-        pathOnFlipper: String
+        pathOnFlipper: Path,
+        fListingStorageApi: FListingStorageApi
     ): Boolean {
-        val fileMd5 = file.inputStream().use {
-            it.md5()
-        }
-
-        val response = requestApi.request(
-            main {
-                storageMd5SumRequest = md5sumRequest {
-                    path = pathOnFlipper
-                }
-            }.wrapToRequest(FlipperRequestPriority.FOREGROUND)
-        ).first()
-        if (response.hasStorageMd5SumResponse()) {
-            return response.storageMd5SumResponse.md5Sum == fileMd5
-        }
-        return false
+        val fileMd5 = file.inputStream()
+            .use { fis -> fis.md5() }
+        val md5Response = fListingStorageApi.lsWithMd5(pathOnFlipper.toString())
+            .onFailure { error(it) { "#fileAlreadyUploaded Could not get lsWithMd5" } }
+            .getOrNull()
+            ?.firstOrNull()
+        return md5Response?.md5 == fileMd5
     }
 }

--- a/components/updater/screen/build.gradle.kts
+++ b/components/updater/screen/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
     implementation(projects.components.core.ui.dialog)
     implementation(projects.components.core.ui.decompose)
 
-    implementation(projects.components.bridge.api)
-    implementation(projects.components.bridge.service.api)
     implementation(projects.components.bridge.synchronization.api)
     implementation(projects.components.singleactivity.api)
     implementation(projects.components.deeplink.api)
@@ -36,6 +34,8 @@ dependencies {
 
     implementation(libs.kotlin.immutable.collections)
     implementation(libs.kotlin.serialization.json)
+
+    implementation(projects.components.bridge.connection.orchestrator.api)
 
     // Compose
     implementation(libs.compose.ui)

--- a/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/viewmodel/UpdaterViewModel.kt
+++ b/components/updater/screen/src/main/java/com/flipperdevices/updater/screen/viewmodel/UpdaterViewModel.kt
@@ -70,7 +70,7 @@ class UpdaterViewModel @Inject constructor(
 
         info {
             "Wait until synchronization end. " +
-                    "Current state is ${synchronizationApi.getSynchronizationState().value}"
+                "Current state is ${synchronizationApi.getSynchronizationState().value}"
         }
 
         // Wait until synchronization is really canceled
@@ -171,8 +171,8 @@ class UpdaterViewModel @Inject constructor(
             }
             verbose {
                 "From updating state ${updatingState.state} " +
-                        "and connection state $connectionState " +
-                        "produce $updaterScreenState"
+                    "and connection state $connectionState " +
+                    "produce $updaterScreenState"
             }
             updaterScreenStateFlow.emit(updaterScreenState)
         }.launchIn(viewModelScope)

--- a/components/updater/subghz/build.gradle.kts
+++ b/components/updater/subghz/build.gradle.kts
@@ -8,15 +8,12 @@ android.namespace = "com.flipperdevices.updater.subghz"
 dependencies {
     implementation(projects.components.updater.api)
 
-    implementation(projects.components.bridge.api)
-    implementation(projects.components.bridge.pbutils)
-    implementation(projects.components.bridge.service.api)
-
     implementation(projects.components.core.di)
     implementation(projects.components.core.log)
     implementation(projects.components.core.data)
     implementation(projects.components.core.ktx)
     implementation(projects.components.core.preference)
+    implementation(projects.components.core.progress)
     implementation(projects.components.core.storage)
     implementation(projects.components.core.ui.lifecycle)
     implementation(projects.components.core.ui.res)
@@ -24,6 +21,14 @@ dependencies {
     implementation(projects.components.analytics.metric.api)
 
     implementation(libs.lifecycle.runtime.ktx)
+
+    implementation(projects.components.bridge.connection.feature.provider.api)
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.feature.storage.api)
+    implementation(projects.components.bridge.connection.feature.getinfo.api)
+    implementation(projects.components.bridge.connection.feature.update.api)
+    implementation(projects.components.bridge.connection.feature.rpc.api)
+    implementation(projects.components.bridge.connection.pbutils)
 
     // Compose
     implementation(libs.compose.ui)

--- a/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
+++ b/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
@@ -1,37 +1,39 @@
 package com.flipperdevices.updater.subghz.helpers
 
-import com.flipperdevices.bridge.api.model.wrapToRequest
-import com.flipperdevices.bridge.api.utils.Constants
-import com.flipperdevices.bridge.protobuf.streamToCommandFlow
-import com.flipperdevices.bridge.service.api.FlipperServiceApi
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGetInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
+import com.flipperdevices.core.progress.copyWithProgress
 import com.flipperdevices.metric.api.MetricApi
 import com.flipperdevices.metric.api.events.complex.RegionSource
 import com.flipperdevices.metric.api.events.complex.SubGhzProvisioningEvent
-import com.flipperdevices.protobuf.Flipper
-import com.flipperdevices.protobuf.RegionKt.band
-import com.flipperdevices.protobuf.region
-import com.flipperdevices.protobuf.storage.file
-import com.flipperdevices.protobuf.storage.writeRequest
+import com.flipperdevices.protobuf.Region
 import com.flipperdevices.updater.api.DownloaderApi
 import com.flipperdevices.updater.subghz.model.FailedUploadSubGhzException
 import com.flipperdevices.updater.subghz.model.RegionProvisioning
 import com.flipperdevices.updater.subghz.model.RegionProvisioningSource
-import com.google.protobuf.ByteString
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import okio.ByteString.Companion.encode
+import okio.buffer
+import okio.source
 import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
 import javax.inject.Inject
 
 private const val UNKNOWN_REGION = "WW"
+const val REGION_FILE = "/int/.region_data"
 
 interface SubGhzProvisioningHelper {
-    suspend fun provideAndUploadSubGhz(serviceApi: FlipperServiceApi)
+    suspend fun provideAndUploadSubGhz(
+        fGetInfoFeatureApi: FGetInfoFeatureApi,
+        fFileUploadApi: FFileUploadApi
+    )
+
     suspend fun getRegion(): String?
 }
 
@@ -53,9 +55,10 @@ class SubGhzProvisioningHelperImpl @Inject constructor(
     }
 
     override suspend fun provideAndUploadSubGhz(
-        serviceApi: FlipperServiceApi
+        fGetInfoFeatureApi: FGetInfoFeatureApi,
+        fFileUploadApi: FFileUploadApi
     ) = withContext(FlipperDispatchers.workStealingDispatcher) {
-        if (skipProvisioningHelper.shouldSkipProvisioning(serviceApi)) {
+        if (skipProvisioningHelper.shouldSkipProvisioning(fGetInfoFeatureApi)) {
             info { "Skip provisioning" }
             return@withContext
         }
@@ -73,37 +76,31 @@ class SubGhzProvisioningHelperImpl @Inject constructor(
 
         val finalCodeRegion = providedRegion?.uppercase() ?: UNKNOWN_REGION
 
-        val regionData = region {
-            countryCode = ByteString.copyFrom(
-                finalCodeRegion,
-                Charset.forName("ASCII")
-            )
-            bands.addAll(
-                providedBands.map {
-                    band {
-                        start = it.start.toInt()
-                        end = it.end.toInt()
-                        powerLimit = it.maxPower
-                        dutyCycle = it.dutyCycle.toInt()
-                    }
+        val regionData = Region(
+            country_code = finalCodeRegion.encode(Charset.forName("ASCII")),
+            bands = providedBands.map {
+                Region.Band(
+                    start = it.start.toInt(),
+                    end = it.end.toInt(),
+                    power_limit = it.maxPower,
+                    duty_cycle = it.dutyCycle.toInt()
+                )
+            }
+        ).encode()
+        try {
+            regionData.inputStream().source().buffer().use { bufferedSource ->
+                fFileUploadApi.sink(REGION_FILE).use { sink ->
+                    bufferedSource.copyWithProgress(
+                        sink = sink,
+                        progressListener = { _, _ -> },
+                        sourceLength = { regionData.size.toLong() }
+                    )
                 }
-            )
-        }.toByteArray()
-        val writeFileResponse = ByteArrayInputStream(regionData).use { inputStream ->
-            val flow = streamToCommandFlow(
-                inputStream,
-                fileSize = regionData.size.toLong()
-            ) { chunkData ->
-                storageWriteRequest = writeRequest {
-                    path = Constants.PATH.REGION_FILE
-                    file = file { data = chunkData }
-                }
-            }.map { it.wrapToRequest() }
-            serviceApi.requestApi.request(flow)
-        }
-        if (writeFileResponse.commandStatus != Flipper.CommandStatus.OK) {
+            }
+        } catch (e: Exception) {
             throw FailedUploadSubGhzException()
         }
+
         reportMetric(providedRegions, providedRegion, source ?: RegionProvisioningSource.DEFAULT)
     }
 

--- a/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
+++ b/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.withContext
 import okio.ByteString.Companion.encode
 import okio.buffer
 import okio.source
-import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
 import javax.inject.Inject
 

--- a/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
+++ b/components/updater/subghz/src/main/kotlin/com/flipperdevices/updater/subghz/helpers/SubGhzProvisioningHelper.kt
@@ -2,6 +2,7 @@ package com.flipperdevices.updater.subghz.helpers
 
 import com.flipperdevices.bridge.connection.feature.getinfo.api.FGetInfoFeatureApi
 import com.flipperdevices.bridge.connection.feature.storage.api.fm.FFileUploadApi
+import com.flipperdevices.bridge.connection.feature.update.api.RegionApi
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.jre.FlipperDispatchers
 import com.flipperdevices.core.log.LogTagProvider
@@ -23,9 +24,6 @@ import okio.buffer
 import okio.source
 import java.nio.charset.Charset
 import javax.inject.Inject
-
-private const val UNKNOWN_REGION = "WW"
-const val REGION_FILE = "/int/.region_data"
 
 interface SubGhzProvisioningHelper {
     suspend fun provideAndUploadSubGhz(
@@ -73,7 +71,7 @@ class SubGhzProvisioningHelperImpl @Inject constructor(
             response.defaults
         }
 
-        val finalCodeRegion = providedRegion?.uppercase() ?: UNKNOWN_REGION
+        val finalCodeRegion = providedRegion?.uppercase() ?: RegionApi.UNKNOWN_REGION
 
         val regionData = Region(
             country_code = finalCodeRegion.encode(Charset.forName("ASCII")),
@@ -88,7 +86,7 @@ class SubGhzProvisioningHelperImpl @Inject constructor(
         ).encode()
         try {
             regionData.inputStream().source().buffer().use { bufferedSource ->
-                fFileUploadApi.sink(REGION_FILE).use { sink ->
+                fFileUploadApi.sink(RegionApi.REGION_FILE).use { sink ->
                     bufferedSource.copyWithProgress(
                         sink = sink,
                         progressListener = { _, _ -> },

--- a/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SkipProvisioningHelperTest.kt
+++ b/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SkipProvisioningHelperTest.kt
@@ -1,13 +1,10 @@
 package com.flipperdevices.updater.subghz.tasks
 
 import androidx.datastore.core.DataStore
-import com.flipperdevices.bridge.api.manager.FlipperRequestApi
-import com.flipperdevices.bridge.api.manager.service.FlipperVersionApi
-import com.flipperdevices.bridge.api.utils.Constants
+import com.flipperdevices.bridge.connection.feature.getinfo.api.FGetInfoFeatureApi
+import com.flipperdevices.bridge.connection.feature.getinfo.model.FGetInfoApiProperty
 import com.flipperdevices.core.ktx.jre.TimeHelper
 import com.flipperdevices.core.preference.pb.Settings
-import com.flipperdevices.protobuf.main
-import com.flipperdevices.protobuf.property.getResponse
 import com.flipperdevices.updater.subghz.helpers.SkipProvisioningHelper
 import com.flipperdevices.updater.subghz.helpers.SkipProvisioningHelperImpl
 import io.mockk.coEvery
@@ -47,74 +44,21 @@ class SkipProvisioningHelperTest {
     }
 
     @Test
-    fun `not skip provisioning if version null`() = runTest {
-        every { settings.data } returns flowOf(
-            Settings(
-                ignore_subghz_provisioning_on_zero_region = true
-            )
-        )
-
-        val versionApi = mockk<FlipperVersionApi> {
-            coEvery {
-                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
-            } returns false
-        }
-
-        val shouldProvide = underTest.shouldSkipProvisioning(
-            mockk {
-                every { flipperVersionApi } returns versionApi
-            }
-        )
-
-        Assert.assertFalse(shouldProvide)
-    }
-
-    @Test
-    fun `not skip provisioning if version deprecated`() = runTest {
-        every { settings.data } returns flowOf(
-            Settings(
-                ignore_subghz_provisioning_on_zero_region = true
-            )
-        )
-
-        val versionApi = mockk<FlipperVersionApi> {
-            coEvery {
-                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
-            } returns false
-        }
-
-        val shouldProvide = underTest.shouldSkipProvisioning(
-            mockk {
-                every { flipperVersionApi } returns versionApi
-            }
-        )
-
-        Assert.assertFalse(shouldProvide)
-    }
-
-    @Test
     fun `not skip provisioning if hardware region null`() = runTest {
         every { settings.data } returns flowOf(
-
             Settings(
                 ignore_subghz_provisioning_on_zero_region = true
             )
         )
 
-        val versionApi = mockk<FlipperVersionApi> {
+        val featureApi = mockk<FGetInfoFeatureApi> {
             coEvery {
-                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
-            } returns true
-        }
-        val mockRequestApi = mockk<FlipperRequestApi> {
-            coEvery { request(any(), any()) } returns main {}
+                get(FGetInfoApiProperty.DeviceInfo.HARDWARE_REGION)
+            } returns Result.failure(Throwable("Test error no region"))
         }
 
         val shouldProvide = underTest.shouldSkipProvisioning(
-            mockk {
-                every { flipperVersionApi } returns versionApi
-                every { requestApi } returns mockRequestApi
-            }
+            featureApi
         )
 
         Assert.assertFalse(shouldProvide)
@@ -128,24 +72,14 @@ class SkipProvisioningHelperTest {
             )
         )
 
-        val versionApi = mockk<FlipperVersionApi> {
+        val featureApi = mockk<FGetInfoFeatureApi> {
             coEvery {
-                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
-            } returns true
-        }
-        val mockRequestApi = mockk<FlipperRequestApi> {
-            coEvery { request(any(), any()) } returns main {
-                propertyGetResponse = getResponse {
-                    value = "1"
-                }
-            }
+                get(FGetInfoApiProperty.DeviceInfo.HARDWARE_REGION)
+            } returns Result.success("1")
         }
 
         val shouldProvide = underTest.shouldSkipProvisioning(
-            mockk {
-                every { flipperVersionApi } returns versionApi
-                every { requestApi } returns mockRequestApi
-            }
+            featureApi
         )
 
         Assert.assertFalse(shouldProvide)
@@ -159,24 +93,14 @@ class SkipProvisioningHelperTest {
             )
         )
 
-        val versionApi = mockk<FlipperVersionApi> {
+        val featureApi = mockk<FGetInfoFeatureApi> {
             coEvery {
-                isSupported(eq(Constants.API_SUPPORTED_GET_REQUEST), any())
-            } returns true
-        }
-        val mockRequestApi = mockk<FlipperRequestApi> {
-            coEvery { request(any(), any()) } returns main {
-                propertyGetResponse = getResponse {
-                    value = "0"
-                }
-            }
+                get(FGetInfoApiProperty.DeviceInfo.HARDWARE_REGION)
+            } returns Result.success("0")
         }
 
         val shouldProvide = underTest.shouldSkipProvisioning(
-            mockk {
-                every { flipperVersionApi } returns versionApi
-                every { requestApi } returns mockRequestApi
-            }
+            featureApi
         )
 
         Assert.assertTrue(shouldProvide)

--- a/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SubGhzProvisioningHelperTest.kt
+++ b/components/updater/subghz/src/test/kotlin/com/flipperdevices/updater/subghz/tasks/SubGhzProvisioningHelperTest.kt
@@ -87,7 +87,6 @@ class SubGhzProvisioningHelperTest(
 
     @Test
     fun `check region protobuf`() = runTest {
-
         val fGetInfoFeatureApi = mockk<FGetInfoFeatureApi>()
         val ostream = ByteArrayOutputStream()
         val fFileUploadApi = mockk<FFileUploadApi> {

--- a/instances/android/app/build.gradle.kts
+++ b/instances/android/app/build.gradle.kts
@@ -192,6 +192,8 @@ dependencies {
     implementation(projects.components.bridge.connection.feature.appstart.impl)
     implementation(projects.components.bridge.connection.feature.screenstreaming.api)
     implementation(projects.components.bridge.connection.feature.screenstreaming.impl)
+    implementation(projects.components.bridge.connection.feature.update.api)
+    implementation(projects.components.bridge.connection.feature.update.impl)
 
     implementation(projects.components.analytics.shake2report.api)
     if (IS_SENTRY_ENABLED) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,6 +95,8 @@ include(
     ":components:bridge:connection:feature:appstart:impl",
     ":components:bridge:connection:feature:screenstreaming:api",
     ":components:bridge:connection:feature:screenstreaming:impl",
+    ":components:bridge:connection:feature:update:api",
+    ":components:bridge:connection:feature:update:impl",
 
     ":components:filemngr:util",
     ":components:filemanager:api",


### PR DESCRIPTION
**Background**

Migration of all update modules into new api

**Changes**

- Added new feature for update
- Migrated every update submodules into new api

**Test plan**

- Open flipper android app and run update
- See flipper is update correctly with all it's flow (image changed, rebooted, location sub-ghz working)
- See all tests previously located is passed

### TODO

- Device reconnect after it being shutdown(we don't get success message on mobile)(the problem is on another layer. Not actually related to feature)
